### PR TITLE
Improve styling of tool approval prompts

### DIFF
--- a/src/renderer/components/interrupt/interrupt.scss
+++ b/src/renderer/components/interrupt/interrupt.scss
@@ -1,3 +1,20 @@
+.interrupt-prompt {
+  margin-bottom: 10px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  background-color: var(--inputControlBackground);
+}
+
+.interrupt-header,
+.interrupt-question {
+  font-size: 1rem;
+  font-weight: bold;
+}
+
+.interrupt-warning-icon {
+  margin-right: 6px;
+}
+
 .message-buttons-options {
   margin-right: 10px;
 }
@@ -9,9 +26,9 @@
 .interrupt-details-summary {
   cursor: pointer;
   user-select: none;
-  opacity: 0.8;
 }
 
-.interrupt-details-summary:hover {
-  opacity: 1;
+.interrupt-details-summary-text {
+  color: var(--blue);
+  text-decoration: underline;
 }

--- a/src/renderer/components/interrupt/interrupt.scss
+++ b/src/renderer/components/interrupt/interrupt.scss
@@ -3,6 +3,7 @@
   padding: 8px 12px;
   border-radius: 4px;
   background-color: var(--inputControlBackground);
+  color: var(--textColorPrimary);
 }
 
 .interrupt-header,

--- a/src/renderer/components/interrupt/interrupt.tsx
+++ b/src/renderer/components/interrupt/interrupt.tsx
@@ -20,8 +20,13 @@ const Interrupt = ({ header, question, text, options, approved, onAction }: Inte
   return (
     <div>
       <style>{styleInline}</style>
-      <h1>{header}</h1>
-      <h2>{question}</h2>
+      <div className="interrupt-prompt">
+        <div className="interrupt-header">
+          <span className="interrupt-warning-icon">⚠️</span>
+          {header}
+        </div>
+        <div className="interrupt-question">{question}</div>
+      </div>
       {approved === null ? (
         <>
           <MarkdownViewer content={text} />
@@ -40,7 +45,9 @@ const Interrupt = ({ header, question, text, options, approved, onAction }: Inte
       ) : (
         <>
           <details className="interrupt-details">
-            <summary className="interrupt-details-summary">Show details</summary>
+            <summary className="interrupt-details-summary">
+              <span className="interrupt-details-summary-text">Show details</span>
+            </summary>
             <MarkdownViewer content={text} />
           </details>
           <StatusNotice approved={approved} />

--- a/src/renderer/components/interrupt/status-notice/status-notice.scss
+++ b/src/renderer/components/interrupt/status-notice/status-notice.scss
@@ -4,6 +4,7 @@
   padding: 12px 16px;
   font-size: 1rem;
   font-weight: 500;
+  color: var(--textColorPrimary);
   transition:
     background-color 0.3s ease,
     color 0.3s ease;

--- a/src/renderer/components/markdown-viewer/markdown-viewer.scss
+++ b/src/renderer/components/markdown-viewer/markdown-viewer.scss
@@ -18,6 +18,41 @@
   color: var(--textColorAccent);
 }
 
+.markdown-viewer-container-theme h1 {
+  font-size: 1.5em;
+}
+
+.markdown-viewer-container-theme h2 {
+  font-size: 1.3em;
+}
+
+.markdown-viewer-container-theme h3 {
+  font-size: 1.15em;
+}
+
+.markdown-viewer-container-theme h4 {
+  font-size: 1.05em;
+}
+
+.markdown-viewer-container-theme h5,
+.markdown-viewer-container-theme h6 {
+  font-size: 1em;
+}
+
+.markdown-viewer-container-theme h1,
+.markdown-viewer-container-theme h2,
+.markdown-viewer-container-theme h3,
+.markdown-viewer-container-theme h4,
+.markdown-viewer-container-theme h5,
+.markdown-viewer-container-theme h6,
+.markdown-viewer-container-theme p,
+.markdown-viewer-container-theme ul,
+.markdown-viewer-container-theme ol,
+.markdown-viewer-container-theme blockquote {
+  margin-top: 0.75em;
+  margin-bottom: 0.75em;
+}
+
 .markdown-viewer-container-theme table {
   border-collapse: collapse;
   display: block;


### PR DESCRIPTION
Closes #144

Improves the look of the tool approval prompts:

- Tool name and question now render at normal text size, bold, with a leading warning sign and an `--inputControlBackground` panel instead of oversized headings
- `Show details` toggler styled like Freelens `.DrawerParamToggler > .param-link` (blue, underlined)
- Smaller headings and bigger paragraph separation in the Markdown viewer
