### PR TITLE
Show a clear error when the AI tries to use an unsupported tool

### DIFF
--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -6,11 +6,16 @@ import { useAgentAnalyzer } from "./analyzer-agent";
 import { useConclusionsAgent } from "./conclusions-agent";
 import { useGeneralPurposeAgent } from "./general-purpose-agent";
 import { useAgentKubernetesOperator } from "./kubernetes-operator-agent";
-import { containsLeakedToolCallMarkup, LEAKED_TOOL_CALL_MESSAGE } from "./leaked-tool-calls";
+import {
+  buildUnsupportedToolCallMessage,
+  containsLeakedToolCallMarkup,
+  findUnknownToolCalls,
+  LEAKED_TOOL_CALL_MESSAGE,
+} from "./leaked-tool-calls";
 import { teardownNode } from "./nodes/teardown";
 import { GraphState } from "./state/graph-state";
 import { useAgentSupervisor } from "./supervisor-agent";
-import { toolFunctionDescriptions } from "./tools/tools";
+import { allToolNames, toolFunctionDescriptions } from "./tools/tools";
 
 export type FreeLensAgent = ReturnType<ReturnType<typeof useFreeLensAgentSystem>["buildAgentSystem"]>;
 
@@ -64,6 +69,11 @@ export const useFreeLensAgentSystem = () => {
     const result = await agentAnalyzer.invoke(state);
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("Analyzer Agent - analysis result: ", result);
+    const analyzerUnknownTools = findUnknownToolCalls(result.messages, allToolNames);
+    if (analyzerUnknownTools.length > 0) {
+      log.error("Analyzer Agent - unsupported tool call requested", analyzerUnknownTools);
+      throw new Error(buildUnsupportedToolCallMessage(analyzerUnknownTools));
+    }
     if (containsLeakedToolCallMarkup(lastMessage.content)) {
       log.error("Analyzer Agent - leaked tool-call markup in response", lastMessage.content);
       throw new Error(LEAKED_TOOL_CALL_MESSAGE);
@@ -82,6 +92,11 @@ export const useFreeLensAgentSystem = () => {
     const result = await agentKubernetesOperator.invoke(state);
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("Kubernetes Operator - k8s operator result: ", result);
+    const operatorUnknownTools = findUnknownToolCalls(result.messages, allToolNames);
+    if (operatorUnknownTools.length > 0) {
+      log.error("Kubernetes Operator - unsupported tool call requested", operatorUnknownTools);
+      throw new Error(buildUnsupportedToolCallMessage(operatorUnknownTools));
+    }
     if (containsLeakedToolCallMarkup(lastMessage.content)) {
       log.error("Kubernetes Operator - leaked tool-call markup in response", lastMessage.content);
       throw new Error(LEAKED_TOOL_CALL_MESSAGE);

--- a/src/renderer/business/agent/leaked-tool-calls.test.ts
+++ b/src/renderer/business/agent/leaked-tool-calls.test.ts
@@ -1,6 +1,12 @@
 import { AIMessage, HumanMessage } from "@langchain/core/messages";
 import { describe, expect, it } from "vitest";
-import { containsLeakedToolCallMarkup, parseDsmlToolCalls, recoverDsmlToolCalls } from "./leaked-tool-calls";
+import {
+  buildUnsupportedToolCallMessage,
+  containsLeakedToolCallMarkup,
+  findUnknownToolCalls,
+  parseDsmlToolCalls,
+  recoverDsmlToolCalls,
+} from "./leaked-tool-calls";
 
 describe("containsLeakedToolCallMarkup", () => {
   it("detects leaked DSML tool_calls markup", () => {
@@ -122,5 +128,61 @@ describe("recoverDsmlToolCalls", () => {
   it("leaves non-AI messages unchanged", () => {
     const message = new HumanMessage({ content: '<｜｜DSML｜｜invoke name="getNamespaces"></｜｜DSML｜｜invoke>' });
     expect(recoverDsmlToolCalls(message)).toBe(message);
+  });
+});
+
+describe("findUnknownToolCalls", () => {
+  const knownToolNames = ["getNamespaces", "listKubernetesResources"];
+
+  it("flags a hallucinated tool such as runCommand", () => {
+    const message = new AIMessage({
+      content: "",
+      tool_calls: [{ name: "runCommand", args: { command: "kubectl get pods" }, id: "0", type: "tool_call" }],
+    });
+    expect(findUnknownToolCalls([message], knownToolNames)).toEqual(["runCommand"]);
+  });
+
+  it("returns nothing when every tool call is known", () => {
+    const message = new AIMessage({
+      content: "",
+      tool_calls: [
+        { name: "getNamespaces", args: {}, id: "0", type: "tool_call" },
+        { name: "listKubernetesResources", args: { kind: "Pod" }, id: "1", type: "tool_call" },
+      ],
+    });
+    expect(findUnknownToolCalls([message], knownToolNames)).toEqual([]);
+  });
+
+  it("de-duplicates and collects unknown names across messages", () => {
+    const messages = [
+      new AIMessage({ content: "", tool_calls: [{ name: "runCommand", args: {}, id: "0", type: "tool_call" }] }),
+      new AIMessage({ content: "", tool_calls: [{ name: "getNamespaces", args: {}, id: "1", type: "tool_call" }] }),
+      new AIMessage({ content: "", tool_calls: [{ name: "execShell", args: {}, id: "2", type: "tool_call" }] }),
+      new AIMessage({ content: "", tool_calls: [{ name: "runCommand", args: {}, id: "3", type: "tool_call" }] }),
+    ];
+    expect(findUnknownToolCalls(messages, knownToolNames)).toEqual(["runCommand", "execShell"]);
+  });
+
+  it("ignores messages without tool calls and non-AI messages", () => {
+    const messages = [
+      new HumanMessage({ content: "redeploy the helm chart" }),
+      new AIMessage({ content: "Sure, I can help." }),
+    ];
+    expect(findUnknownToolCalls(messages, knownToolNames)).toEqual([]);
+  });
+});
+
+describe("buildUnsupportedToolCallMessage", () => {
+  it("names a single unsupported tool", () => {
+    const message = buildUnsupportedToolCallMessage(["runCommand"]);
+    expect(message).toContain("an unsupported tool");
+    expect(message).toContain("`runCommand`");
+    expect(message).toContain("not supported yet");
+  });
+
+  it("names multiple unsupported tools", () => {
+    const message = buildUnsupportedToolCallMessage(["runCommand", "execShell"]);
+    expect(message).toContain("unsupported tools");
+    expect(message).toContain("`runCommand`, `execShell`");
   });
 });

--- a/src/renderer/business/agent/leaked-tool-calls.ts
+++ b/src/renderer/business/agent/leaked-tool-calls.ts
@@ -190,3 +190,47 @@ export const recoverDsmlToolCalls = (message: BaseMessage): BaseMessage => {
     name: message.name,
   });
 };
+
+// ---------------------------------------------------------------------------
+// Unsupported / hallucinated tool calls
+// ---------------------------------------------------------------------------
+//
+// The model may request a tool that does not exist in the extension, for
+// example a shell-style `runCommand` (no command-execution capability is
+// implemented). Such a call can arrive as a structured `tool_calls` entry or be
+// recovered from DSML markup; either way `ToolNode` only answers with a generic
+// "Tool not found" message that the agent then summarizes into a confusing
+// result. Detecting unknown tool names lets the agent fail with an actionable
+// explanation instead.
+
+// Shared, user-facing explanation for an unsupported tool call.
+export const UNSUPPORTED_TOOL_CALL_MESSAGE =
+  "Running shell commands or other CLI tools (kubectl, helm, etc.) is not supported yet; " +
+  "only the built-in Kubernetes tools are available.";
+
+// Build the actionable message naming the unsupported tool(s) the model tried
+// to use.
+export const buildUnsupportedToolCallMessage = (toolNames: string[]): string => {
+  const names = toolNames.map((name) => `\`${name}\``).join(", ");
+  const subject = toolNames.length === 1 ? "an unsupported tool" : "unsupported tools";
+  return `The model tried to use ${subject} (${names}). ${UNSUPPORTED_TOOL_CALL_MESSAGE}`;
+};
+
+// Return the de-duplicated names of any tool calls in the given messages whose
+// name is not part of `knownToolNames`. Empty when every requested tool is known
+// (or no tool calls are present).
+export const findUnknownToolCalls = (messages: BaseMessage[], knownToolNames: Iterable<string>): string[] => {
+  const known = new Set(knownToolNames);
+  const unknown = new Set<string>();
+  for (const message of messages) {
+    if (!isAIMessage(message) || !message.tool_calls) {
+      continue;
+    }
+    for (const toolCall of message.tool_calls) {
+      if (toolCall.name && !known.has(toolCall.name)) {
+        unknown.add(toolCall.name);
+      }
+    }
+  }
+  return [...unknown];
+};

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -191,6 +191,12 @@ export const allToolFunctions = [
   deleteKubernetesResource,
 ];
 
+// The authoritative set of tool names the agent system can actually execute.
+// Used to detect hallucinated / unsupported tool calls (for example a shell
+// `runCommand`) before they reach the graph. Note the registered name of the
+// warning-events tool is `getEventsForNamespace`.
+export const allToolNames: string[] = allToolFunctions.map((tool) => tool.name);
+
 // Data structure describing each tool function: name, description, arguments, and return type
 export const toolFunctionDescriptions = [
   {

--- a/src/renderer/business/provider/prompt-template-provider.ts
+++ b/src/renderer/business/provider/prompt-template-provider.ts
@@ -42,13 +42,14 @@ You have tools at your disposal to solve the coding task. Follow these rules reg
 3. **NEVER refer to tool names when speaking to the USER.** For example, instead of saying 'I need to use the edit_file tool to edit your file', just say 'I will edit your file'.
 4. Only calls tools when they are necessary. If the USER's task is general or you already know the answer, just respond without calling tools.
 5. Before calling each tool, first explain to the USER why you are calling it.
+6. There is NO shell, terminal, or command execution capability. You CANNOT run kubectl, helm, or any other CLI command, and tools such as 'runCommand' do NOT exist. Only the structured tools explicitly provided to you may be used. If a request needs a capability that is not yet implemented, explain that to the USER instead of inventing or guessing a tool.
 </tool_calling>
 
-Answer the user's request using the relevant tool(s), if they are available. 
-Check that all the required parameters for each tool call are provided or can reasonably be inferred from context. 
-IF there are no relevant tools or there are missing values for required parameters, ask the user to supply these values; otherwise proceed with the tool calls. 
-If the user provides a specific value for a parameter (for example provided in quotes), make sure to use that value EXACTLY. 
-DO NOT make up values for or ask about optional parameters. 
+Answer the user's request using the relevant tool(s), if they are available.
+Check that all the required parameters for each tool call are provided or can reasonably be inferred from context.
+IF there are no relevant tools or there are missing values for required parameters, ask the user to supply these values; otherwise proceed with the tool calls.
+If the user provides a specific value for a parameter (for example provided in quotes), make sure to use that value EXACTLY.
+DO NOT make up values for or ask about optional parameters.
 Carefully analyze descriptive terms in the request as they may indicate required parameter values that should be included even if not explicitly quoted.
 `;
 
@@ -66,12 +67,13 @@ You have tools at your disposal to solve the coding task. Follow these rules reg
 3. **NEVER refer to tool names when speaking to the USER.** For example, instead of saying 'I need to use the edit_file tool to edit your file', just say 'I will edit your file'.
 4. Only calls tools when they are necessary. If the USER's task is general or you already know the answer, just respond without calling tools.
 5. Before calling each tool, first explain to the USER why you are calling it.
+6. There is NO shell, terminal, or command execution capability. You CANNOT run kubectl, helm, or any other CLI command, and tools such as 'runCommand' do NOT exist. Only the structured tools explicitly provided to you may be used. If a request needs a capability that is not yet implemented (for example redeploying a Helm chart), explain that to the USER instead of inventing or guessing a tool.
 </tool_calling>
 
-Answer the user's request using the relevant tool(s), if they are available. 
-Check that all the required parameters for each tool call are provided or can reasonably be inferred from context. 
-IF there are no relevant tools or there are missing values for required parameters, ask the user to supply these values; otherwise proceed with the tool calls. 
-If the user provides a specific value for a parameter (for example provided in quotes), make sure to use that value EXACTLY. 
+Answer the user's request using the relevant tool(s), if they are available.
+Check that all the required parameters for each tool call are provided or can reasonably be inferred from context.
+IF there are no relevant tools or there are missing values for required parameters, ask the user to supply these values; otherwise proceed with the tool calls.
+If the user provides a specific value for a parameter (for example provided in quotes), make sure to use that value EXACTLY.
 Carefully analyze descriptive terms in the request as they may indicate required parameter values that should be included even if not explicitly quoted.
 DO NOT repeat or loop if there is an error surface it to the user and ask for clarification.
 
@@ -109,12 +111,13 @@ general software engineering, IT, or other technical and non-technical topics.
 You should provide clear, accurate, and concise answers, adapting your explanations to the user's level of expertise when possible.
 
 Guidelines:
-- If the question is about Kubernetes, provide best practices, conceptual explanations, troubleshooting advice, or generate code snippets as needed (YAML) or kubectl commands.
+- If the question is about Kubernetes, provide best practices, conceptual explanations, troubleshooting advice, or generate code snippets as needed (for example YAML manifests).
 - For general technical questions, offer practical solutions, code examples, or conceptual overviews as appropriate.
 - For non-technical questions, respond helpfully and politely within your knowledge boundaries.
 - If a question is ambiguous or lacks detail, ask clarifying questions before answering.
 - Always use Markdown formatting for clarity and readability.
 - If you reference external resources, provide reputable links.
+- You have NO shell, terminal, or command execution capability and there is no 'runCommand' tool: you cannot run kubectl, helm, or any other CLI command. You may show example commands as reference text, but never claim to have executed one or attempt to call a tool to run it.
 
 If you do not know the answer or the question is outside your scope, clearly state your limitations and suggest where the user might find more information.
 `;


### PR DESCRIPTION
Fixes #138

### Summary

Implements both asks from the issue so a prompt like "Redeploy helm chart" no longer produces a confusing result from a hallucinated `runCommand` tool call.

### Changes

- **Prompt constraint** - the analyzer, operator, and general-purpose prompts now state there is no shell/terminal/CLI capability and no `runCommand` tool; unimplemented requests are explained to the user instead of inventing a tool. Removed the "or kubectl commands" nudge.
- **Unsupported-tool guard** - new `findUnknownToolCalls` helper + `allToolNames`; the analyzer/operator nodes surface an actionable error when the model requests a tool that does not exist.
- Unit tests for the new helpers.

One commit per fix.
