### PR TITLE
Render tool approval prompts as YAML

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "vite-plugin-external": "^6.2.2",
     "vite-plugin-sass-dts": "^1.3.37",
     "vitest": "^4.1.9",
+    "yaml": "^2.7.1",
     "zod": "^3.25.67"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       vitest:
         specifier: ^4.1.9
         version: 4.1.9(@types/node@24.12.4)(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.7.1))
+      yaml:
+        specifier: ^2.7.1
+        version: 2.7.1
       zod:
         specifier: ^3.25.67
         version: 3.25.67
@@ -7938,8 +7941,7 @@ snapshots:
 
   yaml@1.10.2: {}
 
-  yaml@2.7.1:
-    optional: true
+  yaml@2.7.1: {}
 
   yauzl@2.10.0:
     dependencies:

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -1,5 +1,6 @@
 import { Renderer } from "@freelensapp/extensions";
 import { interrupt } from "@langchain/langgraph";
+import { stringify as stringifyYaml } from "yaml";
 import { PreferencesStore } from "../../../../common/store";
 import {
   capLogOutput,
@@ -124,7 +125,9 @@ function requestApproval(action: string, payload: Record<string, unknown>): bool
     question: "Do you want to approve this action?",
     options: ["yes", "no"],
     actionToApprove,
-    requestString: "```json\n" + JSON.stringify(actionToApprove, null, 2) + "\n```",
+    // Render the payload as YAML, the native format of the Kubernetes world,
+    // so the approval prompt is highlighted as YAML rather than JSON.
+    requestString: "```yaml\n" + stringifyYaml(actionToApprove) + "```",
   };
   const review = interrupt(interruptRequest);
   console.log("Tool call review: ", review);


### PR DESCRIPTION
Converts the write-action approval prompt payload from a JSON code block to a YAML code block with proper syntax highlighting, matching Kubernetes' native format.

Closes #156
