### PR TITLE
feat: add Anthropic Claude model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ automate complex tasks and enhance productivity.
 
 - [Install](#install)
 - [How to obtain a Google API Key](./docs/GOOGLE_API_KEY.md)
+- [How to obtain an Anthropic API Key](./docs/ANTHROPIC_SETUP.md)
 - [Build & Run Guide](./docs/BUILD.md)
 
 ---
@@ -56,6 +57,9 @@ freelens-ai-extension currently supports integration with the following AI model
 - ***gpt-4.1***
 - ***gpt-4o***
 - ***gemini 2.0 flash***
+- ***Claude Haiku 4.5***
+- ***Claude Sonnet 4.6***
+- ***Claude Opus 4.6***
 
 Each model offers different capabilities and performance characteristics.
 Choose the one that best suits your needs and workflow requirements.

--- a/docs/ANTHROPIC_SETUP.md
+++ b/docs/ANTHROPIC_SETUP.md
@@ -1,0 +1,38 @@
+# Anthropic (Claude) Setup
+
+This guide explains how to configure Claude models in the Freelens AI extension.
+
+## Getting an API Key
+
+1. Go to [https://console.anthropic.com](https://console.anthropic.com)
+2. Sign in or create an account
+3. Navigate to **API Keys** in the left sidebar
+4. Click **Create Key**, give it a name, and copy it
+
+## Configuring the Extension
+
+### Option A: Via the UI
+
+1. Open Freelens and go to **Preferences** (gear icon)
+2. Find the **Freelens AI** section
+3. Paste your API key in the **Anthropic Key** field
+4. Select one of the Claude models from the model dropdown:
+   - **Claude Haiku 4.5** — fast and cost-efficient, great for quick queries
+   - **Claude Sonnet 4.6** — balanced performance and intelligence (recommended)
+   - **Claude Opus 4.6** — most capable, best for complex analysis
+
+### Option B: Via Environment Variable
+
+Set the `ANTHROPIC_API_KEY` environment variable before launching Freelens:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+The environment variable takes precedence over the value stored in preferences.
+
+## Notes
+
+- MCP (Model Context Protocol) is supported with Claude models
+- Claude models support streaming responses
+- See [https://docs.anthropic.com/en/docs/about-claude/models](https://docs.anthropic.com/en/docs/about-claude/models) for the latest model information

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@babel/plugin-proposal-decorators": "^7.28.0",
     "@electron-toolkit/tsconfig": "^1.0.1",
     "@freelensapp/extensions": "^1.4.0",
+    "@langchain/anthropic": "^0.3.x",
     "@langchain/core": "^0.3.61",
     "@langchain/google-genai": "^0.2.13",
     "@langchain/langgraph": "^0.2.74",

--- a/src/common/store/preferences-store.ts
+++ b/src/common/store/preferences-store.ts
@@ -5,6 +5,7 @@ import { AIModelsEnum } from "../../renderer/business/provider/ai-models";
 
 export interface PreferencesModel {
   openAIKey: string;
+  anthropicKey: string;
   googleAIKey: string;
   selectedModel: AIModelsEnum;
   mcpEnabled: boolean;
@@ -17,6 +18,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
   // Persistent
   @observable accessor openAIKey: string = "";
   @observable accessor googleAIKey: string = "";
+  @observable accessor anthropicKey: string = "";
   @observable accessor selectedModel: AIModelsEnum = AIModelsEnum.GPT_3_5_TURBO;
   @observable accessor mcpEnabled: boolean = false;
   @observable accessor mcpConfiguration: string = "";
@@ -32,6 +34,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
       defaults: {
         openAIKey: "",
         googleAIKey: "",
+        anthropicKey: "",
         selectedModel: AIModelsEnum.GPT_3_5_TURBO,
         mcpEnabled: false,
         mcpConfiguration: JSON.stringify(
@@ -60,6 +63,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
   fromStore = (preferencesModel: PreferencesModel): void => {
     this.openAIKey = preferencesModel.openAIKey;
     this.googleAIKey = preferencesModel.googleAIKey;
+    this.anthropicKey = preferencesModel.anthropicKey;
     this.selectedModel = preferencesModel.selectedModel;
     this.mcpEnabled = preferencesModel.mcpEnabled;
     this.mcpConfiguration = preferencesModel.mcpConfiguration;
@@ -71,6 +75,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
     const value: PreferencesModel = {
       openAIKey: this.openAIKey,
       googleAIKey: this.googleAIKey,
+      anthropicKey: this.anthropicKey,
       selectedModel: this.selectedModel,
       mcpEnabled: this.mcpEnabled,
       mcpConfiguration: this.mcpConfiguration,

--- a/src/renderer/business/provider/ai-models.tsx
+++ b/src/renderer/business/provider/ai-models.tsx
@@ -13,6 +13,9 @@ export enum AIModelsEnum {
   // OLLAMA_LLAMA32_1B = "llama3.2:1b",
   // OLLAMA_MISTRAL_7B = "mistral:7b",
   GEMINI_2_FLASH = "gemini-2.0-flash",
+  CLAUDE_HAIKU_3_5 = "claude-haiku-4-5-20251001",
+  CLAUDE_SONNET_4_5 = "claude-sonnet-4-6",
+  CLAUDE_OPUS_4_5 = "claude-opus-4-6",
 }
 
 export const toAIModelEnum = (value: AIModelsEnum) => {
@@ -24,6 +27,7 @@ export enum AIProviders {
   // DEEP_SEEK = "deep-seek",
   // OLLAMA = "ollama",
   GOOGLE = "google",
+  ANTHROPIC = "anthropic",
 }
 
 export const AIModelInfos: Record<string, AIModelInfo> = {
@@ -36,4 +40,7 @@ export const AIModelInfos: Record<string, AIModelInfo> = {
   // [AIModelsEnum.OLLAMA_LLAMA32_1B]: { description: "ollama-llama3.2 1b", provider: AIProviders.OLLAMA },
   // [AIModelsEnum.OLLAMA_MISTRAL_7B]: { description: "ollama mistral:7b", provider: AIProviders.OLLAMA },
   [AIModelsEnum.GEMINI_2_FLASH]: { description: "gemini 2.0 flash", provider: AIProviders.GOOGLE },
+  [AIModelsEnum.CLAUDE_HAIKU_3_5]: { description: "Claude Haiku 4.5", provider: AIProviders.ANTHROPIC },
+  [AIModelsEnum.CLAUDE_SONNET_4_5]: { description: "Claude Sonnet 4.6", provider: AIProviders.ANTHROPIC },
+  [AIModelsEnum.CLAUDE_OPUS_4_5]: { description: "Claude Opus 4.6", provider: AIProviders.ANTHROPIC },
 };

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -1,3 +1,4 @@
+import { ChatAnthropic } from "@langchain/anthropic";
 import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 // import { ChatOllama } from "@langchain/ollama";
 import { ChatOpenAI } from "@langchain/openai";
@@ -31,6 +32,15 @@ export const useModelProvider = () => {
       //     headers: headers,
       //     baseUrl: `${ollamaHost}:${ollamaPort}`,
       //   });
+      case AIModelsEnum.CLAUDE_HAIKU_3_5:
+      case AIModelsEnum.CLAUDE_SONNET_4_5:
+      case AIModelsEnum.CLAUDE_OPUS_4_5:
+        const anthropicApiKey = process.env.ANTHROPIC_API_KEY || preferencesStore.anthropicKey;
+        return new ChatAnthropic({
+          model: preferencesStore.selectedModel,
+          temperature: 0,
+          apiKey: anthropicApiKey,
+        });
       case AIModelsEnum.GEMINI_2_FLASH:
         const googleApiKey = process.env.GOOGLE_API_KEY || preferencesStore.googleAIKey;
         return new ChatGoogleGenerativeAI({

--- a/src/renderer/pages/preferences/preferences-page.tsx
+++ b/src/renderer/pages/preferences/preferences-page.tsx
@@ -23,6 +23,12 @@ export const PreferencesPage = observer(() => {
         value={preferencesStore.googleAIKey}
         onChange={(value: string) => (preferencesStore.googleAIKey = value)}
       />
+      <div style={{ marginTop: 8, fontWeight: "bold" }}>Anthropic Key</div>
+      <Input
+        placeholder="Put here your Anthropic API key"
+        value={preferencesStore.anthropicKey}
+        onChange={(value: string) => (preferencesStore.anthropicKey = value)}
+      />
       {/*<HorizontalLine />*/}
       {/*<div>*/}
       {/*  <SubTitle title="Ollama settings" />*/}


### PR DESCRIPTION
## Summary

- Add `@langchain/anthropic` dependency and wire up `ChatAnthropic` in the model provider
- Add `CLAUDE_HAIKU_3_5`, `CLAUDE_SONNET_4_5`, and `CLAUDE_OPUS_4_5` enums with an `ANTHROPIC` provider
- Add `anthropicKey` to `PreferencesStore` (persisted, with `ANTHROPIC_API_KEY` env var support)
- Add Anthropic API key input to the preferences UI
- Add `docs/ANTHROPIC_SETUP.md` with setup instructions
- Update README with the new models and setup link

## Test plan

- [ ] Set an Anthropic API key in Preferences and verify it persists across restarts
- [ ] Select each Claude model from the dropdown and confirm the model provider returns a `ChatAnthropic` instance
- [ ] Verify `ANTHROPIC_API_KEY` env var takes precedence over the stored key
- [ ] Confirm OpenAI and Gemini models are unaffected