### PR TITLE
Patch updates only for @types/node

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -48,12 +48,22 @@
     // non-major updates only
     {
       "matchDepNames": [
-        "@types/node",
         "@types/react",
         "npm",
       ],
       "matchUpdateTypes": [
         "major"
+      ],
+      "enabled": false
+    },
+    // patch updates only
+    {
+      "matchDepNames": [
+        "@types/node",
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
       ],
       "enabled": false
     }

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@langchain/mcp-adapters": "^0.5.2",
     "@langchain/ollama": "^0.2.3",
     "@langchain/openai": "^0.5.15",
-    "@types/node": "^22.15.33",
+    "@types/node": "~22.15.33",
     "@types/react": "^17.0.87",
     "@types/react-syntax-highlighter": "^15.5.13",
     "@vitejs/plugin-react": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^0.5.15
         version: 0.5.15(@langchain/core@0.3.61(openai@5.7.0(ws@8.18.3)(zod@3.25.67)))(ws@8.18.3)
       '@types/node':
-        specifier: ^22.15.33
+        specifier: ~22.15.33
         version: 22.15.33
       '@types/react':
         specifier: ^17.0.87


### PR DESCRIPTION
It should be the same as for minor nodejs version.