### PR TITLE
Fold tool approval details into a collapsible section after decision

### DIFF
--- a/src/renderer/components/interrupt/interrupt.scss
+++ b/src/renderer/components/interrupt/interrupt.scss
@@ -1,3 +1,17 @@
 .message-buttons-options {
   margin-right: 10px;
 }
+
+.interrupt-details {
+  margin-bottom: 10px;
+}
+
+.interrupt-details-summary {
+  cursor: pointer;
+  user-select: none;
+  opacity: 0.8;
+}
+
+.interrupt-details-summary:hover {
+  opacity: 1;
+}

--- a/src/renderer/components/interrupt/interrupt.tsx
+++ b/src/renderer/components/interrupt/interrupt.tsx
@@ -22,21 +22,30 @@ const Interrupt = ({ header, question, text, options, approved, onAction }: Inte
       <style>{styleInline}</style>
       <h1>{header}</h1>
       <h2>{question}</h2>
-      <MarkdownViewer content={text} />
-      {approved === null && (
-        <div>
-          {options.map((option) => (
-            <Button
-              className="message-buttons-options"
-              label={option}
-              onClick={() => {
-                onAction(option);
-              }}
-            />
-          ))}
-        </div>
+      {approved === null ? (
+        <>
+          <MarkdownViewer content={text} />
+          <div>
+            {options.map((option) => (
+              <Button
+                className="message-buttons-options"
+                label={option}
+                onClick={() => {
+                  onAction(option);
+                }}
+              />
+            ))}
+          </div>
+        </>
+      ) : (
+        <>
+          <details className="interrupt-details">
+            <summary className="interrupt-details-summary">Show details</summary>
+            <MarkdownViewer content={text} />
+          </details>
+          <StatusNotice approved={approved} />
+        </>
       )}
-      {approved !== null && <StatusNotice approved={approved} />}
     </div>
   );
 };


### PR DESCRIPTION
Closes #141.

After a tool-use action is approved or rejected, the JSON details are folded into a collapsed `details` element with a clickable `Show details` summary to unfold them again on demand. Before a decision is made the details stay expanded so the action can still be reviewed.
