### PR TITLE
Make disable-thinking provider-aware with per-family heuristics

### DIFF
--- a/src/renderer/business/provider/model-capabilities.test.ts
+++ b/src/renderer/business/provider/model-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isReasoningModel, supportsTemperature } from "./model-capabilities";
+import { buildDisableThinkingKwargs, isReasoningModel, supportsTemperature } from "./model-capabilities";
 
 describe("isReasoningModel", () => {
   it.each([
@@ -30,5 +30,21 @@ describe("supportsTemperature", () => {
     for (const name of ["gpt-5.5", "o1", "gpt-4.1", "gpt-4o"]) {
       expect(supportsTemperature(name)).toBe(!isReasoningModel(name));
     }
+  });
+});
+
+describe("buildDisableThinkingKwargs", () => {
+  it.each([
+    ["deepseek-v4-pro", { thinking: { type: "disabled" }, chat_template_kwargs: { thinking: false } }],
+    ["DeepSeek-Reasoner", { thinking: { type: "disabled" }, chat_template_kwargs: { thinking: false } }],
+    ["qwen3-235b", { chat_template_kwargs: { enable_thinking: false } }],
+    ["claude-opus-4-8", { thinking: { type: "disabled" } }],
+    ["gemini-3-pro", { reasoning_effort: "none" }],
+  ])("returns the family-specific kwargs for %s", (name, expected) => {
+    expect(buildDisableThinkingKwargs(name)).toEqual(expected);
+  });
+
+  it.each(["gpt-5.5", "gpt-4o", "o3-mini", ""])("returns null when no family matches (%s)", (name) => {
+    expect(buildDisableThinkingKwargs(name)).toBeNull();
   });
 });

--- a/src/renderer/business/provider/model-capabilities.ts
+++ b/src/renderer/business/provider/model-capabilities.ts
@@ -10,3 +10,31 @@ export const isReasoningModel = (modelName: string): boolean =>
   REASONING_MODEL_PATTERNS.some((pattern) => pattern.test(modelName));
 
 export const supportsTemperature = (modelName: string): boolean => !isReasoningModel(modelName);
+
+// Turning a model's "thinking"/reasoning mode off is provider-specific: there is
+// no shared OpenAI field for it, so each family expects a different extra payload
+// merged into the request body (passed through verbatim by gateways like
+// LiteLLM). The matchers below map a model name to the vendor-specific kwargs
+// that disable thinking. Order matters — the first matching rule wins.
+const DISABLE_THINKING_RULES: { pattern: RegExp; kwargs: Record<string, unknown> }[] = [
+  // DeepSeek (e.g. deepseek-v4-pro/flash, deepseek-reasoner). The official
+  // OpenAI-compatible API disables thinking via a top-level `thinking` object,
+  // while self-hosted deployments (vLLM/SGLang) use a chat-template flag. Send
+  // both so the request works regardless of how the model is served.
+  {
+    pattern: /deepseek/i,
+    kwargs: { thinking: { type: "disabled" }, chat_template_kwargs: { thinking: false } },
+  },
+  // Qwen 3 toggles reasoning with `enable_thinking` in its chat template.
+  { pattern: /qwen/i, kwargs: { chat_template_kwargs: { enable_thinking: false } } },
+  // Anthropic Claude uses the typed `thinking` object.
+  { pattern: /claude/i, kwargs: { thinking: { type: "disabled" } } },
+  // Google Gemini disables reasoning via a "none" reasoning effort.
+  { pattern: /gemini/i, kwargs: { reasoning_effort: "none" } },
+];
+
+// Returns the vendor-specific kwargs that disable thinking for the given model,
+// or null when no known family matches (so nothing provider-specific is sent and
+// gateways that reject unknown fields are not tripped).
+export const buildDisableThinkingKwargs = (modelName: string): Record<string, unknown> | null =>
+  DISABLE_THINKING_RULES.find((rule) => rule.pattern.test(modelName))?.kwargs ?? null;

--- a/src/renderer/business/provider/openai-fields.test.ts
+++ b/src/renderer/business/provider/openai-fields.test.ts
@@ -36,13 +36,26 @@ describe("buildOpenAIChatFields", () => {
     expect(fields.temperature).toBeUndefined();
   });
 
-  it("disables thinking via modelKwargs when requested", () => {
+  it("disables thinking with DeepSeek-specific kwargs when requested", () => {
     const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "deepseek-v4-pro", disableThinking: true });
-    expect(fields.modelKwargs).toMatchObject({ thinking: { type: "disabled" } });
+    expect(fields.modelKwargs).toMatchObject({
+      thinking: { type: "disabled" },
+      chat_template_kwargs: { thinking: false },
+    });
+  });
+
+  it("disables thinking with Qwen-specific kwargs when requested", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "qwen3-235b", disableThinking: true });
+    expect(fields.modelKwargs).toMatchObject({ chat_template_kwargs: { enable_thinking: false } });
   });
 
   it("omits the thinking modelKwargs when not requested", () => {
     const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "deepseek-v4-pro" });
+    expect(fields.modelKwargs).toBeUndefined();
+  });
+
+  it("omits thinking kwargs for models with no known disable mechanism", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "gpt-5.5", disableThinking: true });
     expect(fields.modelKwargs).toBeUndefined();
   });
 });

--- a/src/renderer/business/provider/openai-fields.ts
+++ b/src/renderer/business/provider/openai-fields.ts
@@ -3,7 +3,7 @@
 // reasoning-effort vs temperature heuristic) can be unit-tested without the
 // MobX store or instantiating a real client.
 
-import { isReasoningModel } from "./model-capabilities";
+import { buildDisableThinkingKwargs, isReasoningModel } from "./model-capabilities";
 
 import type { ChatOpenAIFields } from "@langchain/openai";
 
@@ -61,10 +61,16 @@ export const buildOpenAIChatFields = ({
     fields.temperature = 0;
   }
 
-  // Sent via `modelKwargs` so it reaches the upstream request body verbatim
-  // without being passed as a typed field that providers like OpenAI reject.
+  // Disabling thinking is provider-specific (the payload differs per model
+  // family), so the kwargs are resolved by name heuristic and merged into
+  // `modelKwargs` to reach the upstream request body verbatim. Models with no
+  // known disable mechanism contribute nothing, avoiding fields that providers
+  // like OpenAI would reject.
   if (disableThinking) {
-    fields.modelKwargs = { ...fields.modelKwargs, thinking: { type: "disabled" } };
+    const thinkingKwargs = buildDisableThinkingKwargs(modelName);
+    if (thinkingKwargs) {
+      fields.modelKwargs = { ...fields.modelKwargs, ...thinkingKwargs };
+    }
   }
 
   return fields;


### PR DESCRIPTION
Resolves #120.

The "Disable thinking mode" option sent the Anthropic-shaped `thinking:{type:"disabled"}` payload to every model. DeepSeek served through LiteLLM ignores that field, so thinking stayed on and the supervisor's forced `tool_choice` failed with "Thinking mode does not support this tool_choice".

This PR resolves the disable-thinking payload by model-name heuristic (DeepSeek, Qwen, Claude, Gemini) and merges the family-specific kwargs in the field builder. Models with no known disable mechanism send nothing.

Generated with [Claude Code](https://claude.ai/code)