### PR TITLE
Separate distinct assistant messages so Markdown is not glued together

### DIFF
--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -2,6 +2,7 @@ import { isAIMessageChunk } from "@langchain/core/messages";
 import { Command, Interrupt } from "@langchain/langgraph";
 import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
+import { createStreamMergeState, mergeAiChunk } from "./stream-merge";
 
 const MAX_GEMINI_STREAM_RETRIES = 3;
 const BASE_BACKOFF_MS = 700;
@@ -48,6 +49,9 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
     let config = { thread_id: conversationId };
     for (let attempt = 1; attempt <= MAX_GEMINI_STREAM_RETRIES + 1; attempt++) {
       let hasYieldedContent = false;
+      // Tracks assistant message boundaries so distinct messages emitted within a
+      // single run are separated by a blank line instead of being glued together.
+      const mergeState = createStreamMergeState();
 
       try {
         const streamResponse = await agent.stream(agentInput, { streamMode: "messages", configurable: config });
@@ -58,8 +62,11 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
             // console.log(`${message.getType()} MESSAGE TOOL CALL CHUNK: ${message.tool_call_chunks[0].args}`);
           } else {
             if (message.getType() === "ai") {
-              hasYieldedContent = true;
-              yield String(message.content);
+              const text = mergeAiChunk(mergeState, message.id, String(message.content));
+              if (text.length > 0) {
+                hasYieldedContent = true;
+                yield text;
+              }
             }
           }
         }

--- a/src/renderer/business/service/stream-merge.test.ts
+++ b/src/renderer/business/service/stream-merge.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { createStreamMergeState, mergeAiChunk } from "./stream-merge";
+
+describe("mergeAiChunk", () => {
+  it("concatenates chunks of the same message without a separator", () => {
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, "msg-1", "Everything is ")).toBe("Everything is ");
+    expect(mergeAiChunk(state, "msg-1", "working fine.")).toBe("working fine.");
+  });
+
+  it("inserts a blank line when a new message begins", () => {
+    const state = createStreamMergeState();
+    mergeAiChunk(state, "msg-1", "Everything is working fine.");
+    expect(mergeAiChunk(state, "msg-2", "### Summary")).toBe("\n\n### Summary");
+  });
+
+  it("does not prepend a separator before the very first chunk", () => {
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, "msg-1", "### Summary")).toBe("### Summary");
+  });
+
+  it("ignores empty chunks and leaves the boundary state untouched", () => {
+    const state = createStreamMergeState();
+    mergeAiChunk(state, "msg-1", "Hello");
+    expect(mergeAiChunk(state, "msg-2", "")).toBe("");
+    // The empty chunk must not consume the boundary: the next real chunk from a
+    // new message still gets its separator.
+    expect(mergeAiChunk(state, "msg-2", "World")).toBe("\n\nWorld");
+  });
+
+  it("does not separate when ids are missing (preserves token streaming)", () => {
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, undefined, "Hello ")).toBe("Hello ");
+    expect(mergeAiChunk(state, undefined, "world")).toBe("world");
+  });
+
+  it("separates when the first message has no id but the next one does", () => {
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, undefined, "Everything is working fine.")).toBe("Everything is working fine.");
+    expect(mergeAiChunk(state, "msg-2", "### Summary")).toBe("\n\n### Summary");
+  });
+
+  it("handles three distinct messages in a row", () => {
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, "a", "First.")).toBe("First.");
+    expect(mergeAiChunk(state, "b", "Second.")).toBe("\n\nSecond.");
+    expect(mergeAiChunk(state, "c", "Third.")).toBe("\n\nThird.");
+  });
+});

--- a/src/renderer/business/service/stream-merge.ts
+++ b/src/renderer/business/service/stream-merge.ts
@@ -1,0 +1,42 @@
+/**
+ * Helpers for merging the AI message chunks streamed by the agent into a single
+ * Markdown string without gluing distinct assistant messages onto one line.
+ *
+ * The agent streams in `messages` mode: a single assistant message arrives as
+ * many chunks that share the same `id` and must be concatenated directly (token
+ * streaming). When the agent graph emits a *new* assistant message its `id`
+ * changes; concatenating it straight onto the previous one produces output like
+ * `...check?### Summary`, where `###` is no longer at the start of a line and
+ * Markdown renders it verbatim. Inserting a blank line at the boundary keeps the
+ * heading on its own block.
+ */
+
+export interface StreamMergeState {
+  lastMessageId: string | undefined;
+  started: boolean;
+}
+
+export const createStreamMergeState = (): StreamMergeState => ({
+  lastMessageId: undefined,
+  started: false,
+});
+
+/**
+ * Returns the text to yield for an incoming AI message chunk, updating `state`.
+ *
+ * Empty chunks yield nothing. When a new assistant message begins (a defined
+ * `id` that differs from the previous one) a blank-line separator is prepended
+ * so the following content starts a fresh Markdown block. Chunks with no id, or
+ * the same id, are concatenated directly to preserve token streaming.
+ */
+export const mergeAiChunk = (state: StreamMergeState, id: string | undefined, content: string): string => {
+  if (content.length === 0) {
+    return "";
+  }
+
+  const isNewMessage = state.started && id !== undefined && id !== state.lastMessageId;
+  state.lastMessageId = id;
+  state.started = true;
+
+  return isNewMessage ? `\n\n${content}` : content;
+};


### PR DESCRIPTION
Fixes #143.

The agent streams in `messages` mode and each AI message chunk was concatenated directly, so two distinct assistant messages in one run were glued together (e.g. `...check?### Summary`) and Markdown rendered the heading verbatim on one line.

This tracks assistant-message boundaries by chunk id and inserts a blank line when a new message begins, keeping headings and paragraphs on their own blocks. Token streaming (same id) is unchanged. Logic extracted into a pure, unit-tested helper.
