### PR TITLE
Show assistant text streamed alongside a tool call

### DIFF
--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -1,4 +1,3 @@
-import { isAIMessageChunk } from "@langchain/core/messages";
 import { Command, Interrupt } from "@langchain/langgraph";
 import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
@@ -58,15 +57,17 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
 
         // streams LLM token by token to the UI
         for await (const [message, _metadata] of streamResponse) {
-          if (isAIMessageChunk(message) && message.tool_call_chunks?.length) {
-            // console.log(`${message.getType()} MESSAGE TOOL CALL CHUNK: ${message.tool_call_chunks[0].args}`);
-          } else {
-            if (message.getType() === "ai") {
-              const text = mergeAiChunk(mergeState, message.id, String(message.content));
-              if (text.length > 0) {
-                hasYieldedContent = true;
-                yield text;
-              }
+          // Always emit the assistant's text content, even when the same chunk
+          // also carries tool calls. Some providers (e.g. DeepSeek via
+          // DsmlAwareChatOpenAI) deliver the preamble text and the tool call in
+          // a single chunk; dropping the whole chunk would hide the preamble the
+          // model wrote before invoking a tool. Tool-call arguments live in
+          // `tool_call_chunks`, not in `content`, so they are never emitted here.
+          if (message.getType() === "ai") {
+            const text = mergeAiChunk(mergeState, message.id, message.content);
+            if (text.length > 0) {
+              hasYieldedContent = true;
+              yield text;
             }
           }
         }

--- a/src/renderer/business/service/stream-merge.test.ts
+++ b/src/renderer/business/service/stream-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createStreamMergeState, mergeAiChunk } from "./stream-merge";
+import { createStreamMergeState, flattenContentText, mergeAiChunk } from "./stream-merge";
 
 describe("mergeAiChunk", () => {
   it("concatenates chunks of the same message without a separator", () => {
@@ -45,5 +45,52 @@ describe("mergeAiChunk", () => {
     expect(mergeAiChunk(state, "a", "First.")).toBe("First.");
     expect(mergeAiChunk(state, "b", "Second.")).toBe("\n\nSecond.");
     expect(mergeAiChunk(state, "c", "Third.")).toBe("\n\nThird.");
+  });
+
+  it("flattens structured content arrays to their text", () => {
+    const state = createStreamMergeState();
+    expect(
+      mergeAiChunk(state, "msg-1", [
+        { type: "text", text: "I'll investigate " },
+        { type: "text", text: "now." },
+      ]),
+    ).toBe("I'll investigate now.");
+  });
+
+  it("emits the preamble text of a chunk that also carries a tool call", () => {
+    const state = createStreamMergeState();
+    // A chunk where the assistant wrote a preamble and then invoked a tool: the
+    // tool-call lives outside `content`, so only the preamble text is emitted.
+    expect(
+      mergeAiChunk(state, "msg-1", [
+        { type: "text", text: "Good morning! I'll search the cluster." },
+        { type: "tool_use", id: "call_1", name: "read_logs", input: { pod: "foo" } },
+      ]),
+    ).toBe("Good morning! I'll search the cluster.");
+  });
+
+  it("yields nothing for a tool-only chunk with no text", () => {
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, "msg-1", [{ type: "tool_use", id: "call_1", name: "read_logs", input: {} }])).toBe("");
+  });
+});
+
+describe("flattenContentText", () => {
+  it("returns string content unchanged", () => {
+    expect(flattenContentText("hello")).toBe("hello");
+  });
+
+  it("joins the text parts of an array and ignores non-text parts", () => {
+    expect(
+      flattenContentText([
+        { type: "text", text: "a" },
+        { type: "image_url", image_url: { url: "x" } },
+        { type: "text", text: "b" },
+      ]),
+    ).toBe("ab");
+  });
+
+  it("returns an empty string when there is no text", () => {
+    expect(flattenContentText([{ type: "tool_use", id: "1", name: "t", input: {} }])).toBe("");
   });
 });

--- a/src/renderer/business/service/stream-merge.ts
+++ b/src/renderer/business/service/stream-merge.ts
@@ -11,6 +11,8 @@
  * heading on its own block.
  */
 
+import type { MessageContent } from "@langchain/core/messages";
+
 export interface StreamMergeState {
   lastMessageId: string | undefined;
   started: boolean;
@@ -22,15 +24,45 @@ export const createStreamMergeState = (): StreamMergeState => ({
 });
 
 /**
+ * Flatten LangChain message content (a plain string, or an array of content
+ * parts) into its text. Non-text parts such as tool-call blocks are ignored so
+ * tool-call arguments are never emitted to the UI as text.
+ */
+export const flattenContentText = (content: MessageContent): string => {
+  if (typeof content === "string") {
+    return content;
+  }
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .map((part) => {
+      if (typeof part === "string") {
+        return part;
+      }
+      if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
+        return part.text;
+      }
+      return "";
+    })
+    .join("");
+};
+
+/**
  * Returns the text to yield for an incoming AI message chunk, updating `state`.
  *
  * Empty chunks yield nothing. When a new assistant message begins (a defined
  * `id` that differs from the previous one) a blank-line separator is prepended
  * so the following content starts a fresh Markdown block. Chunks with no id, or
  * the same id, are concatenated directly to preserve token streaming.
+ *
+ * `content` may be a plain string or LangChain's structured content array; it is
+ * flattened to text first, so a chunk that also carries `tool_call_chunks` still
+ * contributes its preamble text instead of being dropped.
  */
-export const mergeAiChunk = (state: StreamMergeState, id: string | undefined, content: string): string => {
-  if (content.length === 0) {
+export const mergeAiChunk = (state: StreamMergeState, id: string | undefined, content: MessageContent): string => {
+  const text = flattenContentText(content);
+  if (text.length === 0) {
     return "";
   }
 
@@ -38,5 +70,5 @@ export const mergeAiChunk = (state: StreamMergeState, id: string | undefined, co
   state.lastMessageId = id;
   state.started = true;
 
-  return isNewMessage ? `\n\n${content}` : content;
+  return isNewMessage ? `\n\n${text}` : text;
 };


### PR DESCRIPTION
Fixes #148

### Problem

The assistant's preamble text (e.g. "Good morning! I'll investigate...") was missing from the chat when the model produced text and a tool call in the same response, just before the tool-approval prompt.

### Root cause

The streaming loop in `agent-service.ts` dropped an AI message chunk entirely whenever it carried `tool_call_chunks`, discarding any text content in the same chunk. Providers that deliver the preamble text and the tool call together (notably DeepSeek via `DsmlAwareChatOpenAI`, which aggregates the whole response into one chunk) lost the preamble.

### Fix

Always flatten and emit the chunk's text content, even when it also carries tool calls. Tool-call arguments live in `tool_call_chunks`, not in `content`, so they are never emitted as text. `mergeAiChunk` now accepts structured content (string or content-part array) and flattens it, ignoring non-text parts.
