### PR TITLE
Add pod deletion variants and delete modes for resources

### DIFF
--- a/src/renderer/business/agent/kubernetes-operator-agent.ts
+++ b/src/renderer/business/agent/kubernetes-operator-agent.ts
@@ -7,6 +7,7 @@ import { KUBERNETES_OPERATOR_PROMPT_TEMPLATE } from "../provider/prompt-template
 import {
   createKubernetesResource,
   deleteKubernetesResource,
+  deletePod,
   getKubernetesResource,
   listKubernetesResources,
   patchKubernetesResource,
@@ -29,6 +30,7 @@ export const useAgentKubernetesOperator = () => {
       updateKubernetesResource,
       patchKubernetesResource,
       deleteKubernetesResource,
+      deletePod,
       restartKubernetesResource,
     ];
     const toolNode = new ToolNode(tools);

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -10,8 +10,11 @@ import {
   resolveContainer,
 } from "./pod-logs";
 import {
+  DEFAULT_DELETE_MODE,
+  type DeleteMode,
   isRestartableKind,
   type Manifest,
+  type PodDeleteMode,
   prepareManifest,
   RESTARTABLE_KINDS,
   resolveApiVersion,
@@ -63,6 +66,13 @@ export interface DeleteResourceInput {
   apiVersion?: string;
   name: string;
   namespace?: string;
+  mode?: DeleteMode;
+}
+
+export interface DeletePodInput {
+  name: string;
+  namespace: string;
+  mode: PodDeleteMode;
 }
 
 export interface RestartResourceInput {
@@ -146,6 +156,7 @@ function projectObject(object: KubeObject) {
 // Cast through `unknown` to the exact expected type rather than using `as any`.
 type CreateData = Parameters<KubeObjectStore["create"]>[1];
 type UpdateData = Parameters<KubeObjectStore["update"]>[1];
+type DeleteOptions = Parameters<KubeObjectStore["removeWithOptions"]>[1];
 
 /**
  * List resources of a kind, loading them from the store on demand. Namespaced
@@ -335,14 +346,22 @@ export async function patchKubernetesResource({
 
 /**
  * Delete a resource by name. For namespaced kinds a namespace is required.
+ *
+ * The `mode` mirrors the host `KubeObjectDeleteService` deletion modes:
+ * - `delete` (default): standard delete (`store.remove`).
+ * - `force_delete`: immediate delete with a zero grace period and background
+ *   propagation (`store.removeWithOptions`).
+ * - `force_finalize`: clear the object's finalizers via a merge patch so a
+ *   resource stuck in `Terminating` can be removed (`store.patch`).
  */
 export async function deleteKubernetesResource({
   kind,
   apiVersion,
   name,
   namespace,
+  mode = DEFAULT_DELETE_MODE,
 }: DeleteResourceInput): Promise<string> {
-  console.log("[Tool invocation: deleteKubernetesResource] - kind:", kind, "name:", name);
+  console.log("[Tool invocation: deleteKubernetesResource] - kind:", kind, "name:", name, "mode:", mode);
   const target = resolveTarget(kind, apiVersion);
   if (typeof target === "string") {
     return target;
@@ -352,7 +371,7 @@ export async function deleteKubernetesResource({
     return `Kind "${kind}" is namespaced; please provide a namespace to delete "${name}".`;
   }
 
-  if (!requestApproval(`DELETE ${kind.toUpperCase()}`, { name, namespace })) {
+  if (!requestApproval(`DELETE ${kind.toUpperCase()}`, { name, namespace, mode })) {
     return "The user denied the action";
   }
 
@@ -361,11 +380,68 @@ export async function deleteKubernetesResource({
     if (!item) {
       return `The ${kind} "${name}" you want to delete does not exist`;
     }
-    await store.remove(item);
-    console.log("[Tool invocation result: deleteKubernetesResource] - ", `${kind} deleted successfully`);
-    return `${kind} deleted successfully`;
+    switch (mode) {
+      case "force_delete":
+        await store.removeWithOptions(item, {
+          gracePeriodSeconds: 0,
+          propagationPolicy: "Background",
+        } as unknown as DeleteOptions);
+        break;
+      case "force_finalize":
+        await store.patch(item, { metadata: { finalizers: [] } } as unknown as UpdateData, "merge");
+        break;
+      default:
+        await store.remove(item);
+        break;
+    }
+    const resultMessage =
+      mode === "force_finalize"
+        ? `${kind} finalizers cleared successfully`
+        : `${kind} ${mode === "force_delete" ? "force-" : ""}deleted successfully`;
+    console.log("[Tool invocation result: deleteKubernetesResource] - ", resultMessage);
+    return resultMessage;
   } catch (error) {
     console.error("[Tool invocation error: deleteKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Delete a pod using one of the pod-specific variants exposed by the host
+ * `PodApi`:
+ * - `evict`: request a graceful eviction honoring any matching
+ *   PodDisruptionBudget (`podsApi.evict`).
+ * - `force_delete`: delete immediately with a zero grace period, useful for pods
+ *   stuck on an unreachable node (`podsApi.forceDelete`).
+ * - `delete_with_finalizers`: delete the pod and clear its finalizers so a pod
+ *   stuck in `Terminating` is removed (`podsApi.deleteWithFinalizers`).
+ */
+export async function deletePod({ name, namespace, mode }: DeletePodInput): Promise<string> {
+  console.log("[Tool invocation: deletePod] - name:", name, "namespace:", namespace, "mode:", mode);
+  if (!namespace) {
+    return `Pods are namespaced; please provide a namespace to delete "${name}".`;
+  }
+
+  const podsApi = Renderer.K8sApi.podsApi;
+
+  if (!requestApproval(`DELETE POD (${mode})`, { name, namespace, mode })) {
+    return "The user denied the action";
+  }
+
+  try {
+    switch (mode) {
+      case "evict":
+        await podsApi.evict({ name, namespace });
+        return `Pod "${name}" evicted successfully`;
+      case "force_delete":
+        await podsApi.forceDelete({ name, namespace });
+        return `Pod "${name}" force-deleted successfully`;
+      case "delete_with_finalizers":
+        await podsApi.deleteWithFinalizers({ name, namespace });
+        return `Pod "${name}" deleted and finalizers cleared successfully`;
+    }
+  } catch (error) {
+    console.error("[Tool invocation error: deletePod] - ", error);
     return JSON.stringify(error);
   }
 }

--- a/src/renderer/business/agent/tools/resource-handlers.test.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   buildServiceManifest,
+  DEFAULT_DELETE_MODE,
+  DELETE_MODES,
   getResourceHandler,
+  isDeleteMode,
+  isPodDeleteMode,
   isRestartableKind,
+  POD_DELETE_MODES,
   prepareManifest,
   RESTARTABLE_KINDS,
   resolveApiVersion,
@@ -33,6 +38,51 @@ describe("isRestartableKind", () => {
     expect(isRestartableKind("Pod")).toBe(false);
     expect(isRestartableKind("Service")).toBe(false);
     expect(isRestartableKind("Gateway")).toBe(false);
+  });
+});
+
+describe("DELETE_MODES", () => {
+  it("mirrors the host KubeObjectDeleteService delete types", () => {
+    expect(DELETE_MODES).toEqual(["delete", "force_delete", "force_finalize"]);
+  });
+
+  it("defaults to a plain delete", () => {
+    expect(DEFAULT_DELETE_MODE).toBe("delete");
+    expect(DELETE_MODES).toContain(DEFAULT_DELETE_MODE);
+  });
+});
+
+describe("isDeleteMode", () => {
+  it("accepts the supported delete modes", () => {
+    expect(isDeleteMode("delete")).toBe(true);
+    expect(isDeleteMode("force_delete")).toBe(true);
+    expect(isDeleteMode("force_finalize")).toBe(true);
+  });
+
+  it("rejects unknown modes", () => {
+    expect(isDeleteMode("evict")).toBe(false);
+    expect(isDeleteMode("")).toBe(false);
+    expect(isDeleteMode("forceDelete")).toBe(false);
+  });
+});
+
+describe("POD_DELETE_MODES", () => {
+  it("lists the pod-specific deletion variants", () => {
+    expect(POD_DELETE_MODES).toEqual(["evict", "force_delete", "delete_with_finalizers"]);
+  });
+});
+
+describe("isPodDeleteMode", () => {
+  it("accepts the supported pod deletion modes", () => {
+    expect(isPodDeleteMode("evict")).toBe(true);
+    expect(isPodDeleteMode("force_delete")).toBe(true);
+    expect(isPodDeleteMode("delete_with_finalizers")).toBe(true);
+  });
+
+  it("rejects unknown modes", () => {
+    expect(isPodDeleteMode("force_finalize")).toBe(false);
+    expect(isPodDeleteMode("delete")).toBe(false);
+    expect(isPodDeleteMode("")).toBe(false);
   });
 });
 

--- a/src/renderer/business/agent/tools/resource-handlers.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.ts
@@ -162,6 +162,56 @@ export function isRestartableKind(kind: string): kind is RestartableKind {
   return (RESTARTABLE_KINDS as readonly string[]).includes(kind);
 }
 
+/**
+ * Deletion modes accepted by the generic delete tool. They mirror the Freelens
+ * host `KubeObjectDeleteService` (`delete`, `force_delete`, `force_finalize`):
+ *
+ * - `delete`: the standard delete, honoring the resource's default grace period
+ *   and finalizers (`store.remove`).
+ * - `force_delete`: delete immediately with a zero grace period and background
+ *   propagation, skipping graceful termination
+ *   (`store.removeWithOptions({ gracePeriodSeconds: 0, propagationPolicy: "Background" })`).
+ * - `force_finalize`: clear the object's finalizers via a merge patch so a
+ *   resource stuck in `Terminating` can be removed (`store.patch`).
+ */
+export const DELETE_MODES = ["delete", "force_delete", "force_finalize"] as const;
+
+export type DeleteMode = (typeof DELETE_MODES)[number];
+
+/**
+ * The default deletion mode when the model does not specify one.
+ */
+export const DEFAULT_DELETE_MODE: DeleteMode = "delete";
+
+/**
+ * Whether a string is one of the supported generic deletion modes.
+ */
+export function isDeleteMode(mode: string): mode is DeleteMode {
+  return (DELETE_MODES as readonly string[]).includes(mode);
+}
+
+/**
+ * Pod-specific deletion modes exposed by the dedicated pod delete tool. They map
+ * to the extra methods on the host `PodApi`:
+ *
+ * - `evict`: request a graceful eviction through the Eviction subresource,
+ *   honoring any matching PodDisruptionBudget (`podsApi.evict`).
+ * - `force_delete`: delete the pod immediately with a zero grace period, useful
+ *   for pods stuck on an unreachable node (`podsApi.forceDelete`).
+ * - `delete_with_finalizers`: delete the pod and clear its finalizers so a pod
+ *   stuck in `Terminating` is removed (`podsApi.deleteWithFinalizers`).
+ */
+export const POD_DELETE_MODES = ["evict", "force_delete", "delete_with_finalizers"] as const;
+
+export type PodDeleteMode = (typeof POD_DELETE_MODES)[number];
+
+/**
+ * Whether a string is one of the supported pod deletion modes.
+ */
+export function isPodDeleteMode(mode: string): mode is PodDeleteMode {
+  return (POD_DELETE_MODES as readonly string[]).includes(mode);
+}
+
 export function getResourceHandler(kind: string): ResourceHandler | undefined {
   return RESOURCE_HANDLERS[kind];
 }

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import {
   createKubernetesResource as createKubernetesResourceImpl,
   deleteKubernetesResource as deleteKubernetesResourceImpl,
+  deletePod as deletePodImpl,
   getKubernetesResource as getKubernetesResourceImpl,
   getPodLogs as getPodLogsImpl,
   listKubernetesResources as listKubernetesResourcesImpl,
@@ -11,7 +12,7 @@ import {
   restartKubernetesResource as restartKubernetesResourceImpl,
   updateKubernetesResource as updateKubernetesResourceImpl,
 } from "./kubernetes-resource";
-import { RESTARTABLE_KINDS, SUPPORTED_KINDS } from "./resource-handlers";
+import { DELETE_MODES, POD_DELETE_MODES, RESTARTABLE_KINDS, SUPPORTED_KINDS } from "./resource-handlers";
 
 const supportedKindsHint = `Built-in kinds with extra validation: ${SUPPORTED_KINDS.join(", ")}. Any other kind (including CRDs) is also accepted and passed through as a free manifest; for those provide the apiVersion explicitly.`;
 
@@ -171,12 +172,48 @@ export const getPodLogs = tool(getPodLogsImpl, {
 
 export const deleteKubernetesResource = tool(deleteKubernetesResourceImpl, {
   name: "deleteKubernetesResource",
-  description: "Delete a Kubernetes resource by name (namespace required for namespaced kinds)",
+  description:
+    "Delete a Kubernetes resource by name (namespace required for namespaced kinds). " +
+    'The optional "mode" selects how the deletion is performed: "delete" (default) is a normal delete; ' +
+    '"force_delete" deletes immediately with a zero grace period (use when a normal delete hangs); ' +
+    '"force_finalize" clears the resource finalizers so an object stuck in Terminating can be removed ' +
+    "(use only as a last resort, after a normal or force delete did not complete). " +
+    "For pods prefer the dedicated deletePod tool, which can also evict respecting PodDisruptionBudgets.",
   schema: z.object({
     kind: kindSchema,
     apiVersion: apiVersionSchema,
     name: z.string().describe("The name of the resource to delete"),
     namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
+    mode: z
+      .enum(DELETE_MODES)
+      .optional()
+      .describe(
+        'How to delete the resource. "delete" (default): normal delete. ' +
+          '"force_delete": immediate delete with grace period 0 when a normal delete hangs. ' +
+          '"force_finalize": clear finalizers to unstick a resource in Terminating (last resort).',
+      ),
+  }),
+});
+
+export const deletePod = tool(deletePodImpl, {
+  name: "deletePod",
+  description:
+    "Delete a single pod using a pod-specific variant. Namespace is required. " +
+    'The "mode" selects the behavior: "evict" requests a graceful eviction that honors any matching ' +
+    'PodDisruptionBudget (prefer this for draining or voluntary disruptions); "force_delete" deletes the pod ' +
+    "immediately with a zero grace period (use for pods stuck on an unreachable or NotReady node); " +
+    '"delete_with_finalizers" deletes the pod and clears its finalizers (last resort for a pod stuck in Terminating). ' +
+    "For a plain pod delete, use deleteKubernetesResource instead.",
+  schema: z.object({
+    name: z.string().describe("The name of the pod to delete"),
+    namespace: z.string().describe("The namespace of the pod"),
+    mode: z
+      .enum(POD_DELETE_MODES)
+      .describe(
+        '"evict": graceful eviction honoring PodDisruptionBudgets. ' +
+          '"force_delete": immediate delete with grace period 0 for pods stuck on an unreachable node. ' +
+          '"delete_with_finalizers": delete and clear finalizers to unstick a pod in Terminating (last resort).',
+      ),
   }),
 });
 
@@ -200,6 +237,7 @@ export const allToolFunctions = [
   updateKubernetesResource,
   patchKubernetesResource,
   deleteKubernetesResource,
+  deletePod,
   restartKubernetesResource,
 ];
 
@@ -270,10 +308,19 @@ export const toolFunctionDescriptions = [
   },
   {
     name: "deleteKubernetesResource",
-    description: "Delete a Kubernetes resource by name",
+    description: "Delete a Kubernetes resource by name, optionally with a force delete or finalize mode",
     arguments:
-      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string). Namespace (string) is required for namespaced kinds.",
+      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string) and a mode (string: " +
+      DELETE_MODES.join(", ") +
+      "; defaults to delete). Namespace (string) is required for namespaced kinds.",
     returnType: "Returns a message string indicating success or error after attempting to delete the resource.",
+  },
+  {
+    name: "deletePod",
+    description: "Delete a single pod via a pod-specific variant (evict, force delete, or delete with finalizers)",
+    arguments:
+      "Requires the pod name (string), namespace (string) and mode (string: " + POD_DELETE_MODES.join(", ") + ").",
+    returnType: "Returns a message string indicating success or error after attempting to delete the pod.",
   },
   {
     name: "restartKubernetesResource",


### PR DESCRIPTION
Implements #153.

Adds a dedicated `deletePod` tool exposing the host `PodApi` variants (evict, force_delete, delete_with_finalizers) and a `mode` parameter on `deleteKubernetesResource` mirroring the host `KubeObjectDeleteService` modes (delete, force_delete, force_finalize).
