### PR TITLE
Refactor agent tools into generic Kubernetes resource operations

### DIFF
--- a/src/renderer/business/agent/analyzer-agent.ts
+++ b/src/renderer/business/agent/analyzer-agent.ts
@@ -1,7 +1,12 @@
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { useModelProvider } from "../provider/model-provider";
 import { AGENT_ANALYZER_PROMPT_TEMPLATE } from "../provider/prompt-template-provider";
-import { getNamespaces, getWarningEventsByNamespace } from "./tools/tools";
+import {
+  getKubernetesResource,
+  getNamespaces,
+  getWarningEventsByNamespace,
+  listKubernetesResources,
+} from "./tools/tools";
 
 export const useAgentAnalyzer = () => {
   const model = useModelProvider().getModel();
@@ -11,7 +16,7 @@ export const useAgentAnalyzer = () => {
       model &&
       createReactAgent({
         llm: model,
-        tools: [getNamespaces, getWarningEventsByNamespace],
+        tools: [getNamespaces, getWarningEventsByNamespace, listKubernetesResources, getKubernetesResource],
         stateModifier: AGENT_ANALYZER_PROMPT_TEMPLATE,
       })
     );

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -6,6 +6,7 @@ import { useAgentAnalyzer } from "./analyzer-agent";
 import { useConclusionsAgent } from "./conclusions-agent";
 import { useGeneralPurposeAgent } from "./general-purpose-agent";
 import { useAgentKubernetesOperator } from "./kubernetes-operator-agent";
+import { containsLeakedToolCallMarkup, LEAKED_TOOL_CALL_MESSAGE } from "./leaked-tool-calls";
 import { teardownNode } from "./nodes/teardown";
 import { GraphState } from "./state/graph-state";
 import { useAgentSupervisor } from "./supervisor-agent";
@@ -37,11 +38,21 @@ export const useFreeLensAgentSystem = () => {
     const response: any = await agentSupervisor.invoke({ messages: state.messages });
     log.debug("Supervisor agent - supervisor response", response);
 
-    // TOOD check why response is unknown
-    if (response.goto === "__end__") {
-      response.goto = conclusionsAgentName;
+    // The supervisor must return a structured routing decision ({ reflection,
+    // goto }). When the endpoint does not parse the model's tool calls
+    // server-side, the markup leaks into the message text, the parser yields no
+    // tool call, and `response` is undefined. Fail with an actionable message
+    // instead of crashing on `response.goto` of undefined.
+    if (!response || typeof response.goto !== "string") {
+      log.error("Supervisor agent returned no routing decision", response);
+      throw new Error(`The supervisor did not return a structured routing decision. ${LEAKED_TOOL_CALL_MESSAGE}`);
     }
-    return new Command({ goto: response.goto });
+
+    let goto = response.goto;
+    if (goto === "__end__") {
+      goto = conclusionsAgentName;
+    }
+    return new Command({ goto });
   };
 
   const agentAnalyzerNode = async (state: typeof GraphState.State) => {
@@ -53,6 +64,10 @@ export const useFreeLensAgentSystem = () => {
     const result = await agentAnalyzer.invoke(state);
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("Analyzer Agent - analysis result: ", result);
+    if (containsLeakedToolCallMarkup(lastMessage.content)) {
+      log.error("Analyzer Agent - leaked tool-call markup in response", lastMessage.content);
+      throw new Error(LEAKED_TOOL_CALL_MESSAGE);
+    }
     return {
       messages: [new HumanMessage({ content: lastMessage.content })],
     };
@@ -67,6 +82,10 @@ export const useFreeLensAgentSystem = () => {
     const result = await agentKubernetesOperator.invoke(state);
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("Kubernetes Operator - k8s operator result: ", result);
+    if (containsLeakedToolCallMarkup(lastMessage.content)) {
+      log.error("Kubernetes Operator - leaked tool-call markup in response", lastMessage.content);
+      throw new Error(LEAKED_TOOL_CALL_MESSAGE);
+    }
     return {
       messages: [new HumanMessage({ content: lastMessage.content })],
     };
@@ -81,6 +100,10 @@ export const useFreeLensAgentSystem = () => {
     const result = await generalPurposeAgent.invoke(state);
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("General Purpose Agent - response: ", result);
+    if (containsLeakedToolCallMarkup(lastMessage.content)) {
+      log.error("General Purpose Agent - leaked tool-call markup in response", lastMessage.content);
+      throw new Error(LEAKED_TOOL_CALL_MESSAGE);
+    }
     return {
       messages: [new HumanMessage({ content: lastMessage.content })],
     };

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -22,7 +22,7 @@ export const useFreeLensAgentSystem = () => {
   const subAgents = ["agentAnalyzer", "kubernetesOperator", "generalPurposeAgent"];
   const conclusionsAgentName = "conclusionsAgent";
   const subAgentResponsibilities = [
-    "agentAnalyzer: Reads cluster events and find for warnings and errors",
+    "agentAnalyzer: Reads and inspects live cluster resources (pods, deployments, services, CRDs, and other kinds), events, namespaces, warnings and errors. Use it for any read-only query about the current state of the cluster.",
     "kubernetesOperator: Operates on the cluster in write mode (for example apply changes) and then exits",
     "generalPurposeAgent: Handles general queries including but not limited to: Kubernetes conceptual explanations, best practices, architecture patterns, and non-Kubernetes technical questions. This agent doesn't interact with the live cluster but provides comprehensive knowledge-based responses.",
   ];

--- a/src/renderer/business/agent/kubernetes-operator-agent.ts
+++ b/src/renderer/business/agent/kubernetes-operator-agent.ts
@@ -5,15 +5,12 @@ import { ToolNode } from "@langchain/langgraph/prebuilt";
 import { useModelProvider } from "../provider/model-provider";
 import { KUBERNETES_OPERATOR_PROMPT_TEMPLATE } from "../provider/prompt-template-provider";
 import {
-  createDeployment,
-  createPod,
-  createService,
-  deleteDeployment,
-  deletePod,
-  deleteService,
-  getDeployments,
-  getPods,
-  getServices,
+  createKubernetesResource,
+  deleteKubernetesResource,
+  getKubernetesResource,
+  listKubernetesResources,
+  patchKubernetesResource,
+  updateKubernetesResource,
 } from "./tools/tools";
 
 export const useAgentKubernetesOperator = () => {
@@ -25,15 +22,12 @@ export const useAgentKubernetesOperator = () => {
     }
 
     const tools = [
-      createPod,
-      createDeployment,
-      deletePod,
-      deleteDeployment,
-      createService,
-      deleteService,
-      getPods,
-      getDeployments,
-      getServices,
+      listKubernetesResources,
+      getKubernetesResource,
+      createKubernetesResource,
+      updateKubernetesResource,
+      patchKubernetesResource,
+      deleteKubernetesResource,
     ];
     const toolNode = new ToolNode(tools);
     const boundModel = model.bindTools(tools, { parallel_tool_calls: false });

--- a/src/renderer/business/agent/leaked-tool-calls.test.ts
+++ b/src/renderer/business/agent/leaked-tool-calls.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { containsLeakedToolCallMarkup } from "./leaked-tool-calls";
+
+describe("containsLeakedToolCallMarkup", () => {
+  it("detects leaked DSML tool_calls markup", () => {
+    const content =
+      'OK, I\'m getting Kustomization directly.<｜｜DSML｜｜tool_calls> <｜｜DSML｜｜invoke name="listKubernetesResources"> ' +
+      '<｜｜DSML｜｜parameter name="kind" string="true">Kustomization</｜｜DSML｜｜parameter> </｜｜DSML｜｜invoke> </｜｜DSML｜｜tool_calls>';
+    expect(containsLeakedToolCallMarkup(content)).toBe(true);
+  });
+
+  it("detects DeepSeek native tool-call tokens", () => {
+    expect(containsLeakedToolCallMarkup("<｜tool▁calls▁begin｜>")).toBe(true);
+  });
+
+  it("detects leaked markup inside array content parts", () => {
+    const content = [
+      { type: "text", text: "Sure, let me look that up. " },
+      { type: "text", text: '<｜｜DSML｜｜invoke name="getKubernetesResource">' },
+    ];
+    expect(containsLeakedToolCallMarkup(content)).toBe(true);
+  });
+
+  it("returns false for normal assistant text", () => {
+    expect(containsLeakedToolCallMarkup("The pod uses the image nginx:1.27.")).toBe(false);
+  });
+
+  it("returns false for empty content", () => {
+    expect(containsLeakedToolCallMarkup("")).toBe(false);
+    expect(containsLeakedToolCallMarkup([])).toBe(false);
+  });
+
+  it("does not flag the literal word DSML in prose", () => {
+    expect(containsLeakedToolCallMarkup("DSML stands for domain-specific markup language.")).toBe(false);
+  });
+});

--- a/src/renderer/business/agent/leaked-tool-calls.ts
+++ b/src/renderer/business/agent/leaked-tool-calls.ts
@@ -1,0 +1,58 @@
+// Detects tool-call markup that has leaked into assistant message *content*
+// instead of being returned as a structured `tool_calls` field.
+//
+// This happens when an OpenAI-compatible endpoint serves a model whose native
+// tool-call token format (for example DeepSeek's "DSML" / `<｜tool▁calls▁begin｜>`
+// markup) is not parsed server-side. LangChain's `ChatOpenAI` only reads the
+// OpenAI `tool_calls` field, so the raw tokens surface as plain text, no tool is
+// ever invoked, and the tool-approval prompt never fires. Detecting it lets the
+// agent fail with an actionable message instead of dumping raw markup to the UI.
+
+import type { MessageContent } from "@langchain/core/messages";
+
+// Shared, user-facing explanation for a leaked / missing structured tool call.
+export const LEAKED_TOOL_CALL_MESSAGE =
+  "The selected model returned tool-call markup as plain text instead of a structured tool call. " +
+  "The OpenAI-compatible endpoint behind your base URL is likely missing a server-side tool-call parser " +
+  "(for example vLLM `--enable-auto-tool-choice --tool-call-parser deepseek_v3`, or SGLang " +
+  "`--tool-call-parser deepseek-v3`). You can also try enabling the 'Disable thinking' preference.";
+
+const LEAKED_TOOL_CALL_PATTERNS: RegExp[] = [
+  // DeepSeek "DSML" tool-call markup leaking as text, e.g. `<｜｜DSML｜｜tool_calls>`
+  // or `<｜｜DSML｜｜invoke name="...">`. The bars are fullwidth (U+FF5C); tolerate
+  // ASCII "|" too in case a provider normalizes them.
+  /<\s*[｜|]{1,2}\s*DSML\s*[｜|]{1,2}/i,
+  // DeepSeek native tool-call tokens, e.g. `<｜tool▁calls▁begin｜>` (the separator
+  // is U+2581); tolerate "_" / whitespace variants.
+  /<\s*[｜|]\s*tool[▁_\s]calls?[▁_\s]begin\s*[｜|]\s*>/i,
+];
+
+// Flatten LangChain message content (string or array of content parts) to text.
+const toText = (content: MessageContent): string => {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
+        return part.text;
+      }
+      return "";
+    })
+    .join("");
+};
+
+// True when the assistant content contains tool-call tokens that leaked as text.
+export const containsLeakedToolCallMarkup = (content: MessageContent): boolean => {
+  const text = toText(content);
+  if (!text) {
+    return false;
+  }
+  return LEAKED_TOOL_CALL_PATTERNS.some((pattern) => pattern.test(text));
+};

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -1,0 +1,326 @@
+import { Renderer } from "@freelensapp/extensions";
+import { interrupt } from "@langchain/langgraph";
+import { type Manifest, prepareManifest, resolveApiVersion, validateManifest } from "./resource-handlers";
+
+type KubeApi = Renderer.K8sApi.KubeApi;
+type KubeObject = Renderer.K8sApi.KubeObject;
+// Use the exact store type returned by the host ApiManager rather than the
+// public alias, which differs structurally (it requires extra dependencies).
+type KubeObjectStore = NonNullable<ReturnType<typeof Renderer.K8sApi.apiManager.getStore>>;
+
+interface ResolvedTarget {
+  api: KubeApi;
+  store: KubeObjectStore;
+}
+
+export interface ListResourceInput {
+  kind: string;
+  apiVersion?: string;
+  namespace?: string;
+}
+
+export interface GetResourceInput {
+  kind: string;
+  apiVersion?: string;
+  name: string;
+  namespace?: string;
+}
+
+export interface CreateResourceInput {
+  kind: string;
+  apiVersion?: string;
+  name?: string;
+  namespace?: string;
+  data: Manifest;
+}
+
+export interface WriteResourceInput {
+  kind: string;
+  apiVersion?: string;
+  name: string;
+  namespace?: string;
+  data: Manifest;
+}
+
+export interface DeleteResourceInput {
+  kind: string;
+  apiVersion?: string;
+  name: string;
+  namespace?: string;
+}
+
+/**
+ * Resolve the host KubeApi and store for a given kind/apiVersion. Returns a
+ * human-readable error string when resolution is not possible so the model can
+ * react (for example by supplying an explicit apiVersion for a CRD).
+ */
+function resolveTarget(kind: string, apiVersion?: string): ResolvedTarget | string {
+  const version = resolveApiVersion(kind, apiVersion);
+  if (!version) {
+    return `Could not resolve the apiVersion for kind "${kind}". Provide an explicit apiVersion (for example "apps/v1").`;
+  }
+  const api = Renderer.K8sApi.apiManager.getApiByKind(kind, version);
+  if (!api) {
+    return `Could not resolve a Kubernetes API for kind "${kind}" and apiVersion "${version}".`;
+  }
+  const store = Renderer.K8sApi.apiManager.getStore(api);
+  if (!store) {
+    return `Could not resolve a store for kind "${kind}".`;
+  }
+  return { api, store };
+}
+
+/**
+ * Run the human-in-the-loop approval gate for a write operation.
+ */
+function requestApproval(action: string, payload: Record<string, unknown>): boolean {
+  const actionToApprove = { action, ...payload };
+  const interruptRequest = {
+    question: "Do you want to approve this action?",
+    options: ["yes", "no"],
+    actionToApprove,
+    requestString: "```json\n" + JSON.stringify(actionToApprove, null, 2) + "\n```",
+  };
+  const review = interrupt(interruptRequest);
+  console.log("Tool call review: ", review);
+  return review === "yes";
+}
+
+function projectObject(object: KubeObject) {
+  return {
+    name: object.getName(),
+    namespace: object.getNs(),
+    spec: object.spec,
+    status: object.status,
+    metadata: object.metadata,
+  };
+}
+
+// The host store types its mutating params as a deep-partial of the KubeObject
+// (including its methods), which a free-form manifest cannot satisfy directly.
+// Cast through `unknown` to the exact expected type rather than using `as any`.
+type CreateData = Parameters<KubeObjectStore["create"]>[1];
+type UpdateData = Parameters<KubeObjectStore["update"]>[1];
+
+/**
+ * List resources of a kind, loading them from the store on demand. Namespaced
+ * kinds are scoped to `namespace` when provided; otherwise all loaded
+ * namespaces are returned.
+ */
+export async function listKubernetesResources({ kind, apiVersion, namespace }: ListResourceInput): Promise<string> {
+  console.log("[Tool invocation: listKubernetesResources] - kind:", kind, "namespace:", namespace);
+  const target = resolveTarget(kind, apiVersion);
+  if (typeof target === "string") {
+    return target;
+  }
+  const { api, store } = target;
+  try {
+    const scoped = api.isNamespaced && namespace ? [namespace] : undefined;
+    const loaded = await store.loadAll(scoped ? { namespaces: scoped } : {});
+    const items = loaded ?? (scoped ? store.getAllByNs(namespace as string) : store.items.toJSON());
+    return JSON.stringify(items.map(projectObject));
+  } catch (error) {
+    console.error("[Tool invocation error: listKubernetesResources] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Get a single resource by name, loading it from the store on demand. For
+ * namespaced kinds a namespace is required.
+ */
+export async function getKubernetesResource({ kind, apiVersion, name, namespace }: GetResourceInput): Promise<string> {
+  console.log("[Tool invocation: getKubernetesResource] - kind:", kind, "name:", name, "namespace:", namespace);
+  const target = resolveTarget(kind, apiVersion);
+  if (typeof target === "string") {
+    return target;
+  }
+  const { api, store } = target;
+  if (api.isNamespaced && !namespace) {
+    return `Kind "${kind}" is namespaced; please provide a namespace to get "${name}".`;
+  }
+  try {
+    const object = await store.load({ name, namespace: api.isNamespaced ? namespace : undefined });
+    if (!object) {
+      return `The ${kind} "${name}" was not found.`;
+    }
+    return JSON.stringify(projectObject(object));
+  } catch (error) {
+    console.error("[Tool invocation error: getKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Create a resource. Known kinds are validated and prepared via their handler;
+ * unknown kinds (CRDs) are applied as free YAML/JSON.
+ */
+export async function createKubernetesResource({
+  kind,
+  apiVersion,
+  name,
+  namespace,
+  data,
+}: CreateResourceInput): Promise<string> {
+  console.log("[Tool invocation: createKubernetesResource] - kind:", kind);
+  const target = resolveTarget(kind, apiVersion);
+  if (typeof target === "string") {
+    return target;
+  }
+  const { store } = target;
+
+  const validation = validateManifest(kind, data);
+  if (!validation.success) {
+    return `The ${kind} manifest is invalid: ${validation.error}`;
+  }
+  const manifest = prepareManifest(kind, validation.data);
+  const metadata = (manifest.metadata ?? {}) as { name?: string; namespace?: string };
+  const resourceName = name ?? metadata.name;
+  const resourceNamespace = namespace ?? metadata.namespace;
+  if (!resourceName) {
+    return `Could not determine the name for the ${kind} to create.`;
+  }
+
+  if (
+    !requestApproval(`CREATE ${kind.toUpperCase()}`, {
+      name: resourceName,
+      namespace: resourceNamespace,
+      data: manifest,
+    })
+  ) {
+    return "The user denied the action";
+  }
+
+  try {
+    const result = await store.create(
+      { name: resourceName, namespace: resourceNamespace },
+      manifest as unknown as CreateData,
+    );
+    console.log("[Tool invocation result: createKubernetesResource] - ", result);
+    return `${kind} manifest applied successfully`;
+  } catch (error) {
+    console.error("[Tool invocation error: createKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Update a resource (maps to a PUT). Loads the existing object first, then
+ * replaces it with the provided manifest.
+ */
+export async function updateKubernetesResource({
+  kind,
+  apiVersion,
+  name,
+  namespace,
+  data,
+}: WriteResourceInput): Promise<string> {
+  console.log("[Tool invocation: updateKubernetesResource] - kind:", kind, "name:", name);
+  const target = resolveTarget(kind, apiVersion);
+  if (typeof target === "string") {
+    return target;
+  }
+  const { api, store } = target;
+  if (api.isNamespaced && !namespace) {
+    return `Kind "${kind}" is namespaced; please provide a namespace to update "${name}".`;
+  }
+
+  const validation = validateManifest(kind, data);
+  if (!validation.success) {
+    return `The ${kind} manifest is invalid: ${validation.error}`;
+  }
+  const manifest = prepareManifest(kind, validation.data);
+
+  if (!requestApproval(`UPDATE ${kind.toUpperCase()}`, { name, namespace, data: manifest })) {
+    return "The user denied the action";
+  }
+
+  try {
+    const item = await store.load({ name, namespace: api.isNamespaced ? namespace : undefined });
+    if (!item) {
+      return `The ${kind} "${name}" you want to update does not exist`;
+    }
+    const result = await store.update(item, manifest as unknown as UpdateData);
+    console.log("[Tool invocation result: updateKubernetesResource] - ", result);
+    return `${kind} updated successfully`;
+  } catch (error) {
+    console.error("[Tool invocation error: updateKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Patch a resource (maps to a PATCH). Loads the existing object first, then
+ * applies the provided partial manifest as a merge patch.
+ */
+export async function patchKubernetesResource({
+  kind,
+  apiVersion,
+  name,
+  namespace,
+  data,
+}: WriteResourceInput): Promise<string> {
+  console.log("[Tool invocation: patchKubernetesResource] - kind:", kind, "name:", name);
+  const target = resolveTarget(kind, apiVersion);
+  if (typeof target === "string") {
+    return target;
+  }
+  const { api, store } = target;
+  if (api.isNamespaced && !namespace) {
+    return `Kind "${kind}" is namespaced; please provide a namespace to patch "${name}".`;
+  }
+
+  if (!requestApproval(`PATCH ${kind.toUpperCase()}`, { name, namespace, data })) {
+    return "The user denied the action";
+  }
+
+  try {
+    const item = await store.load({ name, namespace: api.isNamespaced ? namespace : undefined });
+    if (!item) {
+      return `The ${kind} "${name}" you want to patch does not exist`;
+    }
+    const result = await store.patch(item, data as unknown as UpdateData, "merge");
+    console.log("[Tool invocation result: patchKubernetesResource] - ", result);
+    return `${kind} patched successfully`;
+  } catch (error) {
+    console.error("[Tool invocation error: patchKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Delete a resource by name. For namespaced kinds a namespace is required.
+ */
+export async function deleteKubernetesResource({
+  kind,
+  apiVersion,
+  name,
+  namespace,
+}: DeleteResourceInput): Promise<string> {
+  console.log("[Tool invocation: deleteKubernetesResource] - kind:", kind, "name:", name);
+  const target = resolveTarget(kind, apiVersion);
+  if (typeof target === "string") {
+    return target;
+  }
+  const { api, store } = target;
+  if (api.isNamespaced && !namespace) {
+    return `Kind "${kind}" is namespaced; please provide a namespace to delete "${name}".`;
+  }
+
+  if (!requestApproval(`DELETE ${kind.toUpperCase()}`, { name, namespace })) {
+    return "The user denied the action";
+  }
+
+  try {
+    const item = await store.load({ name, namespace: api.isNamespaced ? namespace : undefined });
+    if (!item) {
+      return `The ${kind} "${name}" you want to delete does not exist`;
+    }
+    await store.remove(item);
+    console.log("[Tool invocation result: deleteKubernetesResource] - ", `${kind} deleted successfully`);
+    return `${kind} deleted successfully`;
+  } catch (error) {
+    console.error("[Tool invocation error: deleteKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}

--- a/src/renderer/business/agent/tools/resource-handlers.test.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildServiceManifest,
+  getResourceHandler,
+  prepareManifest,
+  resolveApiVersion,
+  SUPPORTED_KINDS,
+  validateManifest,
+} from "./resource-handlers";
+
+describe("SUPPORTED_KINDS", () => {
+  it("lists the internally handled kinds", () => {
+    expect(SUPPORTED_KINDS).toEqual(["Pod", "Deployment", "Service"]);
+  });
+});
+
+describe("getResourceHandler", () => {
+  it("returns a handler for a known kind", () => {
+    expect(getResourceHandler("Pod")).toBeDefined();
+  });
+
+  it("returns undefined for an unknown kind (CRD passthrough)", () => {
+    expect(getResourceHandler("Gateway")).toBeUndefined();
+  });
+});
+
+describe("resolveApiVersion", () => {
+  it("prefers the explicit apiVersion", () => {
+    expect(resolveApiVersion("Pod", "v2")).toBe("v2");
+  });
+
+  it("falls back to the handler default for known kinds", () => {
+    expect(resolveApiVersion("Deployment")).toBe("apps/v1");
+  });
+
+  it("returns undefined for an unknown kind without an explicit apiVersion", () => {
+    expect(resolveApiVersion("Gateway")).toBeUndefined();
+  });
+
+  it("returns the explicit apiVersion for an unknown kind", () => {
+    expect(resolveApiVersion("Gateway", "gateway.networking.k8s.io/v1")).toBe("gateway.networking.k8s.io/v1");
+  });
+});
+
+describe("buildServiceManifest", () => {
+  it("forces apiVersion and kind", () => {
+    const result = buildServiceManifest({ metadata: { name: "svc" }, spec: {} });
+    expect(result.apiVersion).toBe("v1");
+    expect(result.kind).toBe("Service");
+    expect(result.metadata).toEqual({ name: "svc" });
+  });
+
+  it("does not mutate the input", () => {
+    const input = { kind: "Wrong" };
+    buildServiceManifest(input);
+    expect(input.kind).toBe("Wrong");
+  });
+});
+
+describe("prepareManifest", () => {
+  it("applies the handler buildManifest for Service", () => {
+    const result = prepareManifest("Service", { metadata: { name: "svc" } });
+    expect(result.kind).toBe("Service");
+  });
+
+  it("returns the manifest unchanged for kinds without a builder", () => {
+    const input = { metadata: { name: "pod" } };
+    expect(prepareManifest("Pod", input)).toBe(input);
+  });
+
+  it("returns the manifest unchanged for unknown kinds", () => {
+    const input = { metadata: { name: "gw" } };
+    expect(prepareManifest("Gateway", input)).toBe(input);
+  });
+});
+
+describe("validateManifest", () => {
+  it("passes through unknown kinds without validation", () => {
+    const input = { anything: true };
+    const result = validateManifest("Gateway", input);
+    expect(result).toEqual({ success: true, data: input });
+  });
+
+  it("validates a well-formed Pod manifest", () => {
+    const manifest = {
+      apiVersion: "v1",
+      kind: "Pod",
+      metadata: { name: "p", namespace: "default" },
+      spec: { containers: [{ name: "c", image: "nginx", ports: [{ containerPort: 80 }] }] },
+    };
+    const result = validateManifest("Pod", manifest);
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects an invalid Pod manifest", () => {
+    const result = validateManifest("Pod", { kind: "Pod" });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/renderer/business/agent/tools/resource-handlers.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.ts
@@ -1,0 +1,185 @@
+import { z } from "zod";
+
+/**
+ * A Kubernetes manifest as a free-form object. The generic tools intentionally
+ * skip validation for kinds we do not understand internally (CRDs and anything
+ * else), so the manifest is passed through to the host as-is.
+ */
+export type Manifest = Record<string, unknown>;
+
+/**
+ * Extra, per-kind behavior layered on top of the generic resource operations.
+ *
+ * The set of kinds the model may target is intentionally open (the tools accept
+ * any `kind` string), so this registry does NOT restrict which resources can be
+ * handled. It only adds behavior for the kinds we understand internally:
+ * a default apiVersion, stricter manifest validation, and special manifest
+ * preparation. Unknown kinds (CRDs, etc.) simply have no entry and are treated
+ * as free YAML/JSON passthrough.
+ */
+export interface ResourceHandler {
+  /**
+   * Default apiVersion (group/version) used to resolve the host KubeApi via
+   * `apiManager.getApiByKind` when the model does not supply one. For CRDs the
+   * model is expected to provide the apiVersion explicitly.
+   */
+  defaultApiVersion?: string;
+  /**
+   * Stricter manifest validation for kinds understood internally. Unknown kinds
+   * skip validation entirely.
+   */
+  schema?: z.ZodTypeAny;
+  /**
+   * Special-case manifest preparation (for example forcing `apiVersion`/`kind`).
+   * Defaults to identity for kinds without one. This is where resource-specific
+   * business logic (a `buildPodManifest`-style helper) can live.
+   */
+  buildManifest?: (data: Manifest) => Manifest;
+}
+
+export const podManifestSchema = z
+  .object({
+    apiVersion: z.string(),
+    kind: z.string(),
+    metadata: z.object({
+      name: z.string(),
+      namespace: z.string(),
+    }),
+    spec: z.object({
+      containers: z.array(
+        z.object({
+          name: z.string(),
+          image: z.string(),
+          ports: z.array(
+            z.object({
+              containerPort: z.number(),
+            }),
+          ),
+        }),
+      ),
+    }),
+  })
+  .describe("Pod K8S manifest");
+
+export const deploymentManifestSchema = z
+  .object({
+    apiVersion: z.string(),
+    kind: z.string(),
+    metadata: z.object({
+      name: z.string(),
+      namespace: z.string(),
+    }),
+    spec: z.object({
+      replicas: z.number(),
+      selector: z.object({
+        matchLabels: z.record(z.string()),
+      }),
+      template: z.object({
+        metadata: z.object({
+          labels: z.record(z.string()),
+        }),
+        spec: z.object({
+          containers: z.array(
+            z.object({
+              name: z.string(),
+              image: z.string(),
+              ports: z.array(
+                z.object({
+                  containerPort: z.number(),
+                }),
+              ),
+            }),
+          ),
+        }),
+      }),
+    }),
+  })
+  .describe("Deployment K8S manifest");
+
+export const serviceManifestSchema = z
+  .object({
+    apiVersion: z.string(),
+    kind: z.string(),
+    metadata: z.object({
+      name: z.string(),
+      namespace: z.string().optional(),
+      labels: z.record(z.string()).optional(),
+      annotations: z.record(z.string()).optional(),
+    }),
+    spec: z.object({
+      type: z.enum(["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]).optional(),
+      selector: z.record(z.string()).optional(),
+      ports: z.array(
+        z.object({
+          name: z.string().optional(),
+          protocol: z.enum(["TCP", "UDP", "SCTP"]).optional().default("TCP"),
+          port: z.number().int().min(1).max(65535),
+          targetPort: z.union([z.number().int().min(1).max(65535), z.string()]),
+          nodePort: z.number().int().min(30000).max(32767).optional(),
+        }),
+      ),
+      clusterIP: z.string().optional(),
+      externalName: z.string().optional(),
+      sessionAffinity: z.enum(["None", "ClientIP"]).optional(),
+      ipFamilyPolicy: z.enum(["SingleStack", "PreferDualStack", "RequireDualStack"]).optional(),
+      ipFamilies: z.array(z.string()).optional(),
+    }),
+  })
+  .describe("Service K8S manifest");
+
+/**
+ * Service-specific manifest preparation: force the correct `apiVersion`/`kind`
+ * so the host always receives a well-formed Service manifest.
+ */
+export function buildServiceManifest(data: Manifest): Manifest {
+  return { ...data, apiVersion: "v1", kind: "Service" };
+}
+
+export const RESOURCE_HANDLERS: Record<string, ResourceHandler> = {
+  Pod: { defaultApiVersion: "v1", schema: podManifestSchema },
+  Deployment: { defaultApiVersion: "apps/v1", schema: deploymentManifestSchema },
+  Service: { defaultApiVersion: "v1", schema: serviceManifestSchema, buildManifest: buildServiceManifest },
+};
+
+/**
+ * Kinds with internal handlers. Listed in tool descriptions to hint the model,
+ * but it is allowed to target any other kind (CRDs) as free YAML.
+ */
+export const SUPPORTED_KINDS = Object.keys(RESOURCE_HANDLERS);
+
+export function getResourceHandler(kind: string): ResourceHandler | undefined {
+  return RESOURCE_HANDLERS[kind];
+}
+
+/**
+ * Resolve the apiVersion to use: the explicit one, otherwise the handler default.
+ */
+export function resolveApiVersion(kind: string, apiVersion?: string): string | undefined {
+  return apiVersion ?? getResourceHandler(kind)?.defaultApiVersion;
+}
+
+/**
+ * Apply the per-kind manifest preparation, defaulting to identity.
+ */
+export function prepareManifest(kind: string, data: Manifest): Manifest {
+  const handler = getResourceHandler(kind);
+  return handler?.buildManifest ? handler.buildManifest(data) : data;
+}
+
+export type ManifestValidationResult = { success: true; data: Manifest } | { success: false; error: string };
+
+/**
+ * Validate a manifest against the per-kind schema when one exists. Unknown kinds
+ * (no handler or no schema) pass through unchanged.
+ */
+export function validateManifest(kind: string, data: Manifest): ManifestValidationResult {
+  const handler = getResourceHandler(kind);
+  if (!handler?.schema) {
+    return { success: true, data };
+  }
+  const result = handler.schema.safeParse(data);
+  if (!result.success) {
+    return { success: false, error: result.error.message };
+  }
+  return { success: true, data: result.data as Manifest };
+}

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -1,7 +1,28 @@
-import { Main, Renderer } from "@freelensapp/extensions";
+import { Renderer } from "@freelensapp/extensions";
 import { tool } from "@langchain/core/tools";
-import { interrupt } from "@langchain/langgraph";
 import { z } from "zod";
+import {
+  createKubernetesResource as createKubernetesResourceImpl,
+  deleteKubernetesResource as deleteKubernetesResourceImpl,
+  getKubernetesResource as getKubernetesResourceImpl,
+  listKubernetesResources as listKubernetesResourcesImpl,
+  patchKubernetesResource as patchKubernetesResourceImpl,
+  updateKubernetesResource as updateKubernetesResourceImpl,
+} from "./kubernetes-resource";
+import { SUPPORTED_KINDS } from "./resource-handlers";
+
+const supportedKindsHint = `Built-in kinds with extra validation: ${SUPPORTED_KINDS.join(", ")}. Any other kind (including CRDs) is also accepted and passed through as a free manifest; for those provide the apiVersion explicitly.`;
+
+const kindSchema = z
+  .string()
+  .describe(`The Kubernetes resource kind, e.g. Pod, Deployment, Service or a CRD kind. ${supportedKindsHint}`);
+const apiVersionSchema = z
+  .string()
+  .optional()
+  .describe(
+    'The apiVersion (group/version) of the resource, e.g. "v1" or "apps/v1". Required for kinds without a built-in default.',
+  );
+const manifestSchema = z.record(z.any()).describe("The Kubernetes resource manifest as a JSON object.");
 
 export const getNamespaces = tool(
   (): string[] => {
@@ -63,491 +84,86 @@ export const getWarningEventsByNamespace = tool(
   },
 );
 
-export const createPod = tool(
-  async ({ name, namespace, data }: { name: string; namespace: string; data: Main.K8sApi.Pod }): Promise<string> => {
-    /**
-     * Creates a pod in the Kubernetes cluster
-     */
-    console.log("[Tool invocation: createPod]");
+export const listKubernetesResources = tool(listKubernetesResourcesImpl, {
+  name: "listKubernetesResources",
+  description: "List Kubernetes resources of a given kind, optionally scoped to a namespace",
+  schema: z.object({
+    kind: kindSchema,
+    apiVersion: apiVersionSchema,
+    namespace: z.string().optional().describe("The namespace to list namespaced resources in"),
+  }),
+});
 
-    const interruptRequest = {
-      question: "Do you want to approve this action?",
-      options: ["yes", "no"],
-      actionToApprove: { action: "CREATE POD", name, namespace, data },
-      requestString: "```json\n" + JSON.stringify({ action: "CREATE POD", name, namespace, data }, null, 2) + "\n```",
-    };
-    const review = interrupt(interruptRequest);
-    console.log("Tool call review: ", review);
-    if (review !== "yes") {
-      console.log("[Tool invocation: createPod] - action not approved");
-      return "The user denied the action";
-    }
+export const getKubernetesResource = tool(getKubernetesResourceImpl, {
+  name: "getKubernetesResource",
+  description: "Get a single Kubernetes resource by name (namespace required for namespaced kinds)",
+  schema: z.object({
+    kind: kindSchema,
+    apiVersion: apiVersionSchema,
+    name: z.string().describe("The name of the resource"),
+    namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
+  }),
+});
 
-    try {
-      const podsStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.podsApi);
-      if (!podsStore) {
-        return "Unable to get the object that can create a pod";
-      }
-      const createPodResult: Renderer.K8sApi.Pod = await podsStore.create({ name, namespace }, data);
-      console.log("[Tool invocation result: createPod] - ", createPodResult);
-      return "Pod manifest applied successfully";
-    } catch (error) {
-      console.error("[Tool invocation error: createPod] - ", error);
-      return JSON.stringify(error);
-    }
-  },
-  {
-    name: "createPod",
-    description: "Creates a pod in the Kubernetes cluster",
-    schema: z
-      .object({
-        namespace: z.string(),
-        name: z.string(),
-        data: z.object({
-          apiVersion: z.string(),
-          kind: z.string(),
-          metadata: z.object({
-            name: z.string(),
-            namespace: z.string(),
-          }),
-          spec: z.object({
-            containers: z.array(
-              z.object({
-                name: z.string(),
-                image: z.string(),
-                ports: z.array(
-                  z.object({
-                    containerPort: z.number(),
-                  }),
-                ),
-              }),
-            ),
-          }),
-        }),
-      })
-      .describe("Pod K8S manifest to create"),
-  },
-);
+export const createKubernetesResource = tool(createKubernetesResourceImpl, {
+  name: "createKubernetesResource",
+  description: "Create a Kubernetes resource of any kind from a manifest",
+  schema: z.object({
+    kind: kindSchema,
+    apiVersion: apiVersionSchema,
+    name: z.string().optional().describe("The name of the resource (defaults to metadata.name in the manifest)"),
+    namespace: z
+      .string()
+      .optional()
+      .describe("The namespace of the resource (defaults to metadata.namespace in the manifest)"),
+    data: manifestSchema,
+  }),
+});
 
-export const createDeployment = tool(
-  async ({
-    name,
-    namespace,
-    data,
-  }: {
-    name: string;
-    namespace: string;
-    data: Main.K8sApi.Deployment;
-  }): Promise<string> => {
-    /**
-     * Creates a deployment in the Kubernetes cluster
-     */
-    console.log("[Tool invocation: createDeployment]");
+export const updateKubernetesResource = tool(updateKubernetesResourceImpl, {
+  name: "updateKubernetesResource",
+  description: "Update (replace, via PUT) an existing Kubernetes resource with a manifest",
+  schema: z.object({
+    kind: kindSchema,
+    apiVersion: apiVersionSchema,
+    name: z.string().describe("The name of the resource to update"),
+    namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
+    data: manifestSchema,
+  }),
+});
 
-    const interruptRequest = {
-      question: "Do you want to approve this action?",
-      options: ["yes", "no"],
-      actionToApprove: { action: "CREATE DEPLOYMENT", name, namespace, data },
-      requestString:
-        "```json\n" + JSON.stringify({ action: "CREATE DEPLOYMENT", name, namespace, data }, null, 2) + "\n```",
-    };
-    const review = interrupt(interruptRequest);
-    console.log("Tool call review: ", review);
-    if (review !== "yes") {
-      console.log("[Tool invocation] - action not approved");
-      return "The user denied the action";
-    }
+export const patchKubernetesResource = tool(patchKubernetesResourceImpl, {
+  name: "patchKubernetesResource",
+  description: "Patch (via PATCH) an existing Kubernetes resource with a partial manifest",
+  schema: z.object({
+    kind: kindSchema,
+    apiVersion: apiVersionSchema,
+    name: z.string().describe("The name of the resource to patch"),
+    namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
+    data: manifestSchema.describe("The partial Kubernetes manifest to merge into the resource"),
+  }),
+});
 
-    try {
-      const deploymentsStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.deploymentApi);
-      if (!deploymentsStore) {
-        return "Unable to get the object that can create a deployment";
-      }
-      const createDeploymentResult: Renderer.K8sApi.Deployment = await deploymentsStore.create(
-        { name, namespace },
-        data,
-      );
-      console.log("[Tool invocation result: createDeployment] - ", createDeploymentResult);
-      return "Deployment manifest applied successfully";
-    } catch (error) {
-      console.error("[Tool invocation error: createDeployment] - ", error);
-      return JSON.stringify(error);
-    }
-  },
-  {
-    name: "createDeployment",
-    description: "Creates a deployment in the Kubernetes cluster",
-    schema: z
-      .object({
-        namespace: z.string(),
-        name: z.string(),
-        data: z.object({
-          apiVersion: z.string(),
-          kind: z.string(),
-          metadata: z.object({
-            name: z.string(),
-            namespace: z.string(),
-          }),
-          spec: z.object({
-            replicas: z.number(),
-            selector: z.object({
-              matchLabels: z.record(z.string()),
-            }),
-            template: z.object({
-              metadata: z.object({
-                labels: z.record(z.string()),
-              }),
-              spec: z.object({
-                containers: z.array(
-                  z.object({
-                    name: z.string(),
-                    image: z.string(),
-                    ports: z.array(
-                      z.object({
-                        containerPort: z.number(),
-                      }),
-                    ),
-                  }),
-                ),
-              }),
-            }),
-          }),
-        }),
-      })
-      .describe("Deployment K8S manifest to create"),
-  },
-);
-
-export const deletePod = tool(
-  async ({ name, namespace }: { name: string; namespace: string }): Promise<string> => {
-    /**
-     * Deletes a pod in the Kubernetes cluster
-     */
-    console.log("[Tool invocation: deletePod]");
-
-    const interruptRequest = {
-      question: "Do you want to approve this action?",
-      options: ["yes", "no"],
-      actionToApprove: { action: "DELETE POD", name, namespace },
-      requestString: "```json\n" + JSON.stringify({ action: "DELETE POD", name, namespace }, null, 2) + "\n```",
-    };
-    const review = interrupt(interruptRequest);
-    console.log("Tool call review: ", review);
-    if (review !== "yes") {
-      console.log("[Tool invocation: deletePod] - action not approved");
-      return "The user denied the action";
-    }
-
-    try {
-      const podsStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.podsApi);
-      if (!podsStore) {
-        return "Unable to get the object that can delete a pod";
-      }
-      const podToRemove = podsStore.getByName(name, namespace);
-      if (!podToRemove) {
-        return "The pod you want to delete does not exist";
-      }
-      await podsStore.remove(podToRemove);
-      console.log("[Tool invocation result: deletePod] - Pod deleted successfully");
-      return "Pod deleted successfully";
-    } catch (error) {
-      console.error("[Tool invocation error: deletePod] - ", error);
-      return JSON.stringify(error);
-    }
-  },
-  {
-    name: "deletePod",
-    description: "Deletes a pod in the Kubernetes cluster",
-    schema: z.object({
-      namespace: z.string(),
-      name: z.string(),
-    }),
-  },
-);
-
-export const deleteDeployment = tool(
-  async ({ name, namespace }: { name: string; namespace: string }): Promise<string> => {
-    /**
-     * Deletes a deployment in the Kubernetes cluster
-     */
-    console.log("[Tool invocation: deleteDeployment]");
-
-    const interruptRequest = {
-      question: "Do you want to approve this action?",
-      options: ["yes", "no"],
-      actionToApprove: { action: "DELETE DEPLOYMENT", name, namespace },
-      requestString: "```json\n" + JSON.stringify({ action: "DELETE DEPLOYMENT", name, namespace }, null, 2) + "\n```",
-    };
-    const review = interrupt(interruptRequest);
-    console.log("Tool call review: ", review);
-    if (review !== "yes") {
-      console.log("[Tool invocation: deleteDeployment] - action not approved");
-      return "The user denied the action";
-    }
-
-    try {
-      const deploymentsStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.deploymentApi);
-      if (!deploymentsStore) {
-        return "The object that can delete a deployment does not exist";
-      }
-      const deploymentToRemove = deploymentsStore.getByName(name, namespace);
-      if (!deploymentToRemove) {
-        return "The deployment you want to delete does not exist";
-      }
-      await deploymentsStore.remove(deploymentToRemove);
-      console.log("[Tool invocation result: deleteDeployment] - Deployment deleted successfully");
-      return "Deployment deleted successfully";
-    } catch (error) {
-      console.error("[Tool invocation error: deleteDeployment] - ", error);
-      return JSON.stringify(error);
-    }
-  },
-  {
-    name: "deleteDeployment",
-    description: "Deletes a deployment in the Kubernetes cluster",
-    schema: z.object({
-      namespace: z.string(),
-      name: z.string(),
-    }),
-  },
-);
-
-export const createService = tool(
-  async ({ data }: { data: Main.K8sApi.Service }): Promise<string> => {
-    /**
-     * Creates a service in the Kubernetes cluster
-     */
-
-    if (data) {
-      if (data.metadata) {
-        data.metadata.apiVersion = "v1";
-        data.metadata.kind = "Service";
-      }
-    }
-
-    const interruptRequest = {
-      question: "Approve this action...",
-      options: ["yes", "no"],
-      actionToApprove: { action: "CREATE SERVICE", data },
-      requestString: "```json\n" + JSON.stringify({ action: "CREATE SERVICE", data }, null, 2) + "\n```",
-    };
-    const review = interrupt(interruptRequest);
-    console.log("Tool call review: ", review);
-    if (review !== "yes") {
-      console.log("[Tool invocation: createService] - action not approved");
-      return "The user denied the action";
-    }
-
-    try {
-      const servicesStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.serviceApi);
-      if (!servicesStore) {
-        return "The object that can create a service does not exist";
-      }
-      const createServiceResult: Renderer.K8sApi.Service = await servicesStore.create(
-        {
-          name: data.metadata.name,
-          namespace: data.metadata.namespace,
-        },
-        data,
-      );
-      console.log("[Tool invocation result: createService] - ", createServiceResult);
-      return "Service manifest applied successfully";
-    } catch (error) {
-      console.error("[Tool invocation error: createService] - ", error);
-      return JSON.stringify(error);
-    }
-  },
-  {
-    name: "createService",
-    description: "Creates a service in the Kubernetes cluster",
-    schema: z
-      .object({
-        apiVersion: z.string(),
-        kind: z.string(),
-        metadata: z.object({
-          name: z.string(),
-          namespace: z.string().optional(),
-          labels: z.record(z.string()).optional(),
-          annotations: z.record(z.string()).optional(),
-        }),
-        spec: z.object({
-          type: z.enum(["ClusterIP", "NodePort", "LoadBalancer", "ExternalName"]).optional(),
-          selector: z.record(z.string()).optional(),
-          ports: z.array(
-            z.object({
-              name: z.string().optional(),
-              protocol: z.enum(["TCP", "UDP", "SCTP"]).optional().default("TCP"),
-              port: z.number().int().min(1).max(65535),
-              targetPort: z.union([z.number().int().min(1).max(65535), z.string()]),
-              nodePort: z.number().int().min(30000).max(32767).optional(),
-            }),
-          ),
-          clusterIP: z.string().optional(),
-          externalName: z.string().optional(),
-          sessionAffinity: z.enum(["None", "ClientIP"]).optional(),
-          ipFamilyPolicy: z.enum(["SingleStack", "PreferDualStack", "RequireDualStack"]).optional(),
-          ipFamilies: z.array(z.string()).optional(),
-        }),
-      })
-      .describe("Service K8S manifest to create"),
-  },
-);
-
-export const deleteService = tool(
-  async ({ name, namespace }: { name: string; namespace: string }): Promise<string> => {
-    /**
-     * Deletes a service in the Kubernetes cluster
-     */
-    console.log("[Tool invocation: deleteService]");
-
-    const interruptRequest = {
-      question: "Approve this action...",
-      options: ["yes", "no"],
-      actionToApprove: { action: "DELETE SERVICE", name, namespace },
-      requestString: "```json\n" + JSON.stringify({ action: "DELETE SERVICE", name, namespace }, null, 2) + "\n```",
-    };
-    const review = interrupt(interruptRequest);
-    console.log("Tool call review: ", review);
-    if (review !== "yes") {
-      console.log("[Tool invocation: deleteService] - action not approved");
-      return "The user denied the action";
-    }
-
-    try {
-      const servicesStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.serviceApi);
-      if (!servicesStore) {
-        return "The object that can delete a service does not exist";
-      }
-      const serviceToRemove = servicesStore.getByName(name, namespace);
-      if (!serviceToRemove) {
-        return "The service you want to delete does not exist";
-      }
-      await servicesStore.remove(serviceToRemove);
-      console.log("[Tool invocation result: deleteService] - Service deleted successfully");
-      return "Service deleted successfully";
-    } catch (error) {
-      console.error("[Tool invocation error: deleteService] - ", error);
-      return JSON.stringify(error);
-    }
-  },
-  {
-    name: "deleteService",
-    description: "Deletes a service in the Kubernetes cluster",
-    schema: z.object({
-      namespace: z.string(),
-      name: z.string(),
-    }),
-  },
-);
-
-export const getPods = tool(
-  ({ namespace }: { namespace: string }): string => {
-    /**
-     * Get all pods in a specific Kubernetes namespace
-     */
-    console.log("[Tool invocation: getPods] - namespace: ", namespace);
-    const podsStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.podsApi);
-    if (!podsStore) {
-      return "The object that can get pods does not exist";
-    }
-    const allPodsByNs: Renderer.K8sApi.Pod[] = podsStore.getAllByNs(namespace);
-    const getPodsToolResult = JSON.stringify(
-      allPodsByNs.map((pod) => ({
-        name: pod.getName(),
-        namespace: pod.getNs(),
-        status: pod.status,
-        spec: pod.spec,
-        metadata: pod.metadata,
-      })),
-    );
-    console.log("[Tool invocation result: getPods] - ", getPodsToolResult);
-    return getPodsToolResult;
-  },
-  {
-    name: "getPods",
-    description: "Get all pods in a specific Kubernetes namespace",
-    schema: z.object({
-      namespace: z.string(),
-    }),
-  },
-);
-
-export const getDeployments = tool(
-  ({ namespace }: { namespace: string }): string => {
-    /**
-     * Get all deployments in a specific Kubernetes namespace
-     */
-    console.log("[Tool invocation: getDeployments] - namespace: ", namespace);
-    const deploymentsStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.deploymentApi);
-    if (!deploymentsStore) {
-      return "The object that can get deployments does not exist";
-    }
-    const allDeploymentsByNs: Renderer.K8sApi.Deployment[] = deploymentsStore.getAllByNs(namespace);
-    const getDeploymentsToolResult = JSON.stringify(
-      allDeploymentsByNs.map((deployment) => ({
-        name: deployment.getName(),
-        namespace: deployment.getNs(),
-        status: deployment.status,
-        spec: deployment.spec,
-        metadata: deployment.metadata,
-      })),
-    );
-    console.log("[Tool invocation result: getDeployments] - ", getDeploymentsToolResult);
-    return getDeploymentsToolResult;
-  },
-  {
-    name: "getDeployments",
-    description: "Get all deployments in a specific Kubernetes namespace",
-    schema: z.object({
-      namespace: z.string(),
-    }),
-  },
-);
-
-export const getServices = tool(
-  ({ namespace }: { namespace: string }): string => {
-    /**
-     * Get all services in a specific Kubernetes namespace
-     */
-    console.log("[Tool invocation: getServices] - namespace: ", namespace);
-    const servicesStore = Renderer.K8sApi.apiManager.getStore(Renderer.K8sApi.serviceApi);
-    if (!servicesStore) {
-      return "The object that can get services does not exist";
-    }
-    const allServicesByNs: Renderer.K8sApi.Service[] = servicesStore.getAllByNs(namespace);
-    const getServicesToolResult = JSON.stringify(
-      allServicesByNs.map((service) => ({
-        name: service.getName(),
-        namespace: service.getNs(),
-        spec: service.spec,
-        metadata: service.metadata,
-        status: service.status,
-      })),
-    );
-    console.log("[Tool invocation result: getServices] - ", getServicesToolResult);
-    return getServicesToolResult;
-  },
-  {
-    name: "getServices",
-    description: "Get all services in a specific Kubernetes namespace",
-    schema: z.object({
-      namespace: z.string(),
-    }),
-  },
-);
+export const deleteKubernetesResource = tool(deleteKubernetesResourceImpl, {
+  name: "deleteKubernetesResource",
+  description: "Delete a Kubernetes resource by name (namespace required for namespaced kinds)",
+  schema: z.object({
+    kind: kindSchema,
+    apiVersion: apiVersionSchema,
+    name: z.string().describe("The name of the resource to delete"),
+    namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
+  }),
+});
 
 export const allToolFunctions = [
   getNamespaces,
   getWarningEventsByNamespace,
-  createPod,
-  createDeployment,
-  deletePod,
-  deleteDeployment,
-  createService,
-  deleteService,
-  getPods,
-  getDeployments,
-  getServices,
+  listKubernetesResources,
+  getKubernetesResource,
+  createKubernetesResource,
+  updateKubernetesResource,
+  patchKubernetesResource,
+  deleteKubernetesResource,
 ];
 
 // Data structure describing each tool function: name, description, arguments, and return type
@@ -565,57 +181,47 @@ export const toolFunctionDescriptions = [
     returnType: "Returns a JSON string containing all warning events for the given namespace.",
   },
   {
-    name: "createPod",
-    description: "Creates a pod in the Kubernetes cluster",
-    arguments: "Requires the pod name (string), namespace (string), and the pod manifest data (object).",
-    returnType: "Returns a message string indicating success or error after attempting to create the pod.",
+    name: "listKubernetesResources",
+    description: "List Kubernetes resources of a given kind, optionally scoped to a namespace",
+    arguments:
+      "Requires the resource kind (string) and optionally the apiVersion (string) and namespace (string). Built-in kinds: " +
+      SUPPORTED_KINDS.join(", ") +
+      "; any other kind (including CRDs) is accepted.",
+    returnType: "Returns a JSON string containing the matching resources.",
   },
   {
-    name: "createDeployment",
-    description: "Creates a deployment in the Kubernetes cluster",
-    arguments: "Requires the deployment name (string), namespace (string), and the deployment manifest data (object).",
-    returnType: "Returns a message string indicating success or error after attempting to create the deployment.",
+    name: "getKubernetesResource",
+    description: "Get a single Kubernetes resource by name",
+    arguments:
+      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string). Namespace (string) is required for namespaced kinds.",
+    returnType: "Returns a JSON string containing the requested resource.",
   },
   {
-    name: "deletePod",
-    description: "Deletes a pod in the Kubernetes cluster",
-    arguments: "Requires the pod name (string) and namespace (string).",
-    returnType: "Returns a message string indicating success or error after attempting to delete the pod.",
+    name: "createKubernetesResource",
+    description: "Create a Kubernetes resource of any kind from a manifest",
+    arguments:
+      "Requires the resource kind (string) and the manifest data (object), and optionally the apiVersion (string), name (string) and namespace (string).",
+    returnType: "Returns a message string indicating success or error after attempting to create the resource.",
   },
   {
-    name: "deleteDeployment",
-    description: "Deletes a deployment in the Kubernetes cluster",
-    arguments: "Requires the deployment name (string) and namespace (string).",
-    returnType: "Returns a message string indicating success or error after attempting to delete the deployment.",
+    name: "updateKubernetesResource",
+    description: "Update (replace, via PUT) an existing Kubernetes resource with a manifest",
+    arguments:
+      "Requires the resource kind (string), name (string) and the manifest data (object), and optionally the apiVersion (string) and namespace (string).",
+    returnType: "Returns a message string indicating success or error after attempting to update the resource.",
   },
   {
-    name: "createService",
-    description: "Creates a service in the Kubernetes cluster",
-    arguments: "Requires the service manifest data (object).",
-    returnType: "Returns a message string indicating success or error after attempting to create the service.",
+    name: "patchKubernetesResource",
+    description: "Patch (via PATCH) an existing Kubernetes resource with a partial manifest",
+    arguments:
+      "Requires the resource kind (string), name (string) and the partial manifest data (object), and optionally the apiVersion (string) and namespace (string).",
+    returnType: "Returns a message string indicating success or error after attempting to patch the resource.",
   },
   {
-    name: "deleteService",
-    description: "Deletes a service in the Kubernetes cluster",
-    arguments: "Requires the service name (string) and namespace (string).",
-    returnType: "Returns a message string indicating success or error after attempting to delete the service.",
-  },
-  {
-    name: "getPods",
-    description: "Get all pods in a specific Kubernetes namespace",
-    arguments: "Requires the namespace name as a string.",
-    returnType: "Returns a JSON string containing all pods in the given namespace.",
-  },
-  {
-    name: "getDeployments",
-    description: "Get all deployments in a specific Kubernetes namespace",
-    arguments: "Requires the namespace name as a string.",
-    returnType: "Returns a JSON string containing all deployments in the given namespace.",
-  },
-  {
-    name: "getServices",
-    description: "Get all services in a specific Kubernetes namespace",
-    arguments: "Requires the namespace name as a string.",
-    returnType: "Returns a JSON string containing all services in the given namespace.",
+    name: "deleteKubernetesResource",
+    description: "Delete a Kubernetes resource by name",
+    arguments:
+      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string). Namespace (string) is required for namespaced kinds.",
+    returnType: "Returns a message string indicating success or error after attempting to delete the resource.",
   },
 ];


### PR DESCRIPTION
Collapses the per-resource agent tools into generic kind-agnostic operations: list/get/create/update/patch/delete. The kind set is open (CRDs supported as free manifests) with an internal registry for built-in kinds (Pod/Deployment/Service) carrying schema/manifest heuristics. get/list load from the store on demand; update maps to PUT and patch to a merge PATCH.

Closes #125
