### PR TITLE
Use tool_choice auto for thinking models that reject a forced tool_choice

### DIFF
--- a/src/renderer/business/agent/supervisor-agent.ts
+++ b/src/renderer/business/agent/supervisor-agent.ts
@@ -1,7 +1,63 @@
+import { JsonOutputKeyToolsParser } from "@langchain/core/output_parsers/openai_tools";
 import { ChatPromptTemplate, MessagesPlaceholder } from "@langchain/core/prompts";
+import { toJsonSchema } from "@langchain/core/utils/json_schema";
 import { z } from "zod";
+import { requiresAutoToolChoice } from "../provider/model-capabilities";
 import { useModelProvider } from "../provider/model-provider";
 import { SUPERVISOR_PROMPT_TEMPLATE } from "../provider/prompt-template-provider";
+
+import type { BaseLanguageModelInput } from "@langchain/core/language_models/base";
+import type { Runnable } from "@langchain/core/runnables";
+import type { ChatOpenAI } from "@langchain/openai";
+
+// Name of the single structured-output tool bound for the supervisor. Matches
+// the default `withStructuredOutput` function-calling tool name so the parser
+// behaves identically across the forced and "auto" tool_choice paths.
+const SUPERVISOR_TOOL_NAME = "extract";
+
+// Build the supervisor's structured-output runnable.
+//
+// By default we force function calling: `withStructuredOutput(..., { method:
+// "functionCalling" })` binds a single tool and sets a forced `tool_choice`.
+// This is deliberate: some models (e.g. gpt-5.4) occasionally emit the JSON
+// object twice in a row with `response_format=json_schema` during streaming,
+// which breaks the parser with "Unexpected non-whitespace character after JSON".
+// Function calling avoids that because the payload is returned in a dedicated
+// tool_call argument instead of being concatenated into the assistant text.
+//
+// Some thinking models (DeepSeek, Qwen) reject a forced `tool_choice` while
+// thinking mode is on (`Thinking mode does not support this tool_choice`). For
+// those we bind the same single tool but with `tool_choice: "auto"`, which they
+// accept, and parse the tool call exactly like the function-calling path does.
+const buildSupervisorRunnable = <T extends z.ZodTypeAny>(
+  model: ChatOpenAI,
+  schema: T,
+): Runnable<BaseLanguageModelInput, z.infer<T>> => {
+  if (!requiresAutoToolChoice(model.model)) {
+    return model.withStructuredOutput(schema, { method: "functionCalling" });
+  }
+
+  const asJsonSchema = toJsonSchema(schema);
+  const llm = model.bindTools(
+    [
+      {
+        type: "function",
+        function: {
+          name: SUPERVISOR_TOOL_NAME,
+          description: asJsonSchema.description,
+          parameters: asJsonSchema,
+        },
+      },
+    ],
+    { tool_choice: "auto" },
+  );
+  const parser = new JsonOutputKeyToolsParser<z.infer<T>>({
+    returnSingle: true,
+    keyName: SUPERVISOR_TOOL_NAME,
+    zodSchema: schema,
+  });
+  return llm.pipe(parser);
+};
 
 export const useAgentSupervisor = () => {
   const model = useModelProvider().getModel();
@@ -32,13 +88,7 @@ export const useAgentSupervisor = () => {
       workerResponsibilities: subAgentResponsibilities.join(", "),
       members: subAgents.join(", "),
     });
-    // Force function calling instead of json_schema/json_mode for the supervisor structured output.
-    // Some models (e.g. gpt-5.4) occasionally emit the JSON object twice in a row when using
-    // response_format=json_schema with streaming, which breaks StructuredOutputParser with
-    // "Unexpected non-whitespace character after JSON". Function calling avoids that class of
-    // bugs because the structured payload is returned in a dedicated tool_call argument instead
-    // of being concatenated into the assistant text stream.
-    return formattedPrompt.pipe(model.withStructuredOutput(supervisorResponseSchema, { method: "functionCalling" }));
+    return formattedPrompt.pipe(buildSupervisorRunnable(model, supervisorResponseSchema));
   };
 
   return { getAgent };

--- a/src/renderer/business/provider/model-capabilities.test.ts
+++ b/src/renderer/business/provider/model-capabilities.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isReasoningModel, supportsTemperature } from "./model-capabilities";
+import { isReasoningModel, requiresAutoToolChoice, supportsTemperature } from "./model-capabilities";
 
 describe("isReasoningModel", () => {
   it.each([
@@ -22,6 +22,22 @@ describe("isReasoningModel", () => {
     "",
   ])("treats %s as a non-reasoning model", (name) => {
     expect(isReasoningModel(name)).toBe(false);
+  });
+});
+
+describe("requiresAutoToolChoice", () => {
+  it.each([
+    "deepseek-v4-pro",
+    "deepseek-reasoner",
+    "DeepSeek-V4",
+    "qwen3-235b",
+    "Qwen2.5-72B",
+  ])("requires tool_choice auto for thinking model %s", (name) => {
+    expect(requiresAutoToolChoice(name)).toBe(true);
+  });
+
+  it.each(["gpt-5.5", "gpt-5.4", "gpt-4o", "o3-mini", ""])("keeps forced tool_choice for %s", (name) => {
+    expect(requiresAutoToolChoice(name)).toBe(false);
   });
 });
 

--- a/src/renderer/business/provider/model-capabilities.ts
+++ b/src/renderer/business/provider/model-capabilities.ts
@@ -10,3 +10,16 @@ export const isReasoningModel = (modelName: string): boolean =>
   REASONING_MODEL_PATTERNS.some((pattern) => pattern.test(modelName));
 
 export const supportsTemperature = (modelName: string): boolean => !isReasoningModel(modelName);
+
+// Some "thinking" models (notably DeepSeek served through LiteLLM/OpenAI-compat
+// gateways, and Qwen reasoning models) reject a *forced* `tool_choice` while
+// thinking mode is on, failing with
+// `Thinking mode does not support this tool_choice`. They only accept
+// `tool_choice: "auto"` (or none). The supervisor binds a single structured
+// output tool and normally forces it; for these families it must request
+// `auto` instead so the request is accepted. Extend the pattern list when a new
+// family is found to have the same constraint.
+const FORCED_TOOL_CHOICE_UNSUPPORTED_PATTERNS: RegExp[] = [/deepseek/i, /qwen/i];
+
+export const requiresAutoToolChoice = (modelName: string): boolean =>
+  FORCED_TOOL_CHOICE_UNSUPPORTED_PATTERNS.some((pattern) => pattern.test(modelName));


### PR DESCRIPTION
Resolves #120 (alternative to #121).

PR #121 (Option A) tried to disable thinking, but LiteLLM-served DeepSeek kept thinking on, so the supervisor's forced `tool_choice` still failed with "Thinking mode does not support this tool_choice".

This PR takes the other route: keep thinking on, but stop forcing the tool. The supervisor now binds the same single structured-output tool with `tool_choice: "auto"` for models matched by a new `requiresAutoToolChoice` heuristic (DeepSeek, Qwen), parsing the tool call exactly like the function-calling path. All other models keep forced function calling unchanged.

Generated with [Claude Code](https://claude.ai/code)