### PR TITLE
Show a Configure agent button linking to preferences when unconfigured

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -5,7 +5,10 @@
   "project": ["*.{js,mjs,ts}", "src/**/*.{ts,tsx}"],
 
   "ignoreBinaries": ["electron-rebuild", "yq"],
-  "ignoreDependencies": ["@babel/plugin-proposal-decorators", "@langchain/google-genai"],
+  // `electron` is provided by the Freelens host at runtime and required lazily in
+  // src/renderer/navigation/navigate-to-extension-preferences.ts, so it is not a
+  // declared dependency.
+  "ignoreDependencies": ["@babel/plugin-proposal-decorators", "@langchain/google-genai", "electron"],
   "typescript": {
     "config": ["tsconfig.json"]
   },

--- a/src/renderer/business/provider/chat-readiness.test.ts
+++ b/src/renderer/business/provider/chat-readiness.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { AIProviders, type CustomModel } from "./ai-models";
+import { isAgentConfigured } from "./chat-readiness";
+
+const openAiModels: CustomModel[] = [
+  { provider: AIProviders.OPEN_AI, name: "gpt-5.5" },
+  { provider: AIProviders.OPEN_AI, name: "gpt-5.4" },
+];
+
+describe("isAgentConfigured", () => {
+  it("is false when the model list is empty", () => {
+    expect(isAgentConfigured({ models: [], selectedModel: "", openAIKey: "sk-test" })).toBe(false);
+  });
+
+  it("is false when an OpenAI model is selected but no key is set", () => {
+    expect(isAgentConfigured({ models: openAiModels, selectedModel: "gpt-5.5", openAIKey: "" })).toBe(false);
+  });
+
+  it("treats a whitespace-only key as unset", () => {
+    expect(isAgentConfigured({ models: openAiModels, selectedModel: "gpt-5.5", openAIKey: "   " })).toBe(false);
+  });
+
+  it("is true when an OpenAI model has a stored key", () => {
+    expect(isAgentConfigured({ models: openAiModels, selectedModel: "gpt-5.5", openAIKey: "sk-test" })).toBe(true);
+  });
+
+  it("is true when only the environment key is set", () => {
+    expect(
+      isAgentConfigured({ models: openAiModels, selectedModel: "gpt-5.5", openAIKey: "", envOpenAIKey: "sk-env" }),
+    ).toBe(true);
+  });
+
+  it("falls back to the first model's provider when the selection does not match", () => {
+    expect(isAgentConfigured({ models: openAiModels, selectedModel: "unknown", openAIKey: "" })).toBe(false);
+    expect(isAgentConfigured({ models: openAiModels, selectedModel: "unknown", openAIKey: "sk-test" })).toBe(true);
+  });
+});

--- a/src/renderer/business/provider/chat-readiness.ts
+++ b/src/renderer/business/provider/chat-readiness.ts
@@ -1,0 +1,31 @@
+// Pure helper deciding whether the agent is configured enough to start a chat.
+// Kept free of any host (`@freelensapp/extensions`) or MobX dependency so it can
+// be unit-tested in isolation and reused by the chat input.
+
+import { AIProviders, type CustomModel } from "./ai-models";
+import { findProvider } from "./model-list";
+
+export interface AgentReadinessInput {
+  models: CustomModel[];
+  selectedModel: string;
+  openAIKey: string;
+  // OPENAI_API_KEY takes precedence over the stored key, matching the provider.
+  envOpenAIKey?: string;
+}
+
+// Whether the agent has the minimum configuration to chat: at least one model
+// must exist and, for OpenAI-backed models, an API key must be set. When false,
+// the chat UI shows a single "Configure agent" button linking to the extension
+// preferences instead of the model dropdown.
+export const isAgentConfigured = ({ models, selectedModel, openAIKey, envOpenAIKey }: AgentReadinessInput): boolean => {
+  if (models.length === 0) {
+    return false;
+  }
+
+  const provider = findProvider(models, selectedModel) ?? models[0]?.provider;
+  if (provider === AIProviders.OPEN_AI && !((envOpenAIKey ?? "").trim() || openAIKey.trim())) {
+    return false;
+  }
+
+  return true;
+};

--- a/src/renderer/components/text-input/text-input-hook.tsx
+++ b/src/renderer/components/text-input/text-input-hook.tsx
@@ -3,13 +3,9 @@ import * as React from "react";
 import { PreferencesStore } from "../../../common/store";
 import { isAgentConfigured } from "../../business/provider/chat-readiness";
 import { useApplicationStatusStore } from "../../context/application-context";
-import { getExtensionPreferencesPath } from "../../navigation/extension-preferences";
+import { navigateToExtensionPreferences } from "../../navigation/navigate-to-extension-preferences";
 
 import type { SingleValue } from "react-select";
-
-const {
-  Navigation: { navigate },
-} = Renderer;
 
 const { useEffect, useRef, useState } = React;
 
@@ -73,7 +69,7 @@ export const useTextInput = ({ onSend }: TextInputHookProps) => {
     }
   };
 
-  const goToPreferences = () => navigate(getExtensionPreferencesPath());
+  const goToPreferences = () => navigateToExtensionPreferences();
 
   return {
     message,

--- a/src/renderer/components/text-input/text-input-hook.tsx
+++ b/src/renderer/components/text-input/text-input-hook.tsx
@@ -1,7 +1,9 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as React from "react";
 import { PreferencesStore } from "../../../common/store";
+import { isAgentConfigured } from "../../business/provider/chat-readiness";
 import { useApplicationStatusStore } from "../../context/application-context";
+import { getExtensionPreferencesPath } from "../../navigation/extension-preferences";
 
 import type { SingleValue } from "react-select";
 
@@ -25,7 +27,15 @@ export const useTextInput = ({ onSend }: TextInputHookProps) => {
 
   const modelSelections = preferencesStore.models.map((model) => ({ value: model.name, label: model.name }));
 
-  const hasAvailableModels = modelSelections.length > 0;
+  // Show the model dropdown only when the agent is ready to chat. Otherwise
+  // (no models left, or no OpenAI key set) the UI offers a single button that
+  // links to this extension's preferences.
+  const agentConfigured = isAgentConfigured({
+    models: preferencesStore.models,
+    selectedModel: preferencesStore.selectedModel,
+    openAIKey: preferencesStore.openAIKey,
+    envOpenAIKey: typeof process !== "undefined" ? process.env.OPENAI_API_KEY : undefined,
+  });
 
   const adaptTextareaHeight = () => {
     const textarea = textareaRef.current;
@@ -63,13 +73,13 @@ export const useTextInput = ({ onSend }: TextInputHookProps) => {
     }
   };
 
-  const goToPreferences = () => navigate("/preferences");
+  const goToPreferences = () => navigate(getExtensionPreferencesPath());
 
   return {
     message,
     textareaRef,
     modelSelections,
-    hasAvailableModels,
+    agentConfigured,
     setMessage,
     handleKeyDown,
     handleSend,

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -108,7 +108,7 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
               </button>
             </div>
             <div style={{ display: "flex", alignItems: "center" }}>
-              {textInputHook.hasAvailableModels ? (
+              {textInputHook.agentConfigured ? (
                 <Select
                   id="update-channel-input"
                   options={textInputOptions}
@@ -120,9 +120,9 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
               ) : (
                 <Button
                   primary
-                  label="Configure models in preferences"
+                  label="Configure agent"
                   onClick={textInputHook.goToPreferences}
-                  title="No model is available. Set an API key and add models in Freelens AI settings."
+                  title="Set an API key and add a model in Freelens AI settings."
                 />
               )}
               <button

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -7,6 +7,7 @@ import { Renderer } from "@freelensapp/extensions";
 import { PreferencesStore } from "../common/store";
 import { FreeLensAiIcon } from "./components/freelens-ai-icon";
 import { MenuEntry } from "./components/menu-entry";
+import { setExtensionPreferencesPath } from "./navigation/extension-preferences";
 import { MainPage } from "./pages/main";
 import { PreferencesPage } from "./pages/preferences";
 
@@ -15,6 +16,9 @@ type KubeObjectMenuProps<TKubeObject extends KubeObject> = Renderer.Component.Ku
 
 export default class FreeLensAIRenderer extends Renderer.LensExtension {
   async onActivate() {
+    // Resolve the route to this extension's own preferences tab so the chat
+    // "Configure agent" button can link straight to it.
+    setExtensionPreferencesPath(this.sanitizedExtensionId);
     // @ts-ignore
     PreferencesStore.getInstanceOrCreate<PreferencesStore>().loadExtension(this);
   }

--- a/src/renderer/navigation/extension-preferences.test.ts
+++ b/src/renderer/navigation/extension-preferences.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  BROADCAST_MAIN_CHANNEL,
+  broadcastNavigateToExtensionPreferences,
+  getExtensionPreferencesPath,
+  NAVIGATE_IN_APP_CHANNEL,
+  setExtensionPreferencesPath,
+} from "./extension-preferences";
+
+afterEach(() => {
+  // Reset module state back to the generic route between tests.
+  setExtensionPreferencesPath("");
+});
+
+describe("extension preferences path", () => {
+  it("falls back to the generic preferences route before activation", () => {
+    expect(getExtensionPreferencesPath()).toBe("/preferences");
+  });
+
+  it("targets the extension's own tab once the sanitized id is set", () => {
+    setExtensionPreferencesPath("freelensapp--ai-extension");
+    expect(getExtensionPreferencesPath()).toBe("/preferences/freelensapp--ai-extension");
+  });
+
+  it("falls back to the generic route when the sanitized id is empty", () => {
+    setExtensionPreferencesPath("freelensapp--ai-extension");
+    setExtensionPreferencesPath("");
+    expect(getExtensionPreferencesPath()).toBe("/preferences");
+  });
+});
+
+describe("broadcastNavigateToExtensionPreferences", () => {
+  it("broadcasts the in-app navigation event for the extension preferences path", () => {
+    setExtensionPreferencesPath("freelensapp--ai-extension");
+    const invoke = vi.fn();
+
+    broadcastNavigateToExtensionPreferences(invoke);
+
+    expect(invoke).toHaveBeenCalledWith(
+      BROADCAST_MAIN_CHANNEL,
+      NAVIGATE_IN_APP_CHANNEL,
+      "/preferences/freelensapp--ai-extension",
+    );
+  });
+});

--- a/src/renderer/navigation/extension-preferences.ts
+++ b/src/renderer/navigation/extension-preferences.ts
@@ -1,0 +1,14 @@
+// Resolves the route to this extension's own preferences tab. The Freelens host
+// registers each extension's primary preferences page at
+// `/preferences/:preferenceTabId?` where the tab id is the extension's
+// `sanitizedExtensionId`. That id is only known at activation, so it is captured
+// there via `setExtensionPreferencesPath`. Falls back to the generic preferences
+// route until activation runs.
+
+let preferencesPath = "/preferences";
+
+export const setExtensionPreferencesPath = (sanitizedExtensionId: string): void => {
+  preferencesPath = sanitizedExtensionId ? `/preferences/${sanitizedExtensionId}` : "/preferences";
+};
+
+export const getExtensionPreferencesPath = (): string => preferencesPath;

--- a/src/renderer/navigation/extension-preferences.ts
+++ b/src/renderer/navigation/extension-preferences.ts
@@ -4,6 +4,22 @@
 // `sanitizedExtensionId`. That id is only known at activation, so it is captured
 // there via `setExtensionPreferencesPath`. Falls back to the generic preferences
 // route until activation runs.
+//
+// The preferences page is rendered in the root frame, but the chat UI runs in
+// the cluster frame. `Renderer.Navigation.navigate` only moves the current
+// frame's router, so from the cluster frame it cannot reach the root-only
+// preferences route and the cluster router falls back to its main view. The host
+// reaches the root frame from a cluster frame by broadcasting an in-app
+// navigation event through the main process; `broadcastNavigateToExtensionPreferences`
+// reproduces that here.
+//
+// `ipc:broadcast-main` relays a renderer message through the main process to
+// every frame and `renderer:navigate` is the in-app navigation event the root
+// frame listens for.
+export const BROADCAST_MAIN_CHANNEL = "ipc:broadcast-main";
+export const NAVIGATE_IN_APP_CHANNEL = "renderer:navigate";
+
+export type BroadcastInvoke = (channel: string, ...args: unknown[]) => unknown;
 
 let preferencesPath = "/preferences";
 
@@ -12,3 +28,10 @@ export const setExtensionPreferencesPath = (sanitizedExtensionId: string): void 
 };
 
 export const getExtensionPreferencesPath = (): string => preferencesPath;
+
+// Broadcasts the host navigation event that makes the root frame open this
+// extension's preferences tab. Pure (the broadcaster is injected) so it can be
+// unit-tested without electron.
+export const broadcastNavigateToExtensionPreferences = (invoke: BroadcastInvoke): void => {
+  invoke(BROADCAST_MAIN_CHANNEL, NAVIGATE_IN_APP_CHANNEL, getExtensionPreferencesPath());
+};

--- a/src/renderer/navigation/navigate-to-extension-preferences.ts
+++ b/src/renderer/navigation/navigate-to-extension-preferences.ts
@@ -1,0 +1,19 @@
+import { type BroadcastInvoke, broadcastNavigateToExtensionPreferences } from "./extension-preferences";
+
+// `electron` is provided by the Freelens host at runtime and externalized by the
+// build, so it is required lazily here rather than imported as a build-time
+// dependency.
+type ElectronIpcRenderer = { invoke: BroadcastInvoke };
+
+const getIpcRenderer = (): ElectronIpcRenderer =>
+  (require("electron") as { ipcRenderer: ElectronIpcRenderer }).ipcRenderer;
+
+// Opens this extension's preferences tab from the chat UI. The chat runs in the
+// cluster frame while the preferences page lives in the root frame, so the
+// navigation is broadcast through the host's main-process relay instead of
+// navigated locally (which would only move the cluster frame's router and fall
+// back to its main view).
+export const navigateToExtensionPreferences = (): void => {
+  const ipcRenderer = getIpcRenderer();
+  broadcastNavigateToExtensionPreferences((channel, ...args) => ipcRenderer.invoke(channel, ...args));
+};


### PR DESCRIPTION
Closes #123.

Replaces the model dropdown with a single generic "Configure agent" button when the agent is not configured (no models left, or no OpenAI API key set), and links it to this extension's own preferences tab.

Generated with [Claude Code](https://claude.ai/code)