### PR TITLE
Add pod logs tool with approval gate and preferences

### DIFF
--- a/src/common/store/preferences-store.ts
+++ b/src/common/store/preferences-store.ts
@@ -18,9 +18,13 @@ export interface PreferencesModel {
   models: CustomModel[];
   mcpEnabled: boolean;
   mcpConfiguration: string;
+  podLogsRequireApproval: boolean;
+  podLogsTailLines: number;
   // ollamaHost: string;
   // ollamaPort: string;
 }
+
+export const DEFAULT_POD_LOGS_TAIL_LINES = 1000;
 
 export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesModel> {
   // Persistent
@@ -34,6 +38,11 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
   models: CustomModel[] = [...DEFAULT_MODELS];
   mcpEnabled: boolean = false;
   mcpConfiguration: string = "";
+  // When enabled, reading pod logs goes through the human-in-the-loop approval
+  // gate (logs can contain secrets/PII). Enabled by default.
+  podLogsRequireApproval: boolean = true;
+  // Default number of tail lines fetched when reading pod logs.
+  podLogsTailLines: number = DEFAULT_POD_LOGS_TAIL_LINES;
   // ollamaHost: string = "";
   // ollamaPort: string = "";
 
@@ -55,6 +64,8 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
         selectedModel: DEFAULT_SELECTED_MODEL,
         models: [...DEFAULT_MODELS],
         mcpEnabled: false,
+        podLogsRequireApproval: true,
+        podLogsTailLines: DEFAULT_POD_LOGS_TAIL_LINES,
         mcpConfiguration: JSON.stringify(
           {
             mcpServers: {
@@ -87,6 +98,8 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
       models: observable,
       mcpEnabled: observable,
       mcpConfiguration: observable,
+      podLogsRequireApproval: observable,
+      podLogsTailLines: observable,
       // ollamaHost: observable,
       // ollamaPort: observable,
       explainEvent: observable,
@@ -111,6 +124,11 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
     this.selectedModel = resolveSelectedModel(this.models, preferencesModel.selectedModel);
     this.mcpEnabled = preferencesModel.mcpEnabled;
     this.mcpConfiguration = preferencesModel.mcpConfiguration;
+    this.podLogsRequireApproval = preferencesModel.podLogsRequireApproval ?? true;
+    this.podLogsTailLines =
+      typeof preferencesModel.podLogsTailLines === "number" && preferencesModel.podLogsTailLines > 0
+        ? preferencesModel.podLogsTailLines
+        : DEFAULT_POD_LOGS_TAIL_LINES;
     // this.ollamaHost = preferencesModel.ollamaHost;
     // this.ollamaPort = preferencesModel.ollamaPort;
   }
@@ -132,6 +150,8 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
       models: toJS(this.models),
       mcpEnabled: this.mcpEnabled,
       mcpConfiguration: this.mcpConfiguration,
+      podLogsRequireApproval: this.podLogsRequireApproval,
+      podLogsTailLines: this.podLogsTailLines,
       // ollamaHost: this.ollamaHost,
       // ollamaPort: this.ollamaPort,
     };

--- a/src/renderer/business/agent/analyzer-agent.ts
+++ b/src/renderer/business/agent/analyzer-agent.ts
@@ -4,6 +4,7 @@ import { AGENT_ANALYZER_PROMPT_TEMPLATE } from "../provider/prompt-template-prov
 import {
   getKubernetesResource,
   getNamespaces,
+  getPodLogs,
   getWarningEventsByNamespace,
   listKubernetesResources,
 } from "./tools/tools";
@@ -16,7 +17,7 @@ export const useAgentAnalyzer = () => {
       model &&
       createReactAgent({
         llm: model,
-        tools: [getNamespaces, getWarningEventsByNamespace, listKubernetesResources, getKubernetesResource],
+        tools: [getNamespaces, getWarningEventsByNamespace, listKubernetesResources, getKubernetesResource, getPodLogs],
         stateModifier: AGENT_ANALYZER_PROMPT_TEMPLATE,
       })
     );

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -23,7 +23,7 @@ export const useFreeLensAgentSystem = () => {
   const subAgents = ["agentAnalyzer", "kubernetesOperator", "generalPurposeAgent"];
   const conclusionsAgentName = "conclusionsAgent";
   const subAgentResponsibilities = [
-    "agentAnalyzer: Reads and inspects live cluster resources (pods, deployments, services, CRDs, and other kinds), events, namespaces, warnings and errors. Use it for any read-only query about the current state of the cluster.",
+    "agentAnalyzer: Reads and inspects live cluster resources (pods, deployments, services, CRDs, and other kinds), events, namespaces, warnings and errors, and reads container logs from pods. Use it for any read-only query about the current state of the cluster, including requests to view, read, show, or tail pod/container logs.",
     'kubernetesOperator: Performs any change to the cluster - create, update, replace, patch, annotate, label, scale, restart, delete resources, and trigger operations such as Flux/Argo reconciliation (which is done by patching an annotation). Route here for any request that modifies, triggers, reconciles, restarts, scales, suspends, resumes, rolls out, or applies anything, even when the request uses tool-specific jargon instead of the word "write".',
     "generalPurposeAgent: Handles general queries including but not limited to: Kubernetes conceptual explanations, best practices, architecture patterns, and non-Kubernetes technical questions. This agent doesn't interact with the live cluster but provides comprehensive knowledge-based responses.",
   ];

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -1,5 +1,14 @@
 import { Renderer } from "@freelensapp/extensions";
 import { interrupt } from "@langchain/langgraph";
+import { PreferencesStore } from "../../../../common/store";
+import {
+  capLogOutput,
+  capTailLines,
+  collectContainerNames,
+  emptyLogsMessage,
+  type GetPodLogsInput,
+  resolveContainer,
+} from "./pod-logs";
 import { type Manifest, prepareManifest, resolveApiVersion, validateManifest } from "./resource-handlers";
 
 type KubeApi = Renderer.K8sApi.KubeApi;
@@ -321,6 +330,77 @@ export async function deleteKubernetesResource({
     return `${kind} deleted successfully`;
   } catch (error) {
     console.error("[Tool invocation error: deleteKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Read a one-shot snapshot of container logs from a pod. Loads the pod to
+ * enumerate its containers, runs the optional approval gate (controlled by the
+ * `podLogsRequireApproval` preference), then fetches the logs and caps the
+ * output so it cannot overflow the model context.
+ */
+export async function getPodLogs(input: GetPodLogsInput): Promise<string> {
+  const { name, namespace, container, previous, timestamps } = input;
+  console.log(
+    "[Tool invocation: getPodLogs] - name:",
+    name,
+    "namespace:",
+    namespace,
+    "container:",
+    container,
+    "previous:",
+    previous,
+  );
+
+  if (!namespace) {
+    return `Pods are namespaced; please provide a namespace to read logs for "${name}".`;
+  }
+
+  const podsApi = Renderer.K8sApi.podsApi;
+  const store = Renderer.K8sApi.apiManager.getStore(podsApi);
+  if (!store) {
+    return "Could not resolve the Pods store.";
+  }
+
+  let pod: KubeObject | undefined;
+  try {
+    pod = await store.load({ name, namespace });
+  } catch (error) {
+    console.error("[Tool invocation error: getPodLogs] - ", error);
+    return JSON.stringify(error);
+  }
+  if (!pod) {
+    return `The Pod "${name}" was not found in namespace "${namespace}".`;
+  }
+
+  const resolution = resolveContainer(container, collectContainerNames(pod.spec));
+  if (resolution.kind !== "resolved") {
+    return resolution.message;
+  }
+  const selectedContainer = resolution.container;
+
+  const preferences = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
+  const tailLines = capTailLines(input.tailLines, preferences.podLogsTailLines);
+
+  if (
+    preferences.podLogsRequireApproval &&
+    !requestApproval("READ LOGS POD", { name, namespace, container: selectedContainer, previous })
+  ) {
+    return "The user denied the action";
+  }
+
+  try {
+    const logs = await podsApi.getLogs(
+      { name, namespace },
+      { container: selectedContainer, tailLines, timestamps, previous },
+    );
+    if (!logs || logs.trim().length === 0) {
+      return emptyLogsMessage(selectedContainer, name, previous);
+    }
+    return capLogOutput(logs);
+  } catch (error) {
+    console.error("[Tool invocation error: getPodLogs] - ", error);
     return JSON.stringify(error);
   }
 }

--- a/src/renderer/business/agent/tools/pod-logs.test.ts
+++ b/src/renderer/business/agent/tools/pod-logs.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import {
+  capLogOutput,
+  capTailLines,
+  collectContainerNames,
+  MAX_TAIL_LINES,
+  resolveContainer,
+  TRUNCATION_MARKER,
+} from "./pod-logs";
+
+describe("collectContainerNames", () => {
+  it("collects names from containers, initContainers and ephemeralContainers", () => {
+    const spec = {
+      containers: [{ name: "app" }, { name: "sidecar" }],
+      initContainers: [{ name: "init" }],
+      ephemeralContainers: [{ name: "debug" }],
+    };
+    expect(collectContainerNames(spec)).toEqual({
+      containers: ["app", "sidecar"],
+      initContainers: ["init"],
+      ephemeralContainers: ["debug"],
+    });
+  });
+
+  it("ignores entries without a string name and missing arrays", () => {
+    const spec = { containers: [{ name: "app" }, {}, { name: 5 }, null] };
+    expect(collectContainerNames(spec)).toEqual({
+      containers: ["app"],
+      initContainers: [],
+      ephemeralContainers: [],
+    });
+  });
+
+  it("handles a non-object spec", () => {
+    expect(collectContainerNames(undefined)).toEqual({
+      containers: [],
+      initContainers: [],
+      ephemeralContainers: [],
+    });
+  });
+});
+
+describe("resolveContainer", () => {
+  const names = { containers: ["app", "sidecar"], initContainers: ["init"], ephemeralContainers: [] };
+
+  it("resolves the only container when none is requested", () => {
+    expect(resolveContainer(undefined, { containers: ["solo"], initContainers: [], ephemeralContainers: [] })).toEqual({
+      kind: "resolved",
+      container: "solo",
+    });
+  });
+
+  it("asks which container to use for a multi-container pod", () => {
+    const result = resolveContainer(undefined, names);
+    expect(result.kind).toBe("ask");
+    expect(result.kind === "ask" && result.message).toContain("app");
+    expect(result.kind === "ask" && result.message).toContain("sidecar");
+  });
+
+  it("resolves a requested container including init containers", () => {
+    expect(resolveContainer("init", names)).toEqual({ kind: "resolved", container: "init" });
+  });
+
+  it("errors when the requested container does not exist", () => {
+    const result = resolveContainer("missing", names);
+    expect(result.kind).toBe("error");
+    expect(result.kind === "error" && result.message).toContain("app");
+  });
+
+  it("errors when the pod has no containers", () => {
+    const result = resolveContainer(undefined, { containers: [], initContainers: [], ephemeralContainers: [] });
+    expect(result.kind).toBe("error");
+  });
+});
+
+describe("capTailLines", () => {
+  it("uses the requested value when valid", () => {
+    expect(capTailLines(500, 1000)).toBe(500);
+  });
+
+  it("falls back to the configured default when the request is missing or invalid", () => {
+    expect(capTailLines(undefined, 1000)).toBe(1000);
+    expect(capTailLines(0, 1000)).toBe(1000);
+    expect(capTailLines(-5, 1000)).toBe(1000);
+    expect(capTailLines(Number.NaN, 1000)).toBe(1000);
+  });
+
+  it("hard-caps the value regardless of request or configuration", () => {
+    expect(capTailLines(MAX_TAIL_LINES + 1, 1000)).toBe(MAX_TAIL_LINES);
+    expect(capTailLines(undefined, MAX_TAIL_LINES + 1000)).toBe(MAX_TAIL_LINES);
+  });
+
+  it("floors fractional values", () => {
+    expect(capTailLines(10.9, 1000)).toBe(10);
+  });
+});
+
+describe("capLogOutput", () => {
+  it("returns short logs unchanged", () => {
+    expect(capLogOutput("hello world", 1024)).toBe("hello world");
+  });
+
+  it("keeps the tail and prepends the truncation marker when over the byte cap", () => {
+    const logs = "a".repeat(100);
+    const result = capLogOutput(logs, 10);
+    expect(result.startsWith(TRUNCATION_MARKER)).toBe(true);
+    expect(result.endsWith("a".repeat(10))).toBe(true);
+    expect(result).not.toBe(logs);
+  });
+
+  it("measures multi-byte characters by bytes", () => {
+    // Each "€" is 3 bytes; 10 of them is 30 bytes, over a 12-byte cap.
+    const logs = "€".repeat(10);
+    const result = capLogOutput(logs, 12);
+    expect(result.startsWith(TRUNCATION_MARKER)).toBe(true);
+  });
+});

--- a/src/renderer/business/agent/tools/pod-logs.ts
+++ b/src/renderer/business/agent/tools/pod-logs.ts
@@ -1,0 +1,116 @@
+export interface GetPodLogsInput {
+  name: string;
+  namespace: string;
+  container?: string;
+  previous?: boolean;
+  tailLines?: number;
+  timestamps?: boolean;
+}
+
+// Hard cap on the bytes returned to the model so a chatty pod cannot overflow
+// the model context. The most recent (tail) portion is kept.
+export const MAX_LOG_BYTES = 256 * 1024;
+// Hard cap on tail lines regardless of the configured/requested value.
+export const MAX_TAIL_LINES = 10000;
+export const TRUNCATION_MARKER = "...[truncated]...\n";
+
+export interface PodContainerNames {
+  containers: string[];
+  initContainers: string[];
+  ephemeralContainers: string[];
+}
+
+export type ContainerResolution =
+  | { kind: "resolved"; container: string }
+  | { kind: "ask"; message: string }
+  | { kind: "error"; message: string };
+
+/**
+ * Collect the container names declared on a pod spec. The spec is typed as
+ * `unknown` because the generic host store does not narrow it to a Pod; the
+ * shape is validated at runtime here (no instance methods, per the CRD rule).
+ */
+export function collectContainerNames(spec: unknown): PodContainerNames {
+  const readNames = (value: unknown): string[] => {
+    if (!Array.isArray(value)) {
+      return [];
+    }
+    return value
+      .map((entry) => (entry && typeof entry === "object" ? (entry as { name?: unknown }).name : undefined))
+      .filter((name): name is string => typeof name === "string" && name.length > 0);
+  };
+
+  const podSpec = spec && typeof spec === "object" ? (spec as Record<string, unknown>) : {};
+  return {
+    containers: readNames(podSpec.containers),
+    initContainers: readNames(podSpec.initContainers),
+    ephemeralContainers: readNames(podSpec.ephemeralContainers),
+  };
+}
+
+/**
+ * Decide which container's logs to read. When the container is omitted on a
+ * multi-container pod the model is asked to pick one instead of guessing.
+ */
+export function resolveContainer(requested: string | undefined, names: PodContainerNames): ContainerResolution {
+  const allNames = [...names.containers, ...names.initContainers, ...names.ephemeralContainers];
+
+  if (requested) {
+    if (allNames.includes(requested)) {
+      return { kind: "resolved", container: requested };
+    }
+    return {
+      kind: "error",
+      message: `Container "${requested}" was not found in the pod. Available containers: ${allNames.join(", ") || "(none)"}.`,
+    };
+  }
+
+  if (allNames.length === 0) {
+    return { kind: "error", message: "The pod has no containers to read logs from." };
+  }
+  if (allNames.length === 1) {
+    return { kind: "resolved", container: allNames[0] };
+  }
+  return {
+    kind: "ask",
+    message: `The pod has multiple containers; specify which one to read. Available containers: ${allNames.join(", ")}.`,
+  };
+}
+
+/**
+ * Clamp the tail-lines value to a sane, hard-capped range, falling back to the
+ * configured default when the requested value is missing or invalid.
+ */
+export function capTailLines(requested: number | undefined, configured: number): number {
+  const fallback = Number.isFinite(configured) && configured > 0 ? Math.floor(configured) : MAX_TAIL_LINES;
+  const base = typeof requested === "number" && Number.isFinite(requested) && requested > 0 ? requested : fallback;
+  return Math.min(Math.floor(base), MAX_TAIL_LINES);
+}
+
+/**
+ * Byte-cap the log output, keeping the most recent (tail) portion and marking
+ * the truncation. Measured with TextEncoder so multi-byte characters count
+ * correctly.
+ */
+export function capLogOutput(logs: string, maxBytes: number = MAX_LOG_BYTES): string {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(logs);
+  if (bytes.length <= maxBytes) {
+    return logs;
+  }
+  const tail = bytes.slice(bytes.length - maxBytes);
+  // A byte-slice may start in the middle of a multi-byte character; the decoder
+  // replaces the partial leading bytes gracefully.
+  const decoded = new TextDecoder().decode(tail);
+  return TRUNCATION_MARKER + decoded;
+}
+
+/**
+ * Build the message returned when a pod produced no log output, hinting at the
+ * previous-instance option for containers that have not started yet.
+ */
+export function emptyLogsMessage(container: string, name: string, previous: boolean | undefined): string {
+  return previous
+    ? `No previous logs for container "${container}" in pod "${name}". The container may not have a terminated instance.`
+    : `No logs for container "${container}" in pod "${name}". The container may not have started yet; try previous: true to read the last terminated instance.`;
+}

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -5,6 +5,7 @@ import {
   createKubernetesResource as createKubernetesResourceImpl,
   deleteKubernetesResource as deleteKubernetesResourceImpl,
   getKubernetesResource as getKubernetesResourceImpl,
+  getPodLogs as getPodLogsImpl,
   listKubernetesResources as listKubernetesResourcesImpl,
   patchKubernetesResource as patchKubernetesResourceImpl,
   updateKubernetesResource as updateKubernetesResourceImpl,
@@ -144,6 +145,29 @@ export const patchKubernetesResource = tool(patchKubernetesResourceImpl, {
   }),
 });
 
+export const getPodLogs = tool(getPodLogsImpl, {
+  name: "getPodLogs",
+  description:
+    "Read a one-shot snapshot of container logs from a pod. Namespace is required. If the container is omitted on a multi-container pod, the available containers are returned so one can be chosen. Use previous: true to read the last terminated instance (useful for CrashLoopBackOff).",
+  schema: z.object({
+    name: z.string().describe("The name of the pod"),
+    namespace: z.string().describe("The namespace of the pod"),
+    container: z
+      .string()
+      .optional()
+      .describe("The container to read logs from (required only for multi-container pods)"),
+    previous: z
+      .boolean()
+      .optional()
+      .describe("Read logs from the previous (terminated) container instance, e.g. for CrashLoopBackOff"),
+    tailLines: z
+      .number()
+      .optional()
+      .describe("Number of lines from the end of the logs to read (defaults to the preference value)"),
+    timestamps: z.boolean().optional().describe("Prefix every log line with an RFC3339 timestamp"),
+  }),
+});
+
 export const deleteKubernetesResource = tool(deleteKubernetesResourceImpl, {
   name: "deleteKubernetesResource",
   description: "Delete a Kubernetes resource by name (namespace required for namespaced kinds)",
@@ -160,6 +184,7 @@ export const allToolFunctions = [
   getWarningEventsByNamespace,
   listKubernetesResources,
   getKubernetesResource,
+  getPodLogs,
   createKubernetesResource,
   updateKubernetesResource,
   patchKubernetesResource,
@@ -195,6 +220,14 @@ export const toolFunctionDescriptions = [
     arguments:
       "Requires the resource kind (string) and name (string), and optionally the apiVersion (string). Namespace (string) is required for namespaced kinds.",
     returnType: "Returns a JSON string containing the requested resource.",
+  },
+  {
+    name: "getPodLogs",
+    description: "Read a one-shot snapshot of container logs from a pod",
+    arguments:
+      "Requires the pod name (string) and namespace (string), and optionally the container (string; required only for multi-container pods), previous (boolean, for terminated instances), tailLines (number) and timestamps (boolean).",
+    returnType:
+      "Returns the (possibly truncated) container logs as a string, or the list of containers to choose from for multi-container pods.",
   },
   {
     name: "createKubernetesResource",

--- a/src/renderer/business/provider/prompt-template-provider.ts
+++ b/src/renderer/business/provider/prompt-template-provider.ts
@@ -31,6 +31,7 @@ You are an expert Kubernetes Assistant Agent, powered by Freelens-AI.
 Your primary role is to help users understand, manage, and troubleshoot their Kubernetes clusters.
 You should assist with:
 - Analyzing cluster state and events
+- Reading container logs from pods (one-shot snapshots; ask again for fresher logs). For multi-container pods, pick a container or ask the user which one; use the previous-instance option to troubleshoot CrashLoopBackOff
 - Diagnosing issues and providing solutions
 - Suggesting best practices and improvements
 

--- a/src/renderer/pages/preferences/preferences-page.tsx
+++ b/src/renderer/pages/preferences/preferences-page.tsx
@@ -9,7 +9,7 @@ import type { SingleValue } from "react-select";
 const { observer } = MobxReact;
 const { useState } = React;
 
-import { PreferencesStore } from "../../../common/store";
+import { DEFAULT_POD_LOGS_TAIL_LINES, PreferencesStore } from "../../../common/store";
 
 const {
   Component: { Button, Icon, Input, Select, Switch, HorizontalLine },
@@ -182,6 +182,35 @@ export const PreferencesPage = observer(() => {
           />
         </div>
       </div>
+
+      <HorizontalLine />
+
+      <div style={{ fontWeight: "bold", fontSize: 16 }}>Pod logs</div>
+      <div style={{ marginTop: 8, fontWeight: "bold" }}>Require approval before reading pod logs</div>
+      <div style={{ fontSize: 12, marginBottom: 4, opacity: 0.7 }}>
+        Pod logs can contain secrets or personal data. When enabled, the agent asks for confirmation before reading
+        container logs.
+      </div>
+      <Switch
+        style={{ marginBottom: 8 }}
+        label="Require approval before reading pod logs"
+        checked={preferencesStore.podLogsRequireApproval}
+        onChange={(checked: boolean) => (preferencesStore.podLogsRequireApproval = checked)}
+      />
+      <div style={{ marginTop: 8, fontWeight: "bold" }}>Default tail lines</div>
+      <div style={{ fontSize: 12, marginBottom: 4, opacity: 0.7 }}>
+        Number of lines read from the end of the logs when the agent does not request a specific amount.
+      </div>
+      <Input
+        type="number"
+        placeholder={String(DEFAULT_POD_LOGS_TAIL_LINES)}
+        value={String(preferencesStore.podLogsTailLines)}
+        onChange={(value: string) => {
+          const parsed = Number.parseInt(value, 10);
+          preferencesStore.podLogsTailLines =
+            Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_POD_LOGS_TAIL_LINES;
+        }}
+      />
     </>
   );
 });


### PR DESCRIPTION
Adds a read-only `getPodLogs` tool to the analyzer agent, gated behind a configurable approval toggle. One-shot snapshot, capped to a configurable tail-lines count and a hard byte limit.

Closes #130