### PR TITLE
Recover DeepSeek DSML tool calls into structured tool calls

### DIFF
--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -1,10 +1,12 @@
 import { Command } from "@langchain/langgraph";
 import { getInterruptMessage, getTextMessage } from "../../renderer/business/objects/message-object-provider";
 import { MessageType } from "../../renderer/business/objects/message-type";
+import { DEFAULT_OPENAI_BASE_URL } from "../../renderer/business/provider/ai-models";
 import { AgentService, useAgentService } from "../../renderer/business/service/agent-service";
 import { AiAnalysisService, useAiAnalysisService } from "../../renderer/business/service/ai-analysis-service";
 import { ActionToApprove } from "../../renderer/components/chat";
 import { useApplicationStatusStore } from "../../renderer/context/application-context";
+import { PreferencesStore } from "../store";
 import useLog from "../utils/logger/logger-service";
 
 import type { MessageObject } from "../../renderer/business/objects/message-object";
@@ -27,6 +29,28 @@ const useChatService = () => {
     }
 
     const message = error.message.toLowerCase();
+
+    // A bare "Failed to fetch" / "fetch failed" means the request never reached
+    // the endpoint (proxy not started, wrong base URL, network blocked). The
+    // browser strips the URL from the message, so re-attach the configured
+    // endpoint and proxy port to make the error actionable.
+    const isConnectionFailure =
+      error.name === "APIConnectionError" ||
+      message.includes("failed to fetch") ||
+      message.includes("fetch failed") ||
+      message.includes("network error");
+
+    if (isConnectionFailure) {
+      // @ts-ignore
+      const preferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
+      const baseUrl = preferencesStore.openAIBaseUrl || DEFAULT_OPENAI_BASE_URL;
+      const proxyHint =
+        preferencesStore.aiProxyPort === null
+          ? "the local AI proxy is not running yet"
+          : `via the local AI proxy on port ${preferencesStore.aiProxyPort}`;
+      return `Could not reach the AI endpoint ${baseUrl} (${proxyHint}). Check the base URL, your network connection, and that the endpoint is reachable. Original error: ${error.message}`;
+    }
+
     const isGeminiTemporaryOverload =
       message.includes("failed to parse stream") ||
       message.includes("503") ||

--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -29,16 +29,20 @@ const useChatService = () => {
     }
 
     const message = error.message.toLowerCase();
+    // Duck-type the OpenAI SDK error shape: APIError subclasses carry a numeric
+    // `status`. APIConnectionError has status === undefined (the request never
+    // reached the endpoint at all), while InternalServerError has status >= 500
+    // (the proxy returned a 502/5xx because it could not reach the upstream).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const errorStatus = (error as any).status as number | undefined;
 
-    // A bare "Failed to fetch" / "fetch failed" means the request never reached
-    // the endpoint (proxy not started, wrong base URL, network blocked). The
-    // browser strips the URL from the message, so re-attach the configured
-    // endpoint and proxy port to make the error actionable.
+    // True connection failure: the renderer never reached the proxy (proxy not
+    // started, wrong port, network blocked). APIConnectionError has no HTTP
+    // status; the browser strips the URL from `Failed to fetch` so re-attach it.
     const isConnectionFailure =
-      error.name === "APIConnectionError" ||
-      message.includes("failed to fetch") ||
-      message.includes("fetch failed") ||
-      message.includes("network error");
+      error.constructor?.name === "APIConnectionError" ||
+      (errorStatus === undefined &&
+        (message.includes("failed to fetch") || message.includes("fetch failed") || message.includes("network error")));
 
     if (isConnectionFailure) {
       // @ts-ignore
@@ -49,6 +53,15 @@ const useChatService = () => {
           ? "the local AI proxy is not running yet"
           : `via the local AI proxy on port ${preferencesStore.aiProxyPort}`;
       return `Could not reach the AI endpoint ${baseUrl} (${proxyHint}). Check the base URL, your network connection, and that the endpoint is reachable. Original error: ${error.message}`;
+    }
+
+    // The proxy returned a 5xx (e.g. 502): the renderer reached the proxy
+    // successfully, but the proxy could not reach the upstream endpoint.
+    if (typeof errorStatus === "number" && errorStatus >= 500) {
+      // @ts-ignore
+      const preferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
+      const baseUrl = preferencesStore.openAIBaseUrl || DEFAULT_OPENAI_BASE_URL;
+      return `The AI proxy could not reach the upstream endpoint ${baseUrl}. Check that the endpoint is running and the base URL is correct. Original error: ${error.message}`;
     }
 
     const isGeminiTemporaryOverload =

--- a/src/renderer/business/agent/leaked-tool-calls.test.ts
+++ b/src/renderer/business/agent/leaked-tool-calls.test.ts
@@ -1,5 +1,6 @@
+import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { describe, expect, it } from "vitest";
-import { containsLeakedToolCallMarkup } from "./leaked-tool-calls";
+import { containsLeakedToolCallMarkup, parseDsmlToolCalls, recoverDsmlToolCalls } from "./leaked-tool-calls";
 
 describe("containsLeakedToolCallMarkup", () => {
   it("detects leaked DSML tool_calls markup", () => {
@@ -32,5 +33,94 @@ describe("containsLeakedToolCallMarkup", () => {
 
   it("does not flag the literal word DSML in prose", () => {
     expect(containsLeakedToolCallMarkup("DSML stands for domain-specific markup language.")).toBe(false);
+  });
+});
+
+describe("parseDsmlToolCalls", () => {
+  it("parses a single DSML tool call with a string parameter", () => {
+    const content =
+      'OK, listing them.<｜｜DSML｜｜tool_calls> <｜｜DSML｜｜invoke name="listKubernetesResources"> ' +
+      '<｜｜DSML｜｜parameter name="kind" string="true">Kustomization</｜｜DSML｜｜parameter> ' +
+      "</｜｜DSML｜｜invoke> </｜｜DSML｜｜tool_calls>";
+    const { cleanedText, toolCalls } = parseDsmlToolCalls(content);
+
+    expect(cleanedText).toBe("OK, listing them.");
+    expect(toolCalls).toEqual([
+      { name: "listKubernetesResources", args: { kind: "Kustomization" }, id: "dsml_tool_call_0", type: "tool_call" },
+    ]);
+  });
+
+  it("parses non-string parameters as JSON (objects, numbers)", () => {
+    const content =
+      '<｜｜DSML｜｜invoke name="updateKubernetesResource">' +
+      '<｜｜DSML｜｜parameter name="name" string="true">my-app</｜｜DSML｜｜parameter>' +
+      '<｜｜DSML｜｜parameter name="replicas">3</｜｜DSML｜｜parameter>' +
+      '<｜｜DSML｜｜parameter name="data">{"spec":{"replicas":3}}</｜｜DSML｜｜parameter>' +
+      "</｜｜DSML｜｜invoke>";
+    const { toolCalls } = parseDsmlToolCalls(content);
+
+    expect(toolCalls).toHaveLength(1);
+    expect(toolCalls[0]).toMatchObject({
+      name: "updateKubernetesResource",
+      args: { name: "my-app", replicas: 3, data: { spec: { replicas: 3 } } },
+    });
+  });
+
+  it("parses multiple invoke blocks", () => {
+    const content =
+      '<｜｜DSML｜｜tool_calls><｜｜DSML｜｜invoke name="getNamespaces"></｜｜DSML｜｜invoke>' +
+      '<｜｜DSML｜｜invoke name="getKubernetesResource">' +
+      '<｜｜DSML｜｜parameter name="kind" string="true">Pod</｜｜DSML｜｜parameter>' +
+      "</｜｜DSML｜｜invoke></｜｜DSML｜｜tool_calls>";
+    const { cleanedText, toolCalls } = parseDsmlToolCalls(content);
+
+    expect(cleanedText).toBe("");
+    expect(toolCalls.map((c) => c.name)).toEqual(["getNamespaces", "getKubernetesResource"]);
+    expect(toolCalls[0].args).toEqual({});
+    expect(toolCalls[1].args).toEqual({ kind: "Pod" });
+  });
+
+  it("returns no tool calls for plain text", () => {
+    const { cleanedText, toolCalls } = parseDsmlToolCalls("The pod uses nginx:1.27.");
+    expect(toolCalls).toEqual([]);
+    expect(cleanedText).toBe("The pod uses nginx:1.27.");
+  });
+
+  it("returns no tool calls for the native token format (not recoverable)", () => {
+    const { toolCalls } = parseDsmlToolCalls("<｜tool▁calls▁begin｜>");
+    expect(toolCalls).toEqual([]);
+  });
+});
+
+describe("recoverDsmlToolCalls", () => {
+  it("recovers tool calls from an AIMessage and strips the markup", () => {
+    const message = new AIMessage({
+      content: 'Sure.<｜｜DSML｜｜invoke name="getNamespaces"></｜｜DSML｜｜invoke>',
+    });
+    const recovered = recoverDsmlToolCalls(message) as AIMessage;
+
+    expect(recovered).not.toBe(message);
+    expect(recovered.content).toBe("Sure.");
+    expect(recovered.tool_calls).toEqual([
+      { name: "getNamespaces", args: {}, id: "dsml_tool_call_0", type: "tool_call" },
+    ]);
+  });
+
+  it("leaves a message that already has structured tool calls unchanged", () => {
+    const message = new AIMessage({
+      content: "",
+      tool_calls: [{ name: "getNamespaces", args: {}, id: "real_0", type: "tool_call" }],
+    });
+    expect(recoverDsmlToolCalls(message)).toBe(message);
+  });
+
+  it("leaves a plain assistant message unchanged", () => {
+    const message = new AIMessage({ content: "No tools needed here." });
+    expect(recoverDsmlToolCalls(message)).toBe(message);
+  });
+
+  it("leaves non-AI messages unchanged", () => {
+    const message = new HumanMessage({ content: '<｜｜DSML｜｜invoke name="getNamespaces"></｜｜DSML｜｜invoke>' });
+    expect(recoverDsmlToolCalls(message)).toBe(message);
   });
 });

--- a/src/renderer/business/agent/leaked-tool-calls.ts
+++ b/src/renderer/business/agent/leaked-tool-calls.ts
@@ -8,7 +8,10 @@
 // ever invoked, and the tool-approval prompt never fires. Detecting it lets the
 // agent fail with an actionable message instead of dumping raw markup to the UI.
 
-import type { MessageContent } from "@langchain/core/messages";
+import { AIMessage, isAIMessage } from "@langchain/core/messages";
+
+import type { BaseMessage, MessageContent } from "@langchain/core/messages";
+import type { ToolCall } from "@langchain/core/messages/tool";
 
 // Shared, user-facing explanation for a leaked / missing structured tool call.
 export const LEAKED_TOOL_CALL_MESSAGE =
@@ -55,4 +58,135 @@ export const containsLeakedToolCallMarkup = (content: MessageContent): boolean =
     return false;
   }
   return LEAKED_TOOL_CALL_PATTERNS.some((pattern) => pattern.test(text));
+};
+
+// ---------------------------------------------------------------------------
+// DSML tool-call recovery
+// ---------------------------------------------------------------------------
+//
+// DeepSeek's "DSML" markup mirrors the Anthropic-style function-calling XML,
+// namespaced with `｜｜DSML｜｜` (bars are fullwidth U+FF5C). When the endpoint
+// does not parse it server-side it surfaces verbatim in the assistant text, for
+// example:
+//
+//   <｜｜DSML｜｜tool_calls>
+//     <｜｜DSML｜｜invoke name="listKubernetesResources">
+//       <｜｜DSML｜｜parameter name="kind" string="true">Pod</｜｜DSML｜｜parameter>
+//     </｜｜DSML｜｜invoke>
+//   </｜｜DSML｜｜tool_calls>
+//
+// Recovering these into structured `tool_calls` lets the agent graph execute the
+// tools instead of dumping the raw markup to the UI. The native token format
+// (`<｜tool▁calls▁begin｜>`) carries no parseable arguments, so it is left for the
+// `containsLeakedToolCallMarkup` guard to report.
+
+// Namespace fragment shared by every DSML tag: one or two bars, "DSML", one or
+// two bars. Tolerates ASCII "|" and surrounding whitespace.
+const DSML_NS = String.raw`[｜|]{1,2}\s*DSML\s*[｜|]{1,2}`;
+
+// A single `<｜｜DSML｜｜invoke name="...">...</｜｜DSML｜｜invoke>` block.
+const DSML_INVOKE_BLOCK = new RegExp(
+  String.raw`<\s*${DSML_NS}\s*invoke\b[^>]*?\bname\s*=\s*"([^"]*)"[^>]*?>([\s\S]*?)<\s*/\s*${DSML_NS}\s*invoke\s*>`,
+  "gi",
+);
+
+// A single `<｜｜DSML｜｜parameter name="..." [string="true"]>value</｜｜DSML｜｜parameter>`.
+const DSML_PARAMETER = new RegExp(
+  String.raw`<\s*${DSML_NS}\s*parameter\b([^>]*?)>([\s\S]*?)<\s*/\s*${DSML_NS}\s*parameter\s*>`,
+  "gi",
+);
+
+// Any DSML tag (open or close), used to strip leftover wrappers from the text.
+const DSML_ANY_TAG = new RegExp(String.raw`<\s*/?\s*${DSML_NS}[^>]*>`, "gi");
+
+const PARAM_NAME_ATTR = /\bname\s*=\s*"([^"]*)"/i;
+// DeepSeek marks a literal-string argument with `string="true"`; otherwise the
+// value is JSON (number, boolean, object, array).
+const PARAM_STRING_ATTR = /\bstring\s*=\s*"?\s*true\s*"?/i;
+
+const parseParamValue = (rawValue: string, isString: boolean): unknown => {
+  const value = rawValue.trim();
+  if (isString) {
+    return value;
+  }
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+};
+
+export interface ParsedDsmlToolCalls {
+  // The assistant text with all DSML markup removed (trimmed).
+  cleanedText: string;
+  // Structured tool calls recovered from the markup (empty when none found).
+  toolCalls: ToolCall[];
+}
+
+// Parse DeepSeek DSML tool-call markup out of assistant content. Returns the
+// recovered tool calls and the text with the markup stripped. When no DSML
+// `invoke` block is present, `toolCalls` is empty and `cleanedText` is the
+// original text (trimmed).
+export const parseDsmlToolCalls = (content: MessageContent): ParsedDsmlToolCalls => {
+  const text = toText(content);
+  const toolCalls: ToolCall[] = [];
+
+  if (!text) {
+    return { cleanedText: "", toolCalls };
+  }
+
+  let index = 0;
+  for (const invokeMatch of text.matchAll(DSML_INVOKE_BLOCK)) {
+    const name = invokeMatch[1]?.trim();
+    const body = invokeMatch[2] ?? "";
+    if (!name) {
+      continue;
+    }
+
+    const args: Record<string, unknown> = {};
+    for (const paramMatch of body.matchAll(DSML_PARAMETER)) {
+      const attrs = paramMatch[1] ?? "";
+      const nameAttr = attrs.match(PARAM_NAME_ATTR);
+      if (!nameAttr) {
+        continue;
+      }
+      args[nameAttr[1]] = parseParamValue(paramMatch[2] ?? "", PARAM_STRING_ATTR.test(attrs));
+    }
+
+    toolCalls.push({ name, args, id: `dsml_tool_call_${index}`, type: "tool_call" });
+    index++;
+  }
+
+  if (toolCalls.length === 0) {
+    return { cleanedText: text.trim(), toolCalls };
+  }
+
+  const cleanedText = text.replace(DSML_INVOKE_BLOCK, "").replace(DSML_ANY_TAG, "").trim();
+  return { cleanedText, toolCalls };
+};
+
+// When an assistant message carries DSML tool-call markup in its text but no
+// structured `tool_calls`, return a new message with the tool calls recovered
+// and the markup stripped. Messages that already have structured tool calls, or
+// that contain no recoverable DSML markup, are returned unchanged.
+export const recoverDsmlToolCalls = (message: BaseMessage): BaseMessage => {
+  if (!isAIMessage(message) || (message.tool_calls && message.tool_calls.length > 0)) {
+    return message;
+  }
+
+  const { cleanedText, toolCalls } = parseDsmlToolCalls(message.content);
+  if (toolCalls.length === 0) {
+    return message;
+  }
+
+  return new AIMessage({
+    id: message.id,
+    content: cleanedText,
+    tool_calls: toolCalls,
+    invalid_tool_calls: message.invalid_tool_calls,
+    additional_kwargs: message.additional_kwargs,
+    response_metadata: message.response_metadata,
+    usage_metadata: message.usage_metadata,
+    name: message.name,
+  });
 };

--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -1,0 +1,50 @@
+// A `ChatOpenAI` subclass for DeepSeek models served through OpenAI-compatible
+// endpoints that do not parse the model's native tool calls server-side.
+//
+// Those endpoints leak DeepSeek's "DSML" tool-call markup into the assistant
+// text instead of returning a structured `tool_calls` field. LangChain only
+// reads `tool_calls`, so the markup surfaces verbatim in the UI and no tool ever
+// runs. This client recovers the tool calls from the markup (see
+// `recoverDsmlToolCalls`) so the agent graph executes them normally.
+//
+// HTTP streaming is disabled (`disableStreaming = true`) so every request goes
+// through `_generate` and returns a single complete message: the DSML markup is
+// only recoverable once the whole tool-call block has arrived, and the
+// token-level streaming path would otherwise leak the markup to the UI before we
+// could rewrite it. Used only for DeepSeek models, so other models keep
+// token-by-token streaming intact.
+
+import { ChatOpenAI } from "@langchain/openai";
+import { recoverDsmlToolCalls } from "../agent/leaked-tool-calls";
+
+import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import type { BaseMessage } from "@langchain/core/messages";
+import type { ChatResult } from "@langchain/core/outputs";
+
+export class DsmlAwareChatOpenAI extends ChatOpenAI {
+  // Force the non-streaming `_generate` path; see the file header.
+  disableStreaming = true;
+
+  /** @ignore */
+  async _generate(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ): Promise<ChatResult> {
+    const result = await super._generate(messages, options, runManager);
+
+    const generations = result.generations.map((generation) => {
+      const message = recoverDsmlToolCalls(generation.message);
+      if (message === generation.message) {
+        return generation;
+      }
+      return {
+        ...generation,
+        message,
+        text: typeof message.content === "string" ? message.content : generation.text,
+      };
+    });
+
+    return { ...result, generations };
+  }
+}

--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -7,19 +7,19 @@
 // runs. This client recovers the tool calls from the markup (see
 // `recoverDsmlToolCalls`) so the agent graph executes them normally.
 //
-// `disableStreaming = true` routes the agent/langgraph calls through `_generate`
-// (instead of token-by-token `_streamResponseChunks`), so the DSML markup is
-// never streamed to the UI before we can rewrite it: the whole tool-call block
-// must have arrived before it is recoverable.
+// The caller (`model-provider.ts`) passes `streaming: true` in
+// `ChatOpenAIFields` — a class property would not survive the parent constructor
+// (`this.streaming = fields?.streaming ?? false`). Streaming the upstream HTTP
+// request prevents the proxy's `fetch` from timing out while waiting for slow
+// reasoning models. The parent `_generate` aggregates the upstream stream
+// internally; we drop the run manager so `_streamResponseChunks` skips
+// per-token callbacks (no raw DSML markup leaks to the UI token by token).
+// The whole tool-call block arrives complete before we recover it.
 //
-// The *upstream* HTTP request is still streamed (`streaming = true`), because a
-// non-streaming request to a slow reasoning endpoint makes the proxy's `fetch`
-// wait for the entire completion and time out with a bare "fetch failed" (502).
-// `_generate` streams the upstream response and aggregates it into a single
-// message; we pass no run manager to the super call so those per-token
-// callbacks are not forwarded to the agent's streaming handler (which would
-// leak the raw markup token by token). Used only for DeepSeek models, so other
-// models keep their normal token-by-token streaming intact.
+// We deliberately do NOT set `disableStreaming = true` — the ChatOpenAI
+// constructor overrides `this.streaming = false` when that flag is on, which
+// would defeat upstream streaming and cause 502 timeouts. Used only for DeepSeek
+// models so other models keep their normal token-by-token streaming.
 
 import { ChatOpenAI } from "@langchain/openai";
 import { recoverDsmlToolCalls } from "../agent/leaked-tool-calls";
@@ -29,13 +29,9 @@ import type { BaseMessage } from "@langchain/core/messages";
 import type { ChatResult } from "@langchain/core/outputs";
 
 export class DsmlAwareChatOpenAI extends ChatOpenAI {
-  // Force the agent-facing `_generate` path (no token-level streaming to the
-  // UI); see the file header.
-  disableStreaming = true;
-  // Keep the upstream request streamed so the proxy `fetch` is not left waiting
-  // for a full non-streaming completion (slow reasoning models -> "fetch
-  // failed"); see the file header.
-  streaming = true;
+  // `streaming` is set via `ChatOpenAIFields.streaming = true` by the caller
+  // (`model-provider.ts`) — a class property would be overridden by the
+  // ChatOpenAI constructor (`this.streaming = fields?.streaming ?? false`).
 
   /** @ignore */
   async _generate(
@@ -43,10 +39,11 @@ export class DsmlAwareChatOpenAI extends ChatOpenAI {
     options: this["ParsedCallOptions"],
     _runManager?: CallbackManagerForLLMRun,
   ): Promise<ChatResult> {
-    // Deliberately drop the run manager: `_generate` streams the upstream
-    // response internally, and forwarding its per-token callbacks would leak the
-    // raw DSML markup to the UI token by token. We aggregate here and hand back
-    // a single message with the tool calls recovered.
+    // Deliberately drop the run manager: `_streamResponseChunks` skips
+    // per-token callbacks when runManager is undefined, so the raw DSML markup
+    // is never forwarded to the UI token by token. The upstream response is
+    // still streamed (no timeout) and aggregated into a single message that we
+    // recover tool calls from.
     const result = await super._generate(messages, options, undefined);
 
     const generations = result.generations.map((generation) => {

--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -7,12 +7,19 @@
 // runs. This client recovers the tool calls from the markup (see
 // `recoverDsmlToolCalls`) so the agent graph executes them normally.
 //
-// HTTP streaming is disabled (`disableStreaming = true`) so every request goes
-// through `_generate` and returns a single complete message: the DSML markup is
-// only recoverable once the whole tool-call block has arrived, and the
-// token-level streaming path would otherwise leak the markup to the UI before we
-// could rewrite it. Used only for DeepSeek models, so other models keep
-// token-by-token streaming intact.
+// `disableStreaming = true` routes the agent/langgraph calls through `_generate`
+// (instead of token-by-token `_streamResponseChunks`), so the DSML markup is
+// never streamed to the UI before we can rewrite it: the whole tool-call block
+// must have arrived before it is recoverable.
+//
+// The *upstream* HTTP request is still streamed (`streaming = true`), because a
+// non-streaming request to a slow reasoning endpoint makes the proxy's `fetch`
+// wait for the entire completion and time out with a bare "fetch failed" (502).
+// `_generate` streams the upstream response and aggregates it into a single
+// message; we pass no run manager to the super call so those per-token
+// callbacks are not forwarded to the agent's streaming handler (which would
+// leak the raw markup token by token). Used only for DeepSeek models, so other
+// models keep their normal token-by-token streaming intact.
 
 import { ChatOpenAI } from "@langchain/openai";
 import { recoverDsmlToolCalls } from "../agent/leaked-tool-calls";
@@ -22,16 +29,25 @@ import type { BaseMessage } from "@langchain/core/messages";
 import type { ChatResult } from "@langchain/core/outputs";
 
 export class DsmlAwareChatOpenAI extends ChatOpenAI {
-  // Force the non-streaming `_generate` path; see the file header.
+  // Force the agent-facing `_generate` path (no token-level streaming to the
+  // UI); see the file header.
   disableStreaming = true;
+  // Keep the upstream request streamed so the proxy `fetch` is not left waiting
+  // for a full non-streaming completion (slow reasoning models -> "fetch
+  // failed"); see the file header.
+  streaming = true;
 
   /** @ignore */
   async _generate(
     messages: BaseMessage[],
     options: this["ParsedCallOptions"],
-    runManager?: CallbackManagerForLLMRun,
+    _runManager?: CallbackManagerForLLMRun,
   ): Promise<ChatResult> {
-    const result = await super._generate(messages, options, runManager);
+    // Deliberately drop the run manager: `_generate` streams the upstream
+    // response internally, and forwarding its per-token callbacks would leak the
+    // raw DSML markup to the UI token by token. We aggregate here and hand back
+    // a single message with the tool calls recovered.
+    const result = await super._generate(messages, options, undefined);
 
     const generations = result.generations.map((generation) => {
       const message = recoverDsmlToolCalls(generation.message);

--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -8,19 +8,28 @@
 // `recoverDsmlToolCalls`) so the agent graph executes them normally.
 //
 // The caller (`model-provider.ts`) passes `streaming: true` in
-// `ChatOpenAIFields` — a class property would not survive the parent constructor
-// (`this.streaming = fields?.streaming ?? false`). Streaming the upstream HTTP
-// request prevents the proxy's `fetch` from timing out while waiting for slow
-// reasoning models. The parent `_generate` aggregates the upstream stream
-// internally; we drop the run manager so `_streamResponseChunks` skips
-// per-token callbacks (no raw DSML markup leaks to the UI token by token).
-// The whole tool-call block arrives complete before we recover it.
+// `ChatOpenAIFields` so the upstream HTTP request is streamed (no timeout on
+// slow reasoning models). We override both `_streamResponseChunks` and
+// `_generate` to aggregate the streamed response and recover DSML tool calls
+// before the result reaches the agent graph or the UI.
+//
+// - `_streamResponseChunks` — the primary path. When the agent has a streaming
+//   handler, `_generateUncached` calls `_streamResponseChunks` directly,
+//   bypassing `_generate`. Our override aggregates all chunks without
+//   forwarding per-token callbacks (the run manager is dropped), recovers DSML
+//   tool calls from the aggregated content, and yields a single cleaned chunk.
+// - `_generate` — the fallback path. Taken when there is no streaming handler
+//   (e.g. tool-only calls). `_streamResponseChunks` is called internally by
+//   `ChatOpenAI._generate` and our override already handles aggregation and
+//   recovery, so the extra `recoverDsmlToolCalls` here is a safe no-op.
 //
 // We deliberately do NOT set `disableStreaming = true` — the ChatOpenAI
 // constructor overrides `this.streaming = false` when that flag is on, which
-// would defeat upstream streaming and cause 502 timeouts. Used only for DeepSeek
-// models so other models keep their normal token-by-token streaming.
+// would defeat upstream streaming and cause 502 timeouts. Used only for
+// DeepSeek models so other models keep their normal token-by-token streaming.
 
+import { ChatGenerationChunk } from "@langchain/core/outputs";
+import { concat } from "@langchain/core/utils/stream";
 import { ChatOpenAI } from "@langchain/openai";
 import { recoverDsmlToolCalls } from "../agent/leaked-tool-calls";
 
@@ -33,17 +42,64 @@ export class DsmlAwareChatOpenAI extends ChatOpenAI {
   // (`model-provider.ts`) — a class property would be overridden by the
   // ChatOpenAI constructor (`this.streaming = fields?.streaming ?? false`).
 
+  /**
+   * Aggregate all streamed chunks into a single result without forwarding
+   * per-token callbacks to the UI. When the agent has a streaming handler,
+   * `_generateUncached` calls `_streamResponseChunks` directly — bypassing
+   * `_generate`. This override ensures no raw DSML markup leaks and recovers
+   * tool calls from the aggregated content.
+   *
+   * @ignore
+   */
+  async *_streamResponseChunks(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    _runManager?: CallbackManagerForLLMRun,
+  ): AsyncGenerator<ChatGenerationChunk> {
+    // Drop the run manager so `ChatOpenAI._streamResponseChunks` does not
+    // forward per-token callbacks (raw DSML markup would leak). The upstream
+    // HTTP request is still streamed — only the callbacks are suppressed.
+    let aggregated: ChatGenerationChunk | undefined;
+
+    for await (const chunk of super._streamResponseChunks(messages, options, undefined)) {
+      if (aggregated === undefined) {
+        aggregated = chunk;
+      } else {
+        aggregated = concat(aggregated, chunk);
+      }
+    }
+
+    if (aggregated === undefined) {
+      return; // empty stream — let the caller handle it
+    }
+
+    // Recover DSML tool calls from the aggregated content before yielding.
+    const recovered = recoverDsmlToolCalls(aggregated.message);
+    if (recovered !== aggregated.message) {
+      // AIMessage works as a drop-in for BaseMessageChunk when no further
+      // concat is needed (we aggregate everything into a single chunk here).
+      aggregated = new ChatGenerationChunk({
+        message: recovered as unknown as ChatGenerationChunk["message"],
+        text: typeof recovered.content === "string" ? recovered.content : aggregated.text,
+        generationInfo: aggregated.generationInfo,
+      });
+    }
+
+    yield aggregated;
+  }
+
   /** @ignore */
   async _generate(
     messages: BaseMessage[],
     options: this["ParsedCallOptions"],
     _runManager?: CallbackManagerForLLMRun,
   ): Promise<ChatResult> {
-    // Deliberately drop the run manager: `_streamResponseChunks` skips
-    // per-token callbacks when runManager is undefined, so the raw DSML markup
-    // is never forwarded to the UI token by token. The upstream response is
-    // still streamed (no timeout) and aggregated into a single message that we
-    // recover tool calls from.
+    // This path is taken when `_generateUncached` does NOT detect a streaming
+    // handler (e.g. tool-only calls or when disableStreaming forces the
+    // else-branch). `_streamResponseChunks` is called internally by
+    // `ChatOpenAI._generate` and our override above already aggregates and
+    // recovers DSML, so `recoverDsmlToolCalls` here is a safe no-op when
+    // already recovered.
     const result = await super._generate(messages, options, undefined);
 
     const generations = result.generations.map((generation) => {

--- a/src/renderer/business/provider/model-capabilities.test.ts
+++ b/src/renderer/business/provider/model-capabilities.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { isReasoningModel, requiresAutoToolChoice, supportsTemperature } from "./model-capabilities";
+import {
+  emitsDsmlToolCalls,
+  isReasoningModel,
+  requiresAutoToolChoice,
+  supportsTemperature,
+} from "./model-capabilities";
 
 describe("isReasoningModel", () => {
   it.each([
@@ -38,6 +43,20 @@ describe("requiresAutoToolChoice", () => {
 
   it.each(["gpt-5.5", "gpt-5.4", "gpt-4o", "o3-mini", ""])("keeps forced tool_choice for %s", (name) => {
     expect(requiresAutoToolChoice(name)).toBe(false);
+  });
+});
+
+describe("emitsDsmlToolCalls", () => {
+  it.each([
+    "deepseek-v4-pro",
+    "deepseek-reasoner",
+    "DeepSeek-V4",
+  ])("flags DeepSeek model %s as DSML-emitting", (name) => {
+    expect(emitsDsmlToolCalls(name)).toBe(true);
+  });
+
+  it.each(["gpt-5.5", "gpt-4o", "qwen3-235b", "o3-mini", ""])("does not flag %s", (name) => {
+    expect(emitsDsmlToolCalls(name)).toBe(false);
   });
 });
 

--- a/src/renderer/business/provider/model-capabilities.ts
+++ b/src/renderer/business/provider/model-capabilities.ts
@@ -23,3 +23,15 @@ const FORCED_TOOL_CHOICE_UNSUPPORTED_PATTERNS: RegExp[] = [/deepseek/i, /qwen/i]
 
 export const requiresAutoToolChoice = (modelName: string): boolean =>
   FORCED_TOOL_CHOICE_UNSUPPORTED_PATTERNS.some((pattern) => pattern.test(modelName));
+
+// DeepSeek models emit native tool calls in their "DSML" markup
+// (`<｜｜DSML｜｜invoke name="...">`). OpenAI-compatible endpoints that lack a
+// server-side tool-call parser leak this markup into the assistant text instead
+// of returning structured `tool_calls`, so no tool ever runs. For these models
+// we use a client that recovers the tool calls from the markup (see
+// `dsml-aware-chat-model.ts`). Extend the pattern list when another family is
+// found to emit the same markup.
+const DSML_TOOL_CALL_PATTERNS: RegExp[] = [/deepseek/i];
+
+export const emitsDsmlToolCalls = (modelName: string): boolean =>
+  DSML_TOOL_CALL_PATTERNS.some((pattern) => pattern.test(modelName));

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -3,6 +3,8 @@
 import { ChatOpenAI } from "@langchain/openai";
 import { PreferencesStore } from "../../../common/store";
 import { AIProviders, DEFAULT_OPENAI_BASE_URL } from "./ai-models";
+import { DsmlAwareChatOpenAI } from "./dsml-aware-chat-model";
+import { emitsDsmlToolCalls } from "./model-capabilities";
 import { findProvider } from "./model-list";
 import { buildOpenAIChatFields } from "./openai-fields";
 
@@ -47,6 +49,13 @@ export const useModelProvider = () => {
           reasoningEffort: preferencesStore.openAIReasoningEffort,
           disableThinking: preferencesStore.disableThinking,
         });
+
+        // DeepSeek models leak their native "DSML" tool-call markup into the
+        // assistant text when the endpoint has no server-side tool-call parser.
+        // Use a client that recovers those tool calls so the agents can run them.
+        if (emitsDsmlToolCalls(modelName)) {
+          return new DsmlAwareChatOpenAI(fields);
+        }
 
         return new ChatOpenAI(fields);
       }

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -54,7 +54,7 @@ export const useModelProvider = () => {
         // assistant text when the endpoint has no server-side tool-call parser.
         // Use a client that recovers those tool calls so the agents can run them.
         if (emitsDsmlToolCalls(modelName)) {
-          return new DsmlAwareChatOpenAI(fields);
+          return new DsmlAwareChatOpenAI({ ...fields, streaming: true });
         }
 
         return new ChatOpenAI(fields);


### PR DESCRIPTION
Workaround for DeepSeek's DSML tool-call markup leaking into chat text (issue #127).

For DeepSeek models, the extension now parses the DSML `invoke`/`parameter` markup back into structured tool calls so the agents actually execute the tools, instead of only failing with an error.

- `parseDsmlToolCalls`/`recoverDsmlToolCalls` parse and strip the markup
- `DsmlAwareChatOpenAI` recovers tool calls in `_generate` (streaming disabled), covering all agents
- `emitsDsmlToolCalls` flags DeepSeek models; only they use the DSML-aware client

Closes #127
