### PR TITLE
Add tool to restart workloads via rollout restart

### DIFF
--- a/src/renderer/business/agent/kubernetes-operator-agent.ts
+++ b/src/renderer/business/agent/kubernetes-operator-agent.ts
@@ -10,6 +10,7 @@ import {
   getKubernetesResource,
   listKubernetesResources,
   patchKubernetesResource,
+  restartKubernetesResource,
   updateKubernetesResource,
 } from "./tools/tools";
 
@@ -28,6 +29,7 @@ export const useAgentKubernetesOperator = () => {
       updateKubernetesResource,
       patchKubernetesResource,
       deleteKubernetesResource,
+      restartKubernetesResource,
     ];
     const toolNode = new ToolNode(tools);
     const boundModel = model.bindTools(tools, { parallel_tool_calls: false });

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -9,7 +9,14 @@ import {
   type GetPodLogsInput,
   resolveContainer,
 } from "./pod-logs";
-import { type Manifest, prepareManifest, resolveApiVersion, validateManifest } from "./resource-handlers";
+import {
+  isRestartableKind,
+  type Manifest,
+  prepareManifest,
+  RESTARTABLE_KINDS,
+  resolveApiVersion,
+  validateManifest,
+} from "./resource-handlers";
 
 type KubeApi = Renderer.K8sApi.KubeApi;
 type KubeObject = Renderer.K8sApi.KubeObject;
@@ -56,6 +63,35 @@ export interface DeleteResourceInput {
   apiVersion?: string;
   name: string;
   namespace?: string;
+}
+
+export interface RestartResourceInput {
+  kind: string;
+  name: string;
+  namespace: string;
+}
+
+// Workload APIs that expose a rollout `restart()` endpoint. Their `restart`
+// signatures are identical, so the union accepts the shared call below.
+type RestartableApi =
+  | typeof Renderer.K8sApi.deploymentApi
+  | typeof Renderer.K8sApi.daemonSetApi
+  | typeof Renderer.K8sApi.statefulSetApi;
+
+/**
+ * Resolve the host KubeApi exposing `restart()` for a restartable kind.
+ */
+function getRestartableApi(kind: string): RestartableApi | undefined {
+  switch (kind) {
+    case "Deployment":
+      return Renderer.K8sApi.deploymentApi;
+    case "DaemonSet":
+      return Renderer.K8sApi.daemonSetApi;
+    case "StatefulSet":
+      return Renderer.K8sApi.statefulSetApi;
+    default:
+      return undefined;
+  }
 }
 
 /**
@@ -330,6 +366,39 @@ export async function deleteKubernetesResource({
     return `${kind} deleted successfully`;
   } catch (error) {
     console.error("[Tool invocation error: deleteKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Restart a workload by triggering a rollout restart through its host KubeApi
+ * (`DeploymentApi.restart()` and the equivalent DaemonSet/StatefulSet methods).
+ * This rolls the pods without deleting them directly. Only restartable kinds are
+ * accepted; a namespace is always required.
+ */
+export async function restartKubernetesResource({ kind, name, namespace }: RestartResourceInput): Promise<string> {
+  console.log("[Tool invocation: restartKubernetesResource] - kind:", kind, "name:", name, "namespace:", namespace);
+  if (!isRestartableKind(kind)) {
+    return `Restart is not supported for kind "${kind}". Supported kinds: ${RESTARTABLE_KINDS.join(", ")}.`;
+  }
+  const api = getRestartableApi(kind);
+  if (!api) {
+    return `Could not resolve a Kubernetes API for kind "${kind}".`;
+  }
+  if (!namespace) {
+    return `Kind "${kind}" is namespaced; please provide a namespace to restart "${name}".`;
+  }
+
+  if (!requestApproval(`RESTART ${kind.toUpperCase()}`, { name, namespace })) {
+    return "The user denied the action";
+  }
+
+  try {
+    await api.restart({ name, namespace });
+    console.log("[Tool invocation result: restartKubernetesResource] - ", `${kind} "${name}" restarted successfully`);
+    return `${kind} "${name}" restarted successfully`;
+  } catch (error) {
+    console.error("[Tool invocation error: restartKubernetesResource] - ", error);
     return JSON.stringify(error);
   }
 }

--- a/src/renderer/business/agent/tools/resource-handlers.test.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildServiceManifest,
   getResourceHandler,
+  isRestartableKind,
   prepareManifest,
+  RESTARTABLE_KINDS,
   resolveApiVersion,
   SUPPORTED_KINDS,
   validateManifest,
@@ -11,6 +13,26 @@ import {
 describe("SUPPORTED_KINDS", () => {
   it("lists the internally handled kinds", () => {
     expect(SUPPORTED_KINDS).toEqual(["Pod", "Deployment", "Service"]);
+  });
+});
+
+describe("RESTARTABLE_KINDS", () => {
+  it("lists the workload kinds that expose a rollout restart", () => {
+    expect(RESTARTABLE_KINDS).toEqual(["Deployment", "DaemonSet", "StatefulSet"]);
+  });
+});
+
+describe("isRestartableKind", () => {
+  it("accepts restartable workload kinds", () => {
+    expect(isRestartableKind("Deployment")).toBe(true);
+    expect(isRestartableKind("DaemonSet")).toBe(true);
+    expect(isRestartableKind("StatefulSet")).toBe(true);
+  });
+
+  it("rejects kinds without a restart endpoint", () => {
+    expect(isRestartableKind("Pod")).toBe(false);
+    expect(isRestartableKind("Service")).toBe(false);
+    expect(isRestartableKind("Gateway")).toBe(false);
   });
 });
 

--- a/src/renderer/business/agent/tools/resource-handlers.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.ts
@@ -147,6 +147,21 @@ export const RESOURCE_HANDLERS: Record<string, ResourceHandler> = {
  */
 export const SUPPORTED_KINDS = Object.keys(RESOURCE_HANDLERS);
 
+/**
+ * Workload kinds whose host KubeApi exposes a rollout `restart()` endpoint. The
+ * restart tool only accepts these kinds; anything else is rejected up front.
+ */
+export const RESTARTABLE_KINDS = ["Deployment", "DaemonSet", "StatefulSet"] as const;
+
+export type RestartableKind = (typeof RESTARTABLE_KINDS)[number];
+
+/**
+ * Whether a kind supports a rollout restart via its host KubeApi.
+ */
+export function isRestartableKind(kind: string): kind is RestartableKind {
+  return (RESTARTABLE_KINDS as readonly string[]).includes(kind);
+}
+
 export function getResourceHandler(kind: string): ResourceHandler | undefined {
   return RESOURCE_HANDLERS[kind];
 }

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -8,9 +8,10 @@ import {
   getPodLogs as getPodLogsImpl,
   listKubernetesResources as listKubernetesResourcesImpl,
   patchKubernetesResource as patchKubernetesResourceImpl,
+  restartKubernetesResource as restartKubernetesResourceImpl,
   updateKubernetesResource as updateKubernetesResourceImpl,
 } from "./kubernetes-resource";
-import { SUPPORTED_KINDS } from "./resource-handlers";
+import { RESTARTABLE_KINDS, SUPPORTED_KINDS } from "./resource-handlers";
 
 const supportedKindsHint = `Built-in kinds with extra validation: ${SUPPORTED_KINDS.join(", ")}. Any other kind (including CRDs) is also accepted and passed through as a free manifest; for those provide the apiVersion explicitly.`;
 
@@ -179,6 +180,16 @@ export const deleteKubernetesResource = tool(deleteKubernetesResourceImpl, {
   }),
 });
 
+export const restartKubernetesResource = tool(restartKubernetesResourceImpl, {
+  name: "restartKubernetesResource",
+  description: `Trigger a rollout restart of a workload (rolls its pods without deleting them directly), like "kubectl rollout restart". Namespace is required. Supported kinds: ${RESTARTABLE_KINDS.join(", ")}.`,
+  schema: z.object({
+    kind: z.string().describe(`The workload kind to restart. Supported kinds: ${RESTARTABLE_KINDS.join(", ")}.`),
+    name: z.string().describe("The name of the workload to restart"),
+    namespace: z.string().describe("The namespace of the workload"),
+  }),
+});
+
 export const allToolFunctions = [
   getNamespaces,
   getWarningEventsByNamespace,
@@ -189,6 +200,7 @@ export const allToolFunctions = [
   updateKubernetesResource,
   patchKubernetesResource,
   deleteKubernetesResource,
+  restartKubernetesResource,
 ];
 
 // The authoritative set of tool names the agent system can actually execute.
@@ -262,5 +274,14 @@ export const toolFunctionDescriptions = [
     arguments:
       "Requires the resource kind (string) and name (string), and optionally the apiVersion (string). Namespace (string) is required for namespaced kinds.",
     returnType: "Returns a message string indicating success or error after attempting to delete the resource.",
+  },
+  {
+    name: "restartKubernetesResource",
+    description: 'Trigger a rollout restart of a workload (like "kubectl rollout restart")',
+    arguments:
+      "Requires the workload kind (string), name (string) and namespace (string). Supported kinds: " +
+      RESTARTABLE_KINDS.join(", ") +
+      ".",
+    returnType: "Returns a message string indicating success or error after attempting to restart the workload.",
   },
 ];


### PR DESCRIPTION
Adds a dedicated `restartKubernetesResource` tool that triggers a rollout restart via the host `DeploymentApi.restart()` (and the equivalent DaemonSet/StatefulSet methods), so workloads can be restarted without deleting their pods directly.

closes #150
