### PR TITLE
Editable list of models and OpenAI provider settings in preferences

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -5,7 +5,7 @@
   "project": ["*.{js,mjs,ts}", "src/**/*.{ts,tsx}"],
 
   "ignoreBinaries": ["electron-rebuild", "yq"],
-  "ignoreDependencies": ["@babel/plugin-proposal-decorators"],
+  "ignoreDependencies": ["@babel/plugin-proposal-decorators", "@langchain/google-genai"],
   "typescript": {
     "config": ["tsconfig.json"]
   },

--- a/src/common/store/preferences-store.ts
+++ b/src/common/store/preferences-store.ts
@@ -1,10 +1,6 @@
 import { Common } from "@freelensapp/extensions";
 import { makeObservable, observable, toJS } from "mobx";
-import {
-  type CustomModel,
-  DEFAULT_MODELS,
-  DEFAULT_OPENAI_BASE_URL,
-} from "../../renderer/business/provider/ai-models";
+import { type CustomModel, DEFAULT_MODELS, DEFAULT_OPENAI_BASE_URL } from "../../renderer/business/provider/ai-models";
 
 import type { MessageObject } from "../../renderer/business/objects/message-object";
 

--- a/src/common/store/preferences-store.ts
+++ b/src/common/store/preferences-store.ts
@@ -1,32 +1,42 @@
 import { Common } from "@freelensapp/extensions";
 import { makeObservable, observable, toJS } from "mobx";
-import { AIModelsEnum, toAIModelEnum } from "../../renderer/business/provider/ai-models";
+import {
+  type CustomModel,
+  DEFAULT_MODELS,
+  DEFAULT_OPENAI_BASE_URL,
+} from "../../renderer/business/provider/ai-models";
 
 import type { MessageObject } from "../../renderer/business/objects/message-object";
 
-const DEFAULT_SELECTED_MODEL = AIModelsEnum.GPT_5_5;
+const DEFAULT_SELECTED_MODEL = DEFAULT_MODELS[0]?.name ?? "";
 
 export interface PreferencesModel {
   openAIKey: string;
-  googleAIKey: string;
+  openAIBaseUrl: string;
+  openAIReasoningEffort: string;
+  // googleAIKey: string;
   aiProxyPort: number | null;
-  selectedModel: AIModelsEnum;
+  selectedModel: string;
+  models: CustomModel[];
   mcpEnabled: boolean;
   mcpConfiguration: string;
-  ollamaHost: string;
-  ollamaPort: string;
+  // ollamaHost: string;
+  // ollamaPort: string;
 }
 
 export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesModel> {
   // Persistent
   @observable accessor openAIKey: string = "";
-  @observable accessor googleAIKey: string = "";
+  @observable accessor openAIBaseUrl: string = DEFAULT_OPENAI_BASE_URL;
+  @observable accessor openAIReasoningEffort: string = "";
+  // @observable accessor googleAIKey: string = "";
   @observable accessor aiProxyPort: number | null = null;
-  @observable accessor selectedModel: AIModelsEnum = DEFAULT_SELECTED_MODEL;
+  @observable accessor selectedModel: string = DEFAULT_SELECTED_MODEL;
+  @observable accessor models: CustomModel[] = [...DEFAULT_MODELS];
   @observable accessor mcpEnabled: boolean = false;
   @observable accessor mcpConfiguration: string = "";
-  @observable accessor ollamaHost: string = "";
-  @observable accessor ollamaPort: string = "";
+  // @observable accessor ollamaHost: string = "";
+  // @observable accessor ollamaPort: string = "";
 
   // Not persistent
   @observable accessor explainEvent: MessageObject = {} as MessageObject;
@@ -38,9 +48,12 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
       configName: "freelens-ai-preferences-store",
       defaults: {
         openAIKey: "",
-        googleAIKey: "",
+        openAIBaseUrl: DEFAULT_OPENAI_BASE_URL,
+        openAIReasoningEffort: "",
+        // googleAIKey: "",
         aiProxyPort: null,
         selectedModel: DEFAULT_SELECTED_MODEL,
+        models: [...DEFAULT_MODELS],
         mcpEnabled: false,
         mcpConfiguration: JSON.stringify(
           {
@@ -54,8 +67,8 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
           null,
           2,
         ),
-        ollamaHost: "http://127.0.0.1",
-        ollamaPort: "9898",
+        // ollamaHost: "http://127.0.0.1",
+        // ollamaPort: "9898",
       },
     });
     makeObservable(this);
@@ -67,25 +80,35 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
 
   fromStore = (preferencesModel: PreferencesModel): void => {
     this.openAIKey = preferencesModel.openAIKey;
-    this.googleAIKey = preferencesModel.googleAIKey;
+    this.openAIBaseUrl = preferencesModel.openAIBaseUrl || DEFAULT_OPENAI_BASE_URL;
+    this.openAIReasoningEffort = preferencesModel.openAIReasoningEffort ?? "";
+    // this.googleAIKey = preferencesModel.googleAIKey;
     this.aiProxyPort = preferencesModel.aiProxyPort ?? null;
-    this.selectedModel = toAIModelEnum(preferencesModel.selectedModel) ?? DEFAULT_SELECTED_MODEL;
+    this.models = preferencesModel.models?.length ? preferencesModel.models : [...DEFAULT_MODELS];
+    // Validate the selection against the available models; fall back to the
+    // first entry (replaces the old enum validation).
+    this.selectedModel = this.models.some((model) => model.name === preferencesModel.selectedModel)
+      ? preferencesModel.selectedModel
+      : (this.models[0]?.name ?? DEFAULT_SELECTED_MODEL);
     this.mcpEnabled = preferencesModel.mcpEnabled;
     this.mcpConfiguration = preferencesModel.mcpConfiguration;
-    this.ollamaHost = preferencesModel.ollamaHost;
-    this.ollamaPort = preferencesModel.ollamaPort;
+    // this.ollamaHost = preferencesModel.ollamaHost;
+    // this.ollamaPort = preferencesModel.ollamaPort;
   };
 
   toJSON = (): PreferencesModel => {
     const value: PreferencesModel = {
       openAIKey: this.openAIKey,
-      googleAIKey: this.googleAIKey,
+      openAIBaseUrl: this.openAIBaseUrl,
+      openAIReasoningEffort: this.openAIReasoningEffort,
+      // googleAIKey: this.googleAIKey,
       aiProxyPort: this.aiProxyPort,
       selectedModel: this.selectedModel,
+      models: this.models,
       mcpEnabled: this.mcpEnabled,
       mcpConfiguration: this.mcpConfiguration,
-      ollamaHost: this.ollamaHost,
-      ollamaPort: this.ollamaPort,
+      // ollamaHost: this.ollamaHost,
+      // ollamaPort: this.ollamaPort,
     };
     return toJS(value);
   };

--- a/src/main/ai-proxy-server.ts
+++ b/src/main/ai-proxy-server.ts
@@ -4,8 +4,14 @@ import type { AddressInfo } from "node:net";
 
 const AI_PROXY_HOST = "127.0.0.1";
 
+// Header set by the renderer (see model-provider.ts) carrying the full upstream
+// base URL (including any path, e.g. https://api.openai.com/v1). When present it
+// overrides the static prefix map below, so the user can configure a custom
+// base URL without changing the proxy.
+const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
+
 const UPSTREAM_BY_PREFIX: Record<string, string> = {
-  openai: "https://api.openai.com",
+  openai: "https://api.openai.com/v1",
   google: "https://generativelanguage.googleapis.com",
 };
 
@@ -16,7 +22,7 @@ const corsHeaders = {
   "access-control-allow-origin": "*",
   "access-control-allow-methods": "GET,POST,PUT,PATCH,DELETE,OPTIONS",
   "access-control-allow-headers":
-    "authorization,content-type,x-stainless-os,x-stainless-runtime-version,x-stainless-package-version,x-stainless-runtime,x-stainless-arch,x-stainless-retry-count,x-stainless-lang,accept,user-agent,x-goog-api-key,x-goog-api-client",
+    "authorization,content-type,x-stainless-os,x-stainless-runtime-version,x-stainless-package-version,x-stainless-runtime,x-stainless-arch,x-stainless-retry-count,x-stainless-lang,accept,user-agent,x-goog-api-key,x-goog-api-client,x-upstream-base-url",
 } as const;
 
 const hopByHopHeaders = new Set([
@@ -52,7 +58,7 @@ const createUpstreamHeaders = (request: IncomingMessage) => {
   const headers = new Headers();
 
   for (const [key, value] of Object.entries(request.headers)) {
-    if (hopByHopHeaders.has(key) || value === undefined) {
+    if (hopByHopHeaders.has(key) || key === UPSTREAM_BASE_URL_HEADER || value === undefined) {
       continue;
     }
 
@@ -72,9 +78,14 @@ const proxyRequest = async (request: IncomingMessage, response: ServerResponse) 
   // Extract provider prefix: /<prefix>/rest/of/path
   const match = requestPath.match(/^\/([^/]+)(\/.*)?$/);
   const prefix = match?.[1] ?? "";
-  const upstreamOrigin = UPSTREAM_BY_PREFIX[prefix];
 
-  if (!upstreamOrigin) {
+  // Prefer the upstream base URL advertised by the renderer; fall back to the
+  // static prefix map for callers that do not set the header.
+  const headerBaseUrl = request.headers[UPSTREAM_BASE_URL_HEADER];
+  const upstreamBaseUrl =
+    (typeof headerBaseUrl === "string" && headerBaseUrl) || UPSTREAM_BY_PREFIX[prefix];
+
+  if (!upstreamBaseUrl) {
     response.statusCode = 404;
     response.setHeader("content-type", "application/json");
     response.end(JSON.stringify({ error: `Unknown proxy prefix: ${prefix}` }));
@@ -82,7 +93,11 @@ const proxyRequest = async (request: IncomingMessage, response: ServerResponse) 
   }
 
   const remainingPath = match?.[2] ?? "/";
-  const upstreamUrl = new URL(remainingPath, upstreamOrigin);
+  // Preserve any path on the base URL (e.g. ".../v1") instead of letting the
+  // absolute remaining path replace it.
+  const upstreamBase = new URL(upstreamBaseUrl);
+  const basePath = upstreamBase.pathname.replace(/\/$/, "");
+  const upstreamUrl = new URL(`${basePath}${remainingPath}`, upstreamBase.origin);
   const method = request.method ?? "GET";
   const body = method === "GET" || method === "HEAD" ? undefined : await readRequestBody(request);
 

--- a/src/main/ai-proxy-server.ts
+++ b/src/main/ai-proxy-server.ts
@@ -82,8 +82,7 @@ const proxyRequest = async (request: IncomingMessage, response: ServerResponse) 
   // Prefer the upstream base URL advertised by the renderer; fall back to the
   // static prefix map for callers that do not set the header.
   const headerBaseUrl = request.headers[UPSTREAM_BASE_URL_HEADER];
-  const upstreamBaseUrl =
-    (typeof headerBaseUrl === "string" && headerBaseUrl) || UPSTREAM_BY_PREFIX[prefix];
+  const upstreamBaseUrl = (typeof headerBaseUrl === "string" && headerBaseUrl) || UPSTREAM_BY_PREFIX[prefix];
 
   if (!upstreamBaseUrl) {
     response.statusCode = 404;

--- a/src/renderer/business/agent/state/graph-state.ts
+++ b/src/renderer/business/agent/state/graph-state.ts
@@ -1,9 +1,8 @@
 import { BaseMessage } from "@langchain/core/messages";
 import { Annotation, Messages, messagesStateReducer } from "@langchain/langgraph";
-import { AIModelsEnum } from "../../provider/ai-models";
 
 export const GraphState = Annotation.Root({
-  modelName: Annotation<AIModelsEnum>,
+  modelName: Annotation<string>,
   modelApiKey: Annotation<string>,
   messages: Annotation<BaseMessage[], Messages>({
     reducer: messagesStateReducer,

--- a/src/renderer/business/provider/ai-models.tsx
+++ b/src/renderer/business/provider/ai-models.tsx
@@ -1,37 +1,29 @@
-export interface AIModelInfo {
-  description: string;
-  provider: string;
-}
-
-export enum AIModelsEnum {
-  GPT_4_1 = "gpt-4.1",
-  GPT_5 = "gpt-5",
-  GPT_5_4 = "gpt-5.4",
-  GPT_5_5 = "gpt-5.5",
-  // DEEP_SEEK_R1 = "deep-seek-r1",
-  // OLLAMA_LLAMA32_1B = "llama3.2:1b",
-  // OLLAMA_MISTRAL_7B = "mistral:7b",
-  GEMINI_2_5_FLASH = "gemini-2.5-flash",
-}
-
-export const toAIModelEnum = (value: AIModelsEnum) => {
-  return Object.values(AIModelsEnum).includes(value) ? value : undefined;
-};
-
 export enum AIProviders {
   OPEN_AI = "open-ai",
   // DEEP_SEEK = "deep-seek",
   // OLLAMA = "ollama",
-  GOOGLE = "google",
+  // GOOGLE = "google",
 }
 
-export const AIModelInfos: Record<string, AIModelInfo> = {
-  [AIModelsEnum.GPT_4_1]: { description: "gpt 4.1", provider: AIProviders.OPEN_AI },
-  [AIModelsEnum.GPT_5]: { description: "gpt 5", provider: AIProviders.OPEN_AI },
-  [AIModelsEnum.GPT_5_4]: { description: "gpt 5.4", provider: AIProviders.OPEN_AI },
-  [AIModelsEnum.GPT_5_5]: { description: "gpt 5.5", provider: AIProviders.OPEN_AI },
-  // [AIModelsEnum.DEEP_SEEK_R1]: { description: "deep seek r1", provider: AIProviders.DEEP_SEEK },
-  // [AIModelsEnum.OLLAMA_LLAMA32_1B]: { description: "ollama-llama3.2 1b", provider: AIProviders.OLLAMA },
-  // [AIModelsEnum.OLLAMA_MISTRAL_7B]: { description: "ollama mistral:7b", provider: AIProviders.OLLAMA },
-  [AIModelsEnum.GEMINI_2_5_FLASH]: { description: "gemini 2.5 flash", provider: AIProviders.GOOGLE },
+// A model the user can add/remove freely. `name` is the model id sent to the
+// provider API (e.g. "gpt-5.5"); the provider decides which client/key/proxy
+// path is used. The list is open: model-specific behavior is decided by name
+// heuristics (see model-capabilities.ts), not by a hardcoded enum.
+export interface CustomModel {
+  provider: AIProviders;
+  name: string;
+}
+
+export const DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+// Initial, editable list of models. Users can remove these and add their own.
+export const DEFAULT_MODELS: CustomModel[] = [
+  { provider: AIProviders.OPEN_AI, name: "gpt-5.5" },
+  { provider: AIProviders.OPEN_AI, name: "gpt-5.4" },
+  { provider: AIProviders.OPEN_AI, name: "gpt-5.4-mini" },
+];
+
+export const PROVIDER_LABELS: Record<AIProviders, string> = {
+  [AIProviders.OPEN_AI]: "OpenAI",
+  // [AIProviders.GOOGLE]: "Google",
 };

--- a/src/renderer/business/provider/model-capabilities.ts
+++ b/src/renderer/business/provider/model-capabilities.ts
@@ -1,0 +1,12 @@
+// Model-specific behavior is decided by heuristics on the model name instead of
+// a hardcoded enum, so adding a new model needs no code changes. Extend the
+// pattern table below when a new family needs different handling.
+
+// OpenAI reasoning models (o-series, gpt-5.x) reject `temperature` and instead
+// accept a `reasoningEffort`. Non-reasoning models are the inverse.
+const REASONING_MODEL_PATTERNS: RegExp[] = [/^o\d/i, /gpt-5/i];
+
+export const isReasoningModel = (modelName: string): boolean =>
+  REASONING_MODEL_PATTERNS.some((pattern) => pattern.test(modelName));
+
+export const supportsTemperature = (modelName: string): boolean => !isReasoningModel(modelName);

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -1,8 +1,13 @@
-import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
+// import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 // import { ChatOllama } from "@langchain/ollama";
-import { ChatOpenAI } from "@langchain/openai";
+import { ChatOpenAI, type ChatOpenAIFields } from "@langchain/openai";
 import { PreferencesStore } from "../../../common/store";
-import { AIModelsEnum } from "./ai-models";
+import { AIProviders, DEFAULT_OPENAI_BASE_URL } from "./ai-models";
+import { isReasoningModel } from "./model-capabilities";
+
+// Header read by the local AI proxy to decide which upstream to forward to,
+// letting the user configure a custom base URL without changing the proxy code.
+export const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
 
 const getAiProxyBaseUrl = (aiProxyPort: number | null) => {
   if (aiProxyPort === null) {
@@ -17,27 +22,43 @@ export const useModelProvider = () => {
   const preferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
 
   const getModel = () => {
-    switch (preferencesStore.selectedModel) {
-      case AIModelsEnum.GPT_4_1:
-      case AIModelsEnum.GPT_5:
-      case AIModelsEnum.GPT_5_4:
-      case AIModelsEnum.GPT_5_5:
-        const openAiApiKey = process.env.OPENAI_API_KEY || preferencesStore.openAIKey;
+    const modelName = preferencesStore.selectedModel;
+    const provider = preferencesStore.models.find((model) => model.name === modelName)?.provider ?? AIProviders.OPEN_AI;
 
-        return new ChatOpenAI({
-          model: preferencesStore.selectedModel,
+    switch (provider) {
+      case AIProviders.OPEN_AI: {
+        const openAiApiKey = process.env.OPENAI_API_KEY || preferencesStore.openAIKey;
+        const openAIBaseUrl = preferencesStore.openAIBaseUrl || DEFAULT_OPENAI_BASE_URL;
+
+        const fields: ChatOpenAIFields = {
+          model: modelName,
           apiKey: openAiApiKey,
           configuration: {
-            baseURL: `${getAiProxyBaseUrl(preferencesStore.aiProxyPort)}/openai/v1`,
+            // The proxy strips the "/openai" prefix and forwards to the
+            // upstream advertised via UPSTREAM_BASE_URL_HEADER.
+            baseURL: `${getAiProxyBaseUrl(preferencesStore.aiProxyPort)}/openai`,
+            defaultHeaders: {
+              [UPSTREAM_BASE_URL_HEADER]: openAIBaseUrl,
+            },
           },
-        });
-      // case AIModelsEnum.DEEP_SEEK_R1:
-      //   return null;
-      // case AIModelsEnum.OLLAMA_LLAMA32_1B:
-      // case AIModelsEnum.OLLAMA_MISTRAL_7B:
+        };
+
+        // Reasoning models reject `temperature` and accept a reasoning effort;
+        // non-reasoning models are the inverse. Decided by name heuristic.
+        if (isReasoningModel(modelName)) {
+          if (preferencesStore.openAIReasoningEffort) {
+            fields.reasoningEffort = preferencesStore.openAIReasoningEffort as ChatOpenAIFields["reasoningEffort"];
+          }
+        } else {
+          fields.temperature = 0;
+        }
+
+        return new ChatOpenAI(fields);
+      }
+      // case AIProviders.OLLAMA: {
       //   const ollamaHost = process.env.FREELENS_OLLAMA_HOST || preferencesStore.ollamaHost;
       //   const ollamaPort = process.env.FREELENS_OLLAMA_PORT || preferencesStore.ollamaPort;
-      //   let headers = new Headers();
+      //   const headers = new Headers();
       //   headers.set("Origin", ollamaHost);
       //   return new ChatOllama({
       //     model: modelName,
@@ -45,17 +66,19 @@ export const useModelProvider = () => {
       //     headers: headers,
       //     baseUrl: `${ollamaHost}:${ollamaPort}`,
       //   });
-      case AIModelsEnum.GEMINI_2_5_FLASH:
-        const googleApiKey = process.env.GOOGLE_API_KEY || preferencesStore.googleAIKey;
-        return new ChatGoogleGenerativeAI({
-          model: preferencesStore.selectedModel,
-          temperature: 0,
-          apiKey: googleApiKey,
-          baseUrl: getAiProxyBaseUrl(preferencesStore.aiProxyPort) + "/google",
-          streamUsage: false,
-        });
+      // }
+      // case AIProviders.GOOGLE: {
+      //   const googleApiKey = process.env.GOOGLE_API_KEY || preferencesStore.googleAIKey;
+      //   return new ChatGoogleGenerativeAI({
+      //     model: modelName,
+      //     temperature: 0,
+      //     apiKey: googleApiKey,
+      //     baseUrl: getAiProxyBaseUrl(preferencesStore.aiProxyPort) + "/google",
+      //     streamUsage: false,
+      //   });
+      // }
       default:
-        throw new Error(`Unsupported model: ${preferencesStore.selectedModel}`);
+        throw new Error(`Unsupported provider: ${provider}`);
     }
   };
 

--- a/src/renderer/components/text-input/text-input-hook.tsx
+++ b/src/renderer/components/text-input/text-input-hook.tsx
@@ -1,9 +1,14 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as React from "react";
-import { AIModelInfos, AIModelsEnum, toAIModelEnum } from "../../business/provider/ai-models";
+import { PreferencesStore } from "../../../common/store";
+import { AIProviders } from "../../business/provider/ai-models";
 import { useApplicationStatusStore } from "../../context/application-context";
 
 import type { SingleValue } from "react-select";
+
+const {
+  Navigation: { navigate },
+} = Renderer;
 
 const { useEffect, useRef, useState } = React;
 
@@ -13,13 +18,30 @@ type TextInputHookProps = {
 
 const MAX_ROWS = 5;
 
+// A model is only offered in the dropdown if its provider has a usable key.
+const hasKeyForProvider = (preferencesStore: PreferencesStore, provider: AIProviders): boolean => {
+  switch (provider) {
+    case AIProviders.OPEN_AI:
+      return Boolean(process.env.OPENAI_API_KEY || preferencesStore.openAIKey);
+    // case AIProviders.GOOGLE:
+    //   return Boolean(process.env.GOOGLE_API_KEY || preferencesStore.googleAIKey);
+    default:
+      return false;
+  }
+};
+
 export const useTextInput = ({ onSend }: TextInputHookProps) => {
   const [message, setMessage] = useState("");
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const modelSelections = Object.entries(AIModelInfos).map(([value, aiModelInfo]) => {
-    return { value, label: aiModelInfo.description };
-  });
+  const preferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
   const applicationStatusStore = useApplicationStatusStore();
+
+  // Only list models whose provider has a key configured.
+  const modelSelections = preferencesStore.models
+    .filter((model) => hasKeyForProvider(preferencesStore, model.provider))
+    .map((model) => ({ value: model.name, label: model.name }));
+
+  const hasAvailableModels = modelSelections.length > 0;
 
   const adaptTextareaHeight = () => {
     const textarea = textareaRef.current;
@@ -51,14 +73,23 @@ export const useTextInput = ({ onSend }: TextInputHookProps) => {
     }
   };
 
-  const onChangeModel = (option: SingleValue<Renderer.Component.SelectOption<AIModelsEnum>>) => {
+  const onChangeModel = (option: SingleValue<Renderer.Component.SelectOption<string>>) => {
     if (option) {
-      const selectedModel = toAIModelEnum(option.value);
-      if (selectedModel) {
-        applicationStatusStore.setSelectedModel(selectedModel);
-      }
+      applicationStatusStore.setSelectedModel(option.value);
     }
   };
 
-  return { message, textareaRef, modelSelections, setMessage, handleKeyDown, handleSend, onChangeModel };
+  const goToPreferences = () => navigate("/preferences");
+
+  return {
+    message,
+    textareaRef,
+    modelSelections,
+    hasAvailableModels,
+    setMessage,
+    handleKeyDown,
+    handleSend,
+    onChangeModel,
+    goToPreferences,
+  };
 };

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -1,23 +1,25 @@
 import { Renderer } from "@freelensapp/extensions";
 import { Eraser, SendHorizonal, ShieldOff } from "lucide-react";
+import * as MobxReact from "mobx-react";
 import * as React from "react";
-import { AIModelsEnum } from "../../business/provider/ai-models";
 import { useApplicationStatusStore } from "../../context/application-context";
 import { AvailableTools } from "../available-tools/available-tools";
 import styleInline from "./text-input.scss?inline";
 import { useTextInput } from "./text-input-hook";
 
+const { observer } = MobxReact;
+
 const {
-  Component: { Select },
+  Component: { Button, Select },
 } = Renderer;
 
-type TextInputOption = Renderer.Component.SelectOption<AIModelsEnum>;
+type TextInputOption = Renderer.Component.SelectOption<string>;
 
 type TextInputProps = {
   onSend: (message: string) => void;
 };
 
-export const TextInput = ({ onSend }: TextInputProps) => {
+export const TextInput = observer(({ onSend }: TextInputProps) => {
   const applicationStatusStore = useApplicationStatusStore();
   const textInputHook = useTextInput({ onSend });
   const textInputOptions = textInputHook.modelSelections as TextInputOption[];
@@ -106,14 +108,23 @@ export const TextInput = ({ onSend }: TextInputProps) => {
               </button>
             </div>
             <div style={{ display: "flex", alignItems: "center" }}>
-              <Select
-                id="update-channel-input"
-                options={textInputOptions}
-                value={applicationStatusStore.selectedModel}
-                onChange={textInputHook.onChangeModel}
-                themeName="lens"
-                className="text-input-select-box"
-              />
+              {textInputHook.hasAvailableModels ? (
+                <Select
+                  id="update-channel-input"
+                  options={textInputOptions}
+                  value={applicationStatusStore.selectedModel}
+                  onChange={textInputHook.onChangeModel}
+                  themeName="lens"
+                  className="text-input-select-box"
+                />
+              ) : (
+                <Button
+                  primary
+                  label="Configure models in preferences"
+                  onClick={textInputHook.goToPreferences}
+                  title="No model is available. Set an API key and add models in Freelens AI settings."
+                />
+              )}
               <button
                 className="text-input-send-button"
                 onClick={textInputHook.handleSend}
@@ -131,4 +142,4 @@ export const TextInput = ({ onSend }: TextInputProps) => {
       </div>
     </>
   );
-};
+});

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -12,26 +12,24 @@ import { generateUuid } from "../../common/utils/uuid";
 import { FreeLensAgent, useFreeLensAgentSystem } from "../business/agent/freelens-agent-system";
 import { MPCAgent, useMcpAgent } from "../business/agent/mcp-agent";
 import { getTextMessage } from "../business/objects/message-object-provider";
-import { AIModelsEnum } from "../business/provider/ai-models";
+import { AIProviders } from "../business/provider/ai-models";
 
 import type { MessageObject } from "../business/objects/message-object";
 
 export interface AppContextType {
   apiKey: string;
-  selectedModel: AIModelsEnum;
+  selectedModel: string;
   mcpEnabled: boolean;
   mcpConfiguration: string;
   bypassApprovals: boolean;
   explainEvent: MessageObject;
-  ollamaHost: string;
-  ollamaPort: string;
   conversationId: string;
   isLoading: boolean;
   isConversationInterrupted: boolean;
   chatMessages: MessageObject[] | null;
   freeLensAgent: FreeLensAgent | null;
   mcpAgent: MPCAgent | null;
-  setSelectedModel: (selectedModel: AIModelsEnum) => void;
+  setSelectedModel: (selectedModel: string) => void;
   setExplainEvent: (messageObject: MessageObject) => void;
   setBypassApprovals: (bypassApprovals: boolean) => void;
   setLoading: (isLoading: boolean) => void;
@@ -247,8 +245,22 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     return freeLensAgent;
   };
 
-  const setSelectedModel = (selectedModel: AIModelsEnum) => {
+  const setSelectedModel = (selectedModel: string) => {
     preferencesStore.selectedModel = selectedModel;
+  };
+
+  // The API key to use depends on the selected model's provider. Only OpenAI is
+  // active for now; other providers are derived here once re-added.
+  const getApiKeyForSelectedModel = (): string => {
+    const provider = preferencesStore.models.find((model) => model.name === preferencesStore.selectedModel)?.provider;
+    switch (provider) {
+      case AIProviders.OPEN_AI:
+        return preferencesStore.openAIKey;
+      // case AIProviders.GOOGLE:
+      //   return preferencesStore.googleAIKey;
+      default:
+        return preferencesStore.openAIKey;
+    }
   };
 
   const getAvailableTools = async () => {
@@ -275,14 +287,12 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   return (
     <AppContext.Provider
       value={{
-        apiKey: preferencesStore.openAIKey,
+        apiKey: getApiKeyForSelectedModel(),
         selectedModel: preferencesStore.selectedModel,
         mcpEnabled: preferencesStore.mcpEnabled,
         mcpConfiguration: preferencesStore.mcpConfiguration,
         bypassApprovals: preferencesStore.bypassApprovals,
         explainEvent: preferencesStore.explainEvent,
-        ollamaHost: preferencesStore.ollamaHost,
-        ollamaPort: preferencesStore.ollamaPort,
         conversationId,
         isLoading,
         isConversationInterrupted,

--- a/src/renderer/pages/preferences/preferences-page.tsx
+++ b/src/renderer/pages/preferences/preferences-page.tsx
@@ -1,31 +1,137 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
+import * as React from "react";
+import { AIProviders, DEFAULT_MODELS, PROVIDER_LABELS } from "../../business/provider/ai-models";
+
+import type { SingleValue } from "react-select";
 
 const { observer } = MobxReact;
+const { useState } = React;
 
 import { PreferencesStore } from "../../../common/store";
 
 const {
-  Component: { Input, Switch, HorizontalLine },
+  Component: { Button, Icon, Input, Select, Switch, HorizontalLine },
 } = Renderer;
+
+type SelectOption<T> = Renderer.Component.SelectOption<T>;
+
+const REASONING_EFFORT_OPTIONS: SelectOption<string>[] = [
+  { value: "", label: "Default" },
+  { value: "low", label: "Low" },
+  { value: "medium", label: "Medium" },
+  { value: "high", label: "High" },
+];
+
+const PROVIDER_OPTIONS: SelectOption<AIProviders>[] = Object.values(AIProviders).map((provider) => ({
+  value: provider,
+  label: PROVIDER_LABELS[provider],
+}));
 
 export const PreferencesPage = observer(() => {
   const preferencesStore: PreferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
 
+  const [newModelProvider, setNewModelProvider] = useState<AIProviders>(AIProviders.OPEN_AI);
+  const [newModelName, setNewModelName] = useState<string>("");
+
+  const addModel = () => {
+    const name = newModelName.trim();
+    if (!name) return;
+    // Avoid duplicates of the same provider + model name.
+    if (preferencesStore.models.some((model) => model.provider === newModelProvider && model.name === name)) {
+      setNewModelName("");
+      return;
+    }
+    preferencesStore.models = [...preferencesStore.models, { provider: newModelProvider, name }];
+    setNewModelName("");
+  };
+
+  const removeModel = (index: number) => {
+    const removed = preferencesStore.models[index];
+    preferencesStore.models = preferencesStore.models.filter((_, i) => i !== index);
+    // If the removed entry was selected, fall back to a valid model.
+    if (removed?.name === preferencesStore.selectedModel) {
+      preferencesStore.selectedModel = preferencesStore.models[0]?.name ?? "";
+    }
+  };
+
+  const resetModels = () => {
+    preferencesStore.models = [...DEFAULT_MODELS];
+    if (!preferencesStore.models.some((model) => model.name === preferencesStore.selectedModel)) {
+      preferencesStore.selectedModel = preferencesStore.models[0]?.name ?? "";
+    }
+  };
+
   return (
     <>
-      <div style={{ marginTop: 8, fontWeight: "bold" }}>OpenAI Key</div>
+      <div style={{ fontWeight: "bold", fontSize: 16 }}>OpenAI</div>
+      <div style={{ marginTop: 8, fontWeight: "bold" }}>API key</div>
       <Input
+        type="password"
         placeholder="Put here your OpenAI API key"
         value={preferencesStore.openAIKey}
         onChange={(value: string) => (preferencesStore.openAIKey = value)}
       />
-      <div style={{ marginTop: 8, fontWeight: "bold" }}>GoogleAI Key</div>
+      <div style={{ marginTop: 8, fontWeight: "bold" }}>Base URL</div>
       <Input
-        placeholder="Put here your GoogleAI API key"
-        value={preferencesStore.googleAIKey}
-        onChange={(value: string) => (preferencesStore.googleAIKey = value)}
+        placeholder="https://api.openai.com/v1"
+        value={preferencesStore.openAIBaseUrl}
+        onChange={(value: string) => (preferencesStore.openAIBaseUrl = value)}
       />
+      <div style={{ marginTop: 8, fontWeight: "bold" }}>Reasoning effort</div>
+      <div style={{ fontSize: 12, marginBottom: 4, opacity: 0.7 }}>
+        Applied only to reasoning-capable models (o-series, gpt-5.x).
+      </div>
+      <Select
+        options={REASONING_EFFORT_OPTIONS}
+        value={preferencesStore.openAIReasoningEffort}
+        onChange={(option: SingleValue<SelectOption<string>>) =>
+          (preferencesStore.openAIReasoningEffort = option?.value ?? "")
+        }
+        themeName="lens"
+      />
+
+      <HorizontalLine />
+
+      <div style={{ fontWeight: "bold", fontSize: 16 }}>Models</div>
+      <div style={{ fontSize: 12, marginBottom: 8, opacity: 0.7 }}>
+        Add or remove the models offered in the chat. The model name is sent to the provider API.
+      </div>
+      {preferencesStore.models.map((model, index) => (
+        <div
+          key={`${model.provider}/${model.name}`}
+          style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 6 }}
+        >
+          <span style={{ minWidth: 80, opacity: 0.7 }}>{PROVIDER_LABELS[model.provider] ?? model.provider}</span>
+          <span style={{ flex: 1, fontFamily: "monospace" }}>{model.name}</span>
+          <Icon material="delete" small interactive tooltip="Remove model" onClick={() => removeModel(index)} />
+        </div>
+      ))}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 8 }}>
+        <div style={{ minWidth: 120 }}>
+          <Select
+            options={PROVIDER_OPTIONS}
+            value={newModelProvider}
+            onChange={(option: SingleValue<SelectOption<AIProviders>>) =>
+              setNewModelProvider(option?.value ?? AIProviders.OPEN_AI)
+            }
+            themeName="lens"
+          />
+        </div>
+        <div style={{ flex: 1 }}>
+          <Input
+            placeholder="Model name, e.g. gpt-5.5"
+            value={newModelName}
+            onChange={(value: string) => setNewModelName(value)}
+            onSubmit={addModel}
+          />
+        </div>
+        <Button primary label="Add" onClick={addModel} />
+      </div>
+      <div style={{ marginTop: 8 }}>
+        <Button plain label="Reset to defaults" onClick={resetModels} />
+      </div>
+
       {/*<HorizontalLine />*/}
       {/*<div>*/}
       {/*  <SubTitle title="Ollama settings" />*/}
@@ -44,6 +150,7 @@ export const PreferencesPage = observer(() => {
       {/*    onChange={(value: string) => (preferencesStore.ollamaPort = value)}*/}
       {/*  />*/}
       {/*</div>*/}
+
       <HorizontalLine />
       <div>
         <div style={{ fontWeight: "bold" }}>Enable MCP</div>


### PR DESCRIPTION
Implements a user-editable list of models with OpenAI provider settings, replacing the hardcoded model enum.

- Open, editable model list seeded with gpt-5.5, gpt-5.4, gpt-5.4-mini
- OpenAI provider section in preferences: API key, base URL (default https://api.openai.com/v1), reasoning effort
- Configurable base URL routed to the local proxy via an x-upstream-base-url header
- Model-specific behavior decided by name heuristics instead of an enum
- Chat dropdown lists only models whose provider has a key, with a preferences button when empty
- Google/Ollama temporarily commented out for later re-add

Resolves #112

Generated with [Claude Code](https://claude.ai/code)