### PR TITLE
Validation, edge cases, tests and docs for the editable model list

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,57 @@
+name: Unit tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  test-unit:
+    name: unit tests
+
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: Setup pnpm
+        run: corepack enable
+
+      - name: Get pnpm cache directory
+        shell: bash
+        run: echo "pnpm_cache_dir=$(pnpm store path)" >> ${GITHUB_ENV}
+
+      - name: Use pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ env.pnpm_cache_dir }}
+          key: ubuntu-24.04-arm-node-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ubuntu-24.04-arm-node-
+
+      - name: Install pnpm dependencies
+        id: install-pnpm
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+        continue-on-error: true
+
+      - name: Install pnpm dependencies (retry)
+        if: steps.install-pnpm.outcome == 'failure'
+        run: timeout 300 pnpm install --color=always --prefer-offline --frozen-lockfile
+
+      - name: Run unit tests
+        run: pnpm --color=always --stream test:unit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,32 @@ These are NOT bundled, they come from the Freelens host as globals:
 
 Other dependencies ARE bundled into the extension output.
 
+## AI Model & Provider System
+
+The list of chat models is user-editable and persisted in the preferences
+store; there is no hardcoded model enum. Key files live in
+`src/renderer/business/provider/`:
+
+- `ai-models.tsx` — `AIProviders` enum (only `OPEN_AI` active; Google/Ollama
+  commented out for later re-add), the `CustomModel` type (`{ provider, name }`),
+  the seed list `DEFAULT_MODELS` (`gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`), and
+  `DEFAULT_OPENAI_BASE_URL`.
+- `model-capabilities.ts` — name heuristics (regex) deciding model behavior.
+  Add new model families here rather than hardcoding ids. Reasoning models
+  (`o<n>`, `gpt-5.x`) take a reasoning effort and reject `temperature`.
+- `model-list.ts` — pure helpers for the editable list (trim, dedupe, remove,
+  `resolveSelectedModel` selection fallback). No host/MobX deps so they are
+  unit-tested directly.
+- `openai-fields.ts` — pure `buildOpenAIChatFields` builder (proxy routing
+  header + reasoning-effort/temperature heuristic), unit-tested in isolation.
+- `model-provider.ts` — `getModel()` resolves the selected model's provider and
+  builds the LangChain client; throws when no model is selected.
+
+A custom base URL is routed to the local proxy (`src/main/ai-proxy-server.ts`)
+via the `x-upstream-base-url` header rather than being passed straight to the
+client. When changing the heuristics or list logic, prefer extending the pure
+helpers and add/adjust the matching `*.test.ts` (run with `pnpm test:unit`).
+
 ## Code Style
 
 - **Biome** formats **TypeScript/TSX**: double quotes, semicolons, trailing commas, 2-space indent, 120 char line width

--- a/README.md
+++ b/README.md
@@ -48,24 +48,33 @@ Use a following URL in the browser:
 [freelens://app/extensions/install/%40freelensapp%2Fai-extension](freelens://app/extensions/install/%40freelensapp%2Fai-extension)
 
 ## Available Models
-freelens-ai-extension currently supports integration with the following AI models:
+The list of models is fully editable in the extension preferences. You can add
+or remove any model offered by the configured provider; the model name you enter
+is sent directly to the provider API.
+
+The list comes seeded with these OpenAI models, which you can change at any time:
 
 - ***gpt-5.5***
 - ***gpt-5.4***
-- ***gpt-5***
-- ***gpt-4.1***
-- ***gemini 2.5 flash***
+- ***gpt-5.4-mini***
 
-Each model offers different capabilities and performance characteristics.
-Choose the one that best suits your needs and workflow requirements.
+Model-specific behavior (for example, sending a reasoning effort instead of a
+temperature) is decided by heuristics on the model name, so adding a new model
+needs no code changes.
+
+> Currently only the OpenAI provider is enabled. Google/Gemini and Ollama
+> support is temporarily disabled and will return after further refactoring.
 
 ### Connecting a model
-You can connect your model by setting its API Key in the preferences page or by using you environment variables;
-for example you can set:
-- GOOGLE_API_KEY = ...
+Open the preferences page and, in the OpenAI section, set your API key and
+(optionally) a custom base URL. You can also provide the key through an
+environment variable instead:
+
 - OPENAI_API_KEY = ...
 
-together to switch model without switch the API Key in settings page.
+A model is only offered in the chat dropdown once its provider has a key set; if
+no model is available, the chat shows a button that takes you to the preferences
+page.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "knip:check": "pnpm \"/^knip:(development|production)\\$/\"",
     "knip:development": "pnpm knip",
     "knip:production": "pnpm knip --production --strict",
+    "test:unit": "vitest run",
     "type:check": "tsc --noEmit -p tsconfig.json --composite false",
     "prebuild": "pnpm type:check",
     "build": "electron-vite build",
@@ -88,6 +89,7 @@
     "vite": "^8.0.16",
     "vite-plugin-external": "^6.2.2",
     "vite-plugin-sass-dts": "^1.3.37",
+    "vitest": "^4.1.9",
     "zod": "^3.25.67"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       vite-plugin-sass-dts:
         specifier: ^1.3.37
         version: 1.3.37(postcss@8.5.15)(prettier@3.8.4)(sass-embedded@1.100.0)(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1))
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@24.12.4)(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1))
       zod:
         specifier: ^3.25.67
         version: 3.25.67
@@ -1111,8 +1114,17 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/fs-extra@11.0.4':
     resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
@@ -1207,6 +1219,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
+
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
+
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
+
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
+
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
+
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
+
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
 
@@ -1264,6 +1305,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1402,6 +1447,10 @@ packages:
 
   caniuse-lite@1.0.30001724:
     resolution: {integrity: sha512-WqJo7p0TbHDOythNTqYujmaJTvtYRZrjpP8TCvH6Vb9CYJerJNKamKzIWOM4BkQatWj9H2lYulpdAQNBe7QhNA==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1711,6 +1760,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1748,6 +1800,9 @@ packages:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1766,6 +1821,10 @@ packages:
   eventsource@3.0.7:
     resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
     engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -2566,6 +2625,10 @@ packages:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.3:
+    resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
+    engines: {node: '>=12.20.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -2686,6 +2749,9 @@ packages:
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
@@ -3198,6 +3264,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -3255,6 +3324,9 @@ packages:
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   static-eval@2.0.2:
     resolution: {integrity: sha512-N/D219Hcr2bPjLxPiV+TQE++Tsmrady7TqAJugLy7Xk1EumfDWS/f5dtBbkRCGE7wKKXuYockQoj8Rm2/pVKyg==}
 
@@ -3265,6 +3337,9 @@ packages:
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -3359,9 +3434,20 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -3579,6 +3665,47 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   vp-runtime-helper@1.0.10:
     resolution: {integrity: sha512-2HUCkqI0uwgBti1/+utRu7Hvk/I3HeowBQfRlEL3487r+LpW1w91kk6uTZbwOd6I2Sj3aAxBE0HxYNC/NLbuhA==}
     engines: {node: '>=14.18.0', vite: '>=3.1.0'}
@@ -3586,6 +3713,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   winston-transport-browserconsole@1.0.5:
@@ -5016,9 +5148,18 @@ snapshots:
       '@types/node': 24.12.4
       '@types/responselike': 1.0.3
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/fs-extra@11.0.4':
     dependencies:
@@ -5114,6 +5255,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1)
 
+  '@vitest/expect@4.1.9':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 4.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1)
+
+  '@vitest/pretty-format@4.1.9':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.9':
+    dependencies:
+      '@vitest/utils': 4.1.9
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.9': {}
+
+  '@vitest/utils@4.1.9':
+    dependencies:
+      '@vitest/pretty-format': 4.1.9
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   '@xterm/addon-fit@0.11.0': {}
 
   '@xterm/addon-web-links@0.12.0': {}
@@ -5164,6 +5346,8 @@ snapshots:
   argparse@2.0.1: {}
 
   array-union@2.1.0: {}
+
+  assertion-error@2.0.1: {}
 
   async@3.2.6: {}
 
@@ -5305,6 +5489,8 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001724: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -5606,6 +5792,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.1.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -5661,6 +5849,10 @@ snapshots:
 
   estraverse@4.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -5672,6 +5864,8 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.0.2
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@7.5.1(express@5.1.0):
     dependencies:
@@ -6467,6 +6661,8 @@ snapshots:
   object-keys@1.1.1:
     optional: true
 
+  obug@2.1.3: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -6577,6 +6773,8 @@ snapshots:
   path-to-regexp@8.2.0: {}
 
   path-type@4.0.0: {}
+
+  pathe@2.0.3: {}
 
   pend@1.2.0: {}
 
@@ -7142,6 +7340,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   simple-swizzle@0.2.2:
@@ -7190,6 +7390,8 @@ snapshots:
 
   stack-trace@0.0.10: {}
 
+  stackback@0.0.2: {}
+
   static-eval@2.0.2:
     dependencies:
       escodegen: 1.14.3
@@ -7197,6 +7399,8 @@ snapshots:
   statuses@2.0.1: {}
 
   statuses@2.0.2: {}
+
+  std-env@4.1.0: {}
 
   stoppable@1.1.0: {}
 
@@ -7317,10 +7521,16 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.2.4: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinyrainbow@3.1.0: {}
 
   to-regex-range@5.0.1:
     dependencies:
@@ -7498,6 +7708,33 @@ snapshots:
       terser: 5.39.1
       yaml: 2.7.1
 
+  vitest@4.1.9(@types/node@24.12.4)(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1)):
+    dependencies:
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
+      es-module-lexer: 2.1.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.3
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.0
+      vite: 8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.12.4
+    transitivePeerDependencies:
+      - msw
+
   vp-runtime-helper@1.0.10:
     dependencies:
       '@types/fs-extra': 11.0.4
@@ -7512,6 +7749,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   winston-transport-browserconsole@1.0.5:
     dependencies:

--- a/src/common/store/preferences-store.ts
+++ b/src/common/store/preferences-store.ts
@@ -1,6 +1,7 @@
 import { Common } from "@freelensapp/extensions";
 import { makeObservable, observable, toJS } from "mobx";
 import { type CustomModel, DEFAULT_MODELS, DEFAULT_OPENAI_BASE_URL } from "../../renderer/business/provider/ai-models";
+import { resolveSelectedModel } from "../../renderer/business/provider/model-list";
 
 import type { MessageObject } from "../../renderer/business/objects/message-object";
 
@@ -83,9 +84,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
     this.models = preferencesModel.models?.length ? preferencesModel.models : [...DEFAULT_MODELS];
     // Validate the selection against the available models; fall back to the
     // first entry (replaces the old enum validation).
-    this.selectedModel = this.models.some((model) => model.name === preferencesModel.selectedModel)
-      ? preferencesModel.selectedModel
-      : (this.models[0]?.name ?? DEFAULT_SELECTED_MODEL);
+    this.selectedModel = resolveSelectedModel(this.models, preferencesModel.selectedModel);
     this.mcpEnabled = preferencesModel.mcpEnabled;
     this.mcpConfiguration = preferencesModel.mcpConfiguration;
     // this.ollamaHost = preferencesModel.ollamaHost;

--- a/src/renderer/business/provider/model-capabilities.test.ts
+++ b/src/renderer/business/provider/model-capabilities.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { isReasoningModel, supportsTemperature } from "./model-capabilities";
+
+describe("isReasoningModel", () => {
+  it.each([
+    "o1",
+    "o3-mini",
+    "O1-preview",
+    "gpt-5",
+    "gpt-5.4",
+    "gpt-5.5",
+    "gpt-5.4-mini",
+  ])("treats %s as a reasoning model", (name) => {
+    expect(isReasoningModel(name)).toBe(true);
+  });
+
+  it.each([
+    "gpt-4.1",
+    "gpt-4o",
+    "gpt-3.5-turbo",
+    "text-embedding-3-small",
+    "",
+  ])("treats %s as a non-reasoning model", (name) => {
+    expect(isReasoningModel(name)).toBe(false);
+  });
+});
+
+describe("supportsTemperature", () => {
+  it("is the inverse of isReasoningModel", () => {
+    for (const name of ["gpt-5.5", "o1", "gpt-4.1", "gpt-4o"]) {
+      expect(supportsTemperature(name)).toBe(!isReasoningModel(name));
+    }
+  });
+});

--- a/src/renderer/business/provider/model-list.test.ts
+++ b/src/renderer/business/provider/model-list.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { AIProviders, type CustomModel, DEFAULT_MODELS } from "./ai-models";
+import {
+  addModel,
+  findProvider,
+  hasModel,
+  normalizeModelName,
+  removeModelAt,
+  resolveSelectedModel,
+} from "./model-list";
+
+const models = (): CustomModel[] => [
+  { provider: AIProviders.OPEN_AI, name: "gpt-5.5" },
+  { provider: AIProviders.OPEN_AI, name: "gpt-5.4" },
+];
+
+describe("normalizeModelName", () => {
+  it("trims surrounding whitespace", () => {
+    expect(normalizeModelName("  gpt-5.5  ")).toBe("gpt-5.5");
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(normalizeModelName("   ")).toBe("");
+  });
+});
+
+describe("hasModel", () => {
+  it("matches on provider + name", () => {
+    expect(hasModel(models(), AIProviders.OPEN_AI, "gpt-5.5")).toBe(true);
+    expect(hasModel(models(), AIProviders.OPEN_AI, "gpt-4.1")).toBe(false);
+  });
+});
+
+describe("addModel", () => {
+  it("appends a new model and trims the name", () => {
+    const result = addModel(models(), AIProviders.OPEN_AI, "  gpt-4.1 ");
+    expect(result).toHaveLength(3);
+    expect(result[2]).toEqual({ provider: AIProviders.OPEN_AI, name: "gpt-4.1" });
+  });
+
+  it("does not mutate the input list", () => {
+    const input = models();
+    addModel(input, AIProviders.OPEN_AI, "gpt-4.1");
+    expect(input).toHaveLength(2);
+  });
+
+  it("ignores empty / whitespace-only names", () => {
+    const input = models();
+    expect(addModel(input, AIProviders.OPEN_AI, "   ")).toBe(input);
+  });
+
+  it("ignores duplicates of the same provider + name", () => {
+    const input = models();
+    expect(addModel(input, AIProviders.OPEN_AI, "gpt-5.5")).toBe(input);
+  });
+});
+
+describe("removeModelAt", () => {
+  it("removes the entry at the given index without mutating the input", () => {
+    const input = models();
+    const result = removeModelAt(input, 0);
+    expect(result).toEqual([{ provider: AIProviders.OPEN_AI, name: "gpt-5.4" }]);
+    expect(input).toHaveLength(2);
+  });
+});
+
+describe("findProvider", () => {
+  it("returns the provider of the matching model", () => {
+    expect(findProvider(models(), "gpt-5.4")).toBe(AIProviders.OPEN_AI);
+  });
+
+  it("returns undefined when no model matches", () => {
+    expect(findProvider(models(), "missing")).toBeUndefined();
+  });
+});
+
+describe("resolveSelectedModel", () => {
+  it("keeps a selection that still exists", () => {
+    expect(resolveSelectedModel(models(), "gpt-5.4")).toBe("gpt-5.4");
+  });
+
+  it("falls back to the first model when the selection is missing", () => {
+    expect(resolveSelectedModel(models(), "removed-model")).toBe("gpt-5.5");
+  });
+
+  it("returns an empty string for an empty list", () => {
+    expect(resolveSelectedModel([], "gpt-5.5")).toBe("");
+  });
+
+  it("resolves the seed list selection", () => {
+    expect(resolveSelectedModel([...DEFAULT_MODELS], "")).toBe(DEFAULT_MODELS[0].name);
+  });
+});

--- a/src/renderer/business/provider/model-list.ts
+++ b/src/renderer/business/provider/model-list.ts
@@ -1,0 +1,35 @@
+// Pure helpers for managing the editable model list. Kept free of any host
+// (`@freelensapp/extensions`) or MobX dependency so they can be unit-tested in
+// isolation and reused by the store, the preferences UI and the model provider.
+
+import { type AIProviders, type CustomModel } from "./ai-models";
+
+// Trim surrounding whitespace from a typed-in model name.
+export const normalizeModelName = (name: string): string => name.trim();
+
+// Whether the list already contains the given provider + name combination.
+export const hasModel = (models: CustomModel[], provider: AIProviders, name: string): boolean =>
+  models.some((model) => model.provider === provider && model.name === name);
+
+// Return a new list with the model appended. No-op (returns the same list) when
+// the name is empty after trimming or the provider + name pair already exists.
+export const addModel = (models: CustomModel[], provider: AIProviders, rawName: string): CustomModel[] => {
+  const name = normalizeModelName(rawName);
+  if (!name || hasModel(models, provider, name)) {
+    return models;
+  }
+  return [...models, { provider, name }];
+};
+
+// Return a new list with the entry at `index` removed.
+export const removeModelAt = (models: CustomModel[], index: number): CustomModel[] =>
+  models.filter((_, i) => i !== index);
+
+// Provider for the first model matching `name`, or undefined if none matches.
+export const findProvider = (models: CustomModel[], name: string): AIProviders | undefined =>
+  models.find((model) => model.name === name)?.provider;
+
+// Validate a stored/desired selection against the available models. Falls back
+// to the first model when the selection is missing, and to "" for an empty list.
+export const resolveSelectedModel = (models: CustomModel[], selected: string): string =>
+  models.some((model) => model.name === selected) ? selected : (models[0]?.name ?? "");

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -1,13 +1,14 @@
 // import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 // import { ChatOllama } from "@langchain/ollama";
-import { ChatOpenAI, type ChatOpenAIFields } from "@langchain/openai";
+import { ChatOpenAI } from "@langchain/openai";
 import { PreferencesStore } from "../../../common/store";
 import { AIProviders, DEFAULT_OPENAI_BASE_URL } from "./ai-models";
-import { isReasoningModel } from "./model-capabilities";
+import { findProvider } from "./model-list";
+import { buildOpenAIChatFields } from "./openai-fields";
 
-// Header read by the local AI proxy to decide which upstream to forward to,
-// letting the user configure a custom base URL without changing the proxy code.
-export const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
+// Re-exported for callers that imported it from here previously; the canonical
+// definition now lives next to the field builder.
+export { UPSTREAM_BASE_URL_HEADER } from "./openai-fields";
 
 const getAiProxyBaseUrl = (aiProxyPort: number | null) => {
   if (aiProxyPort === null) {
@@ -23,35 +24,28 @@ export const useModelProvider = () => {
 
   const getModel = () => {
     const modelName = preferencesStore.selectedModel;
-    const provider = preferencesStore.models.find((model) => model.name === modelName)?.provider ?? AIProviders.OPEN_AI;
+
+    // Guard the empty-list / no-selection case: the chat UI offers a
+    // "Configure models in preferences" button instead of a dropdown when no
+    // model is available, but bail out clearly if we are still reached.
+    if (!modelName) {
+      throw new Error("No model selected. Add a model in the extension preferences.");
+    }
+
+    const provider = findProvider(preferencesStore.models, modelName) ?? AIProviders.OPEN_AI;
 
     switch (provider) {
       case AIProviders.OPEN_AI: {
         const openAiApiKey = process.env.OPENAI_API_KEY || preferencesStore.openAIKey;
         const openAIBaseUrl = preferencesStore.openAIBaseUrl || DEFAULT_OPENAI_BASE_URL;
 
-        const fields: ChatOpenAIFields = {
-          model: modelName,
+        const fields = buildOpenAIChatFields({
+          modelName,
           apiKey: openAiApiKey,
-          configuration: {
-            // The proxy strips the "/openai" prefix and forwards to the
-            // upstream advertised via UPSTREAM_BASE_URL_HEADER.
-            baseURL: `${getAiProxyBaseUrl(preferencesStore.aiProxyPort)}/openai`,
-            defaultHeaders: {
-              [UPSTREAM_BASE_URL_HEADER]: openAIBaseUrl,
-            },
-          },
-        };
-
-        // Reasoning models reject `temperature` and accept a reasoning effort;
-        // non-reasoning models are the inverse. Decided by name heuristic.
-        if (isReasoningModel(modelName)) {
-          if (preferencesStore.openAIReasoningEffort) {
-            fields.reasoningEffort = preferencesStore.openAIReasoningEffort as ChatOpenAIFields["reasoningEffort"];
-          }
-        } else {
-          fields.temperature = 0;
-        }
+          upstreamBaseUrl: openAIBaseUrl,
+          proxyBaseUrl: getAiProxyBaseUrl(preferencesStore.aiProxyPort),
+          reasoningEffort: preferencesStore.openAIReasoningEffort,
+        });
 
         return new ChatOpenAI(fields);
       }

--- a/src/renderer/business/provider/openai-fields.test.ts
+++ b/src/renderer/business/provider/openai-fields.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { buildOpenAIChatFields, UPSTREAM_BASE_URL_HEADER } from "./openai-fields";
+
+const baseOptions = {
+  apiKey: "sk-test",
+  upstreamBaseUrl: "https://api.openai.com/v1",
+  proxyBaseUrl: "http://127.0.0.1:1234",
+};
+
+describe("buildOpenAIChatFields", () => {
+  it("routes through the proxy and advertises the upstream via header", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "gpt-4.1" });
+    expect(fields.model).toBe("gpt-4.1");
+    expect(fields.apiKey).toBe("sk-test");
+    expect(fields.configuration?.baseURL).toBe("http://127.0.0.1:1234/openai");
+    expect(fields.configuration?.defaultHeaders).toMatchObject({
+      [UPSTREAM_BASE_URL_HEADER]: "https://api.openai.com/v1",
+    });
+  });
+
+  it("sets temperature 0 and no reasoning effort for non-reasoning models", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "gpt-4.1", reasoningEffort: "high" });
+    expect(fields.temperature).toBe(0);
+    expect(fields.reasoningEffort).toBeUndefined();
+  });
+
+  it("sets reasoning effort and omits temperature for reasoning models", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "gpt-5.5", reasoningEffort: "high" });
+    expect(fields.reasoningEffort).toBe("high");
+    expect(fields.temperature).toBeUndefined();
+  });
+
+  it("omits reasoning effort when it is not configured", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "gpt-5.5", reasoningEffort: "" });
+    expect(fields.reasoningEffort).toBeUndefined();
+    expect(fields.temperature).toBeUndefined();
+  });
+});

--- a/src/renderer/business/provider/openai-fields.ts
+++ b/src/renderer/business/provider/openai-fields.ts
@@ -1,0 +1,58 @@
+// Pure builder for the `ChatOpenAIFields` passed to `ChatOpenAI`. Separated from
+// `model-provider.ts` so the option-building logic (proxy routing header,
+// reasoning-effort vs temperature heuristic) can be unit-tested without the
+// MobX store or instantiating a real client.
+
+import { isReasoningModel } from "./model-capabilities";
+
+import type { ChatOpenAIFields } from "@langchain/openai";
+
+// Header read by the local AI proxy to decide which upstream to forward to,
+// letting the user configure a custom base URL without changing the proxy code.
+export const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
+
+export interface OpenAIChatFieldsOptions {
+  // Model id sent to the OpenAI API (e.g. "gpt-5.5").
+  modelName: string;
+  // API key used for the request.
+  apiKey: string;
+  // Full upstream base URL advertised to the proxy (e.g. https://api.openai.com/v1).
+  upstreamBaseUrl: string;
+  // Local proxy origin (e.g. http://127.0.0.1:<port>); the "/openai" prefix is appended.
+  proxyBaseUrl: string;
+  // Optional reasoning effort; applied only to reasoning-capable models.
+  reasoningEffort?: string;
+}
+
+export const buildOpenAIChatFields = ({
+  modelName,
+  apiKey,
+  upstreamBaseUrl,
+  proxyBaseUrl,
+  reasoningEffort,
+}: OpenAIChatFieldsOptions): ChatOpenAIFields => {
+  const fields: ChatOpenAIFields = {
+    model: modelName,
+    apiKey,
+    configuration: {
+      // The proxy strips the "/openai" prefix and forwards to the upstream
+      // advertised via UPSTREAM_BASE_URL_HEADER.
+      baseURL: `${proxyBaseUrl}/openai`,
+      defaultHeaders: {
+        [UPSTREAM_BASE_URL_HEADER]: upstreamBaseUrl,
+      },
+    },
+  };
+
+  // Reasoning models reject `temperature` and accept a reasoning effort;
+  // non-reasoning models are the inverse. Decided by name heuristic.
+  if (isReasoningModel(modelName)) {
+    if (reasoningEffort) {
+      fields.reasoningEffort = reasoningEffort as ChatOpenAIFields["reasoningEffort"];
+    }
+  } else {
+    fields.temperature = 0;
+  }
+
+  return fields;
+};

--- a/src/renderer/pages/preferences/preferences-page.tsx
+++ b/src/renderer/pages/preferences/preferences-page.tsx
@@ -2,6 +2,7 @@ import { Renderer } from "@freelensapp/extensions";
 import * as MobxReact from "mobx-react";
 import * as React from "react";
 import { AIProviders, DEFAULT_MODELS, PROVIDER_LABELS } from "../../business/provider/ai-models";
+import { addModel, removeModelAt, resolveSelectedModel } from "../../business/provider/model-list";
 
 import type { SingleValue } from "react-select";
 
@@ -34,32 +35,22 @@ export const PreferencesPage = observer(() => {
   const [newModelProvider, setNewModelProvider] = useState<AIProviders>(AIProviders.OPEN_AI);
   const [newModelName, setNewModelName] = useState<string>("");
 
-  const addModel = () => {
-    const name = newModelName.trim();
-    if (!name) return;
-    // Avoid duplicates of the same provider + model name.
-    if (preferencesStore.models.some((model) => model.provider === newModelProvider && model.name === name)) {
-      setNewModelName("");
-      return;
-    }
-    preferencesStore.models = [...preferencesStore.models, { provider: newModelProvider, name }];
+  const handleAddModel = () => {
+    // `addModel` trims the name and ignores empty/duplicate entries.
+    preferencesStore.models = addModel(preferencesStore.models, newModelProvider, newModelName);
     setNewModelName("");
   };
 
   const removeModel = (index: number) => {
-    const removed = preferencesStore.models[index];
-    preferencesStore.models = preferencesStore.models.filter((_, i) => i !== index);
-    // If the removed entry was selected, fall back to a valid model.
-    if (removed?.name === preferencesStore.selectedModel) {
-      preferencesStore.selectedModel = preferencesStore.models[0]?.name ?? "";
-    }
+    preferencesStore.models = removeModelAt(preferencesStore.models, index);
+    // Re-validate the selection: if the removed entry was selected, fall back
+    // to a valid model (or "" when the list is now empty).
+    preferencesStore.selectedModel = resolveSelectedModel(preferencesStore.models, preferencesStore.selectedModel);
   };
 
   const resetModels = () => {
     preferencesStore.models = [...DEFAULT_MODELS];
-    if (!preferencesStore.models.some((model) => model.name === preferencesStore.selectedModel)) {
-      preferencesStore.selectedModel = preferencesStore.models[0]?.name ?? "";
-    }
+    preferencesStore.selectedModel = resolveSelectedModel(preferencesStore.models, preferencesStore.selectedModel);
   };
 
   return (
@@ -123,10 +114,10 @@ export const PreferencesPage = observer(() => {
             placeholder="Model name, e.g. gpt-5.5"
             value={newModelName}
             onChange={(value: string) => setNewModelName(value)}
-            onSubmit={addModel}
+            onSubmit={handleAddModel}
           />
         </div>
-        <Button primary label="Add" onClick={addModel} />
+        <Button primary label="Add" onClick={handleAddModel} />
       </div>
       <div style={{ marginTop: 8 }}>
         <Button plain label="Reset to defaults" onClick={resetModels} />

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Unit tests live next to the code they cover as *.test.ts files.
+    include: ["src/**/*.test.ts"],
+    environment: "node",
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    // Unit tests live next to the code they cover as *.test.ts files.
-    include: ["src/**/*.test.ts"],
     environment: "node",
+    exclude: ["integration/**", "node_modules/**", "out/**"],
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    passWithNoTests: true,
   },
 });


### PR DESCRIPTION
Completes PR 5 of the editable-model-list plan (issue #112).

- Extract pure, testable helpers: `model-list.ts` (trim/dedupe/remove/selection fallback) and `openai-fields.ts` (ChatOpenAI option builder)
- Guard the empty-list/no-selection case in `getModel()` and re-validate the selection on removal/reset
- Add vitest + `test:unit` script and 31 unit tests (model-capabilities, model-list, openai-fields)
- Add `.github/workflows/unit-tests.yaml` CI workflow (copied from `freelens-gateway-api-extension`) to run unit tests on push and pull requests
- Align `vitest.config.ts` with the gateway-api-extension pattern (add `exclude`, `passWithNoTests`, and `.spec`/`.tsx` glob support)
- Update README and AGENTS docs for the editable model list

All checks pass: type:check, test:unit, lint:check, build, knip.

Refs #112

Generated with <a href="https://claude.ai/code">Claude Code</a>