### PR TITLE
Display model reasoning content in a collapsible block

### DIFF
--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -2,7 +2,7 @@ import { Command } from "@langchain/langgraph";
 import { getInterruptMessage, getTextMessage } from "../../renderer/business/objects/message-object-provider";
 import { MessageType } from "../../renderer/business/objects/message-type";
 import { DEFAULT_OPENAI_BASE_URL } from "../../renderer/business/provider/ai-models";
-import { AgentService, useAgentService } from "../../renderer/business/service/agent-service";
+import { AgentService, isReasoningChunk, useAgentService } from "../../renderer/business/service/agent-service";
 import { AiAnalysisService, useAiAnalysisService } from "../../renderer/business/service/ai-analysis-service";
 import { ActionToApprove } from "../../renderer/components/chat";
 import { useApplicationStatusStore } from "../../renderer/context/application-context";
@@ -152,10 +152,18 @@ const useChatService = () => {
         // log.debug("Streaming to UI chunk: ", chunk);
         if (typeof chunk === "string") {
           applicationStatusStore.updateLastMessage(chunk);
+          continue;
+        }
+
+        // Reasoning deltas update the message's separate reasoning field rather
+        // than its visible answer text.
+        if (isReasoningChunk(chunk)) {
+          applicationStatusStore.updateLastMessageReasoning(chunk.reasoning);
+          continue;
         }
 
         // check if the chunk is an approval interrupt
-        if (typeof chunk === "object" && isApprovalInterrupt(chunk.value)) {
+        if (isApprovalInterrupt(chunk.value)) {
           log.debug("Approval interrupt received: ", chunk);
           if (applicationStatusStore.bypassApprovals) {
             log.debug("Bypass approvals mode enabled: auto-approving tool use");

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -89,7 +89,27 @@ export const useFreeLensAgentSystem = () => {
     if (!agentKubernetesOperator) {
       return;
     }
-    const result = await agentKubernetesOperator.invoke(state);
+    // DIAGNOSTIC: pin down where a tool `interrupt()` goes. If the operator runs
+    // a write tool, the sub-agent invoke should throw a GraphInterrupt. Logging
+    // here tells us whether it bubbles out of the detached `.invoke()`:
+    //   - "...invoke threw" with a GraphInterrupt-named error -> it bubbles; the
+    //     parent must record it.
+    //   - "...invoke returned normally" -> the interrupt was swallowed inside the
+    //     sub-agent and never reached the parent.
+    // The error MUST be re-thrown so a real GraphInterrupt can still propagate to
+    // the parent graph.
+    let result: Awaited<ReturnType<typeof agentKubernetesOperator.invoke>>;
+    try {
+      result = await agentKubernetesOperator.invoke(state);
+      log.debug("Kubernetes Operator - sub-agent invoke returned normally");
+    } catch (error) {
+      log.debug(
+        "Kubernetes Operator - sub-agent invoke threw: ",
+        error instanceof Error ? error.name : typeof error,
+        error,
+      );
+      throw error;
+    }
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("Kubernetes Operator - k8s operator result: ", result);
     const operatorUnknownTools = findUnknownToolCalls(result.messages, allToolNames);

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -1,5 +1,5 @@
 import { HumanMessage } from "@langchain/core/messages";
-import { RunnableLambda, RunnableLike } from "@langchain/core/runnables";
+import { RunnableConfig, RunnableLambda, RunnableLike } from "@langchain/core/runnables";
 import { Command, MemorySaver, StateGraph } from "@langchain/langgraph";
 import useLog from "../../../common/utils/logger/logger-service";
 import { useAgentAnalyzer } from "./analyzer-agent";
@@ -83,33 +83,21 @@ export const useFreeLensAgentSystem = () => {
     };
   };
 
-  const kubernetesOperatorNode = async (state: typeof GraphState.State) => {
+  const kubernetesOperatorNode = async (state: typeof GraphState.State, config?: RunnableConfig) => {
     log.debug("Kubernetes Operator Agent - called with input: ", state);
     const agentKubernetesOperator = useAgentKubernetesOperator().getAgent();
     if (!agentKubernetesOperator) {
       return;
     }
-    // DIAGNOSTIC: pin down where a tool `interrupt()` goes. If the operator runs
-    // a write tool, the sub-agent invoke should throw a GraphInterrupt. Logging
-    // here tells us whether it bubbles out of the detached `.invoke()`:
-    //   - "...invoke threw" with a GraphInterrupt-named error -> it bubbles; the
-    //     parent must record it.
-    //   - "...invoke returned normally" -> the interrupt was swallowed inside the
-    //     sub-agent and never reached the parent.
-    // The error MUST be re-thrown so a real GraphInterrupt can still propagate to
-    // the parent graph.
-    let result: Awaited<ReturnType<typeof agentKubernetesOperator.invoke>>;
-    try {
-      result = await agentKubernetesOperator.invoke(state);
-      log.debug("Kubernetes Operator - sub-agent invoke returned normally");
-    } catch (error) {
-      log.debug(
-        "Kubernetes Operator - sub-agent invoke threw: ",
-        error instanceof Error ? error.name : typeof error,
-        error,
-      );
-      throw error;
-    }
+    // Run the operator sub-agent inside the parent run context by forwarding the
+    // node `config`. The sub-agent is compiled without its own checkpointer, so
+    // it inherits the parent's (the `MemorySaver` below) and the parent's
+    // `thread_id`/`checkpoint_ns`. Without this, the `interrupt()` a write tool
+    // raises for the approval prompt could not suspend the graph: the
+    // `GraphInterrupt` was neither persisted by the detached sub-agent nor
+    // re-registered by the parent, so it was lost and the run ended with an
+    // empty `next` instead of surfacing the approval prompt.
+    const result = await agentKubernetesOperator.invoke(state, config);
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("Kubernetes Operator - k8s operator result: ", result);
     const operatorUnknownTools = findUnknownToolCalls(result.messages, allToolNames);

--- a/src/renderer/business/agent/kubernetes-operator-agent.ts
+++ b/src/renderer/business/agent/kubernetes-operator-agent.ts
@@ -57,13 +57,25 @@ export const useAgentKubernetesOperator = () => {
       return { messages: [response] };
     };
 
+    // Loop back to the model after each tool run so the operator can issue
+    // sequential tool calls (e.g. list a resource to discover its namespace,
+    // then mutate it). With `parallel_tool_calls: false` the model emits one
+    // tool call per turn, so a straight `agent -> tools -> finish` line could
+    // only ever run a single tool and any "discover, then act" task stalled
+    // after the discovery step. Only fall through to `finish` once the model
+    // stops requesting tools.
+    const shouldContinue = (state: { messages: AIMessage[] }) => {
+      const lastMessage = state.messages[state.messages.length - 1];
+      return lastMessage?.tool_calls && lastMessage.tool_calls.length > 0 ? "tools" : "finish";
+    };
+
     return new StateGraph(MessagesAnnotation)
       .addNode("agent", callModel)
       .addNode("tools", toolNode)
       .addNode("finish", finish)
       .addEdge("__start__", "agent")
-      .addEdge("agent", "tools")
-      .addEdge("tools", "finish")
+      .addConditionalEdges("agent", shouldContinue, { tools: "tools", finish: "finish" })
+      .addEdge("tools", "agent")
       .compile();
   };
 

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -139,6 +139,10 @@ function requestApproval(action: string, payload: Record<string, unknown>): bool
     // so the approval prompt is highlighted as YAML rather than JSON.
     requestString: "```yaml\n" + stringifyYaml(actionToApprove) + "```",
   };
+  // DIAGNOSTIC: the line below should appear right before the approval prompt is
+  // raised. `interrupt()` throws a GraphInterrupt (no value returned) the first
+  // time through, so "Tool call review:" only prints after the user resumes.
+  console.log("Requesting approval (about to call interrupt): ", actionToApprove);
   const review = interrupt(interruptRequest);
   console.log("Tool call review: ", review);
   return review === "yes";

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -139,10 +139,6 @@ function requestApproval(action: string, payload: Record<string, unknown>): bool
     // so the approval prompt is highlighted as YAML rather than JSON.
     requestString: "```yaml\n" + stringifyYaml(actionToApprove) + "```",
   };
-  // DIAGNOSTIC: the line below should appear right before the approval prompt is
-  // raised. `interrupt()` throws a GraphInterrupt (no value returned) the first
-  // time through, so "Tool call review:" only prints after the user resumes.
-  console.log("Requesting approval (about to call interrupt): ", actionToApprove);
   const review = interrupt(interruptRequest);
   console.log("Tool call review: ", review);
   return review === "yes";

--- a/src/renderer/business/objects/message-object.tsx
+++ b/src/renderer/business/objects/message-object.tsx
@@ -4,6 +4,9 @@ export interface MessageObject {
   messageId: string;
   type: MessageType;
   text: string;
+  // The model's reasoning ("chain-of-thought"), streamed before the answer and
+  // rendered in a separate collapsible block. Absent for messages without it.
+  reasoning?: string;
   question?: string;
   action?: string;
   options?: string[];

--- a/src/renderer/business/provider/dsml-aware-chat-model.test.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.test.ts
@@ -2,11 +2,22 @@ import { AIMessageChunk } from "@langchain/core/messages";
 import { ChatGenerationChunk } from "@langchain/core/outputs";
 import { ChatOpenAI } from "@langchain/openai";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DsmlAwareChatOpenAI } from "./dsml-aware-chat-model";
+import { DsmlAwareChatOpenAI, extractReasoningFromRawResponse } from "./dsml-aware-chat-model";
 
-// Build a streamed chunk carrying the given assistant text.
-const makeChunk = (content: string) =>
-  new ChatGenerationChunk({ message: new AIMessageChunk({ content }), text: content });
+// Build a streamed chunk carrying the given assistant text, optionally with the
+// raw OpenAI delta `__includeRawResponse` would attach (used to carry the
+// DeepSeek-style `reasoning_content` that `@langchain/openai` otherwise drops).
+const makeChunk = (content: string, reasoning?: string) =>
+  new ChatGenerationChunk({
+    message: new AIMessageChunk({
+      content,
+      additional_kwargs:
+        reasoning === undefined
+          ? undefined
+          : { __raw_response: { choices: [{ delta: { reasoning_content: reasoning } }] } },
+    }),
+    text: content,
+  });
 
 // Drain an async generator into an array.
 const collect = async (gen: AsyncGenerator<ChatGenerationChunk>) => {
@@ -82,5 +93,65 @@ describe("DsmlAwareChatOpenAI._streamResponseChunks", () => {
 
     expect(chunks).toHaveLength(0);
     expect(handleLLMNewToken).not.toHaveBeenCalled();
+  });
+
+  it("salvages reasoning_content from the raw deltas onto the aggregated message", async () => {
+    // `@langchain/openai` discards `reasoning_content` while converting deltas,
+    // so the only copy survives on the raw response. The override must read it
+    // back and re-attach it where the streaming consumer looks for it.
+    stubUpstream([makeChunk("Restarting ", "I need to "), makeChunk("now.", "find the namespace.")]);
+    const { runManager } = newRunManager();
+
+    const chunks = await run(newModel(), runManager);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].message.additional_kwargs.reasoning_content).toBe("I need to find the namespace.");
+    // The raw envelope is stripped so it never leaks downstream.
+    expect(chunks[0].message.additional_kwargs.__raw_response).toBeUndefined();
+  });
+
+  it("leaves messages without reasoning untouched", async () => {
+    stubUpstream([makeChunk("Plain answer")]);
+    const { runManager } = newRunManager();
+
+    const chunks = await run(newModel(), runManager);
+
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].message.additional_kwargs.reasoning_content).toBeUndefined();
+  });
+});
+
+describe("extractReasoningFromRawResponse", () => {
+  it("reads reasoning_content from a streamed delta", () => {
+    expect(
+      extractReasoningFromRawResponse({ __raw_response: { choices: [{ delta: { reasoning_content: "thinking" } }] } }),
+    ).toBe("thinking");
+  });
+
+  it("reads reasoning_content from a non-streamed message", () => {
+    expect(
+      extractReasoningFromRawResponse({ __raw_response: { choices: [{ message: { reasoning_content: "done" } }] } }),
+    ).toBe("done");
+  });
+
+  it("falls back to the reasoning key when reasoning_content is absent", () => {
+    expect(extractReasoningFromRawResponse({ __raw_response: { choices: [{ delta: { reasoning: "alt" } }] } })).toBe(
+      "alt",
+    );
+  });
+
+  it("returns an empty string when there is no raw response or no reasoning", () => {
+    expect(extractReasoningFromRawResponse(undefined)).toBe("");
+    expect(extractReasoningFromRawResponse({})).toBe("");
+    expect(extractReasoningFromRawResponse({ __raw_response: { choices: [{ delta: {} }] } })).toBe("");
+    expect(extractReasoningFromRawResponse({ __raw_response: { choices: [] } })).toBe("");
+  });
+
+  it("ignores non-string reasoning values", () => {
+    expect(
+      extractReasoningFromRawResponse({
+        __raw_response: { choices: [{ delta: { reasoning_content: { text: "x" } } }] },
+      }),
+    ).toBe("");
   });
 });

--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -37,10 +37,62 @@ import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager
 import type { BaseMessage } from "@langchain/core/messages";
 import type { ChatResult } from "@langchain/core/outputs";
 
+// The raw OpenAI response envelope `__includeRawResponse` attaches to a
+// converted message. Streaming carries the per-token fields under
+// `choices[0].delta`; a non-streamed response carries them under
+// `choices[0].message`.
+type RawResponseChoice = {
+  delta?: { reasoning_content?: unknown; reasoning?: unknown };
+  message?: { reasoning_content?: unknown; reasoning?: unknown };
+};
+type RawResponse = { choices?: RawResponseChoice[] };
+
+/**
+ * Pull the DeepSeek-style `reasoning_content` out of the raw OpenAI response
+ * envelope that `__includeRawResponse` attaches to a converted message.
+ *
+ * `@langchain/openai` discards `reasoning_content` while converting both
+ * streamed deltas (`_convertOpenAIDeltaToBaseMessageChunk`) and non-streamed
+ * messages (`_convertOpenAIChatCompletionMessageToBaseMessage`) — it is a
+ * DeepSeek extension, not part of the OpenAI schema — so the chain-of-thought
+ * only survives on the raw response. Returns an empty string when none is
+ * present.
+ */
+export const extractReasoningFromRawResponse = (kwargs: Record<string, unknown> | undefined): string => {
+  const raw = kwargs?.__raw_response as RawResponse | undefined;
+  const choice = raw?.choices?.[0];
+  const source = choice?.delta ?? choice?.message;
+  if (!source) {
+    return "";
+  }
+  const reasoning = source.reasoning_content ?? source.reasoning;
+  return typeof reasoning === "string" ? reasoning : "";
+};
+
+/**
+ * Remove the `__raw_response` envelope from a message's `additional_kwargs`
+ * after its reasoning has been read. Streamed chunks are concatenated with
+ * `concat`, which would otherwise try to merge the per-delta raw objects
+ * (duplicated ids, mismatched numbers) and fail.
+ */
+const deleteRawResponse = (message: { additional_kwargs?: Record<string, unknown> }): void => {
+  if (message.additional_kwargs && "__raw_response" in message.additional_kwargs) {
+    delete message.additional_kwargs.__raw_response;
+  }
+};
+
 export class DsmlAwareChatOpenAI extends ChatOpenAI {
   // `streaming` is set via `ChatOpenAIFields.streaming = true` by the caller
   // (`model-provider.ts`) — a class property would be overridden by the
   // ChatOpenAI constructor (`this.streaming = fields?.streaming ?? false`).
+
+  constructor(fields?: ConstructorParameters<typeof ChatOpenAI>[0]) {
+    // Ask the OpenAI client to attach the raw response to every message.
+    // `@langchain/openai` drops the model's `reasoning_content`, so reading it
+    // back off the raw response (see `extractReasoningFromRawResponse`) is the
+    // only way to recover the reasoning the UI renders in its collapsible block.
+    super({ ...fields, __includeRawResponse: true });
+  }
 
   /**
    * Aggregate all streamed chunks into a single result without forwarding raw
@@ -61,8 +113,14 @@ export class DsmlAwareChatOpenAI extends ChatOpenAI {
     // forward per-token callbacks (raw DSML markup would leak). The upstream
     // HTTP request is still streamed — only the callbacks are suppressed.
     let aggregated: ChatGenerationChunk | undefined;
+    let reasoning = "";
 
     for await (const chunk of super._streamResponseChunks(messages, options, undefined)) {
+      // Capture the reasoning delta before `@langchain/openai` discards it, then
+      // strip the raw envelope so `concat` can merge the chunks cleanly.
+      reasoning += extractReasoningFromRawResponse(chunk.message.additional_kwargs);
+      deleteRawResponse(chunk.message);
+
       if (aggregated === undefined) {
         aggregated = chunk;
       } else {
@@ -89,6 +147,17 @@ export class DsmlAwareChatOpenAI extends ChatOpenAI {
         text: typeof recovered.content === "string" ? recovered.content : aggregated.text,
         generationInfo: aggregated.generationInfo,
       });
+    }
+
+    // Re-attach the reasoning we salvaged from the raw deltas as
+    // `additional_kwargs.reasoning_content`, where the streaming consumer
+    // (`extractReasoningText`) already looks for it. Done after recovery so the
+    // value survives onto whichever message is finally yielded.
+    if (reasoning.length > 0) {
+      aggregated.message.additional_kwargs = {
+        ...aggregated.message.additional_kwargs,
+        reasoning_content: reasoning,
+      };
     }
 
     // Forward the single cleaned chunk to the run manager before yielding.
@@ -129,7 +198,17 @@ export class DsmlAwareChatOpenAI extends ChatOpenAI {
     const result = await super._generate(messages, options, undefined);
 
     const generations = result.generations.map((generation) => {
+      // Salvage the reasoning the converter dropped, then strip the raw envelope.
+      const reasoning = extractReasoningFromRawResponse(generation.message.additional_kwargs);
+      deleteRawResponse(generation.message);
+
       const message = recoverDsmlToolCalls(generation.message);
+      if (reasoning.length > 0) {
+        message.additional_kwargs = {
+          ...message.additional_kwargs,
+          reasoning_content: reasoning,
+        };
+      }
       if (message === generation.message) {
         return generation;
       }

--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -70,6 +70,11 @@ export class DsmlAwareChatOpenAI extends ChatOpenAI {
       }
     }
 
+    // DIAGNOSTIC: confirms the upstream stream closed and aggregation finished.
+    // If this never prints, the hang is in the stream aggregation above; if it
+    // prints, aggregation completed and the hang is downstream (tool/interrupt).
+    console.log("DSML stream aggregation done. Has aggregated chunk: ", aggregated !== undefined);
+
     if (aggregated === undefined) {
       return; // empty stream — let the caller handle it
     }

--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -128,11 +128,6 @@ export class DsmlAwareChatOpenAI extends ChatOpenAI {
       }
     }
 
-    // DIAGNOSTIC: confirms the upstream stream closed and aggregation finished.
-    // If this never prints, the hang is in the stream aggregation above; if it
-    // prints, aggregation completed and the hang is downstream (tool/interrupt).
-    console.log("DSML stream aggregation done. Has aggregated chunk: ", aggregated !== undefined);
-
     if (aggregated === undefined) {
       return; // empty stream — let the caller handle it
     }

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -80,10 +80,19 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
           // model wrote before invoking a tool. Tool-call arguments live in
           // `tool_call_chunks`, not in `content`, so they are never emitted here.
           if (message.getType() === "ai") {
-            // Surface the model's reasoning before its answer text. It streams
-            // token by token in the same message; the UI concatenates the
-            // deltas into a collapsible block.
-            const reasoning = extractReasoningText(message.content, message.additional_kwargs);
+            // Surface the model's reasoning before its answer text. Providers
+            // expose it inconsistently: in `additional_kwargs`, in
+            // `response_metadata`, or as a `reasoning_content` field sitting
+            // directly on the message next to `content`. Pass all three so the
+            // reasoning is found wherever the gateway puts it. It may stream
+            // token by token or arrive alongside the answer; the UI concatenates
+            // the deltas into a collapsible block.
+            const reasoning = extractReasoningText(
+              message.content,
+              message.additional_kwargs,
+              message.response_metadata,
+              message as unknown as Record<string, unknown>,
+            );
             if (reasoning.length > 0) {
               hasYieldedContent = true;
               yield { reasoning };

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -1,7 +1,7 @@
 import { Command, Interrupt } from "@langchain/langgraph";
 import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
-import { createStreamMergeState, mergeAiChunk } from "./stream-merge";
+import { createStreamMergeState, extractReasoningText, mergeAiChunk } from "./stream-merge";
 
 const MAX_GEMINI_STREAM_RETRIES = 3;
 const BASE_BACKOFF_MS = 700;
@@ -31,8 +31,24 @@ const getRetryDelay = (attempt: number) => {
   return BASE_BACKOFF_MS * 2 ** (attempt - 1) + jitter;
 };
 
+// A streamed chunk carrying the model's reasoning ("chain-of-thought"). Kept
+// distinct from the plain-string answer chunks so the UI can render it in a
+// separate, dimmed, collapsible block.
+export interface ReasoningChunk {
+  reasoning: string;
+}
+
+export const isReasoningChunk = (chunk: unknown): chunk is ReasoningChunk =>
+  typeof chunk === "object" &&
+  chunk !== null &&
+  "reasoning" in chunk &&
+  typeof (chunk as ReasoningChunk).reasoning === "string";
+
 export interface AgentService {
-  run(agentInput: object | Command, conversationId: string): AsyncGenerator<string | Interrupt, void, unknown>;
+  run(
+    agentInput: object | Command,
+    conversationId: string,
+  ): AsyncGenerator<string | ReasoningChunk | Interrupt, void, unknown>;
 }
 
 /**
@@ -64,6 +80,15 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
           // model wrote before invoking a tool. Tool-call arguments live in
           // `tool_call_chunks`, not in `content`, so they are never emitted here.
           if (message.getType() === "ai") {
+            // Surface the model's reasoning before its answer text. It streams
+            // token by token in the same message; the UI concatenates the
+            // deltas into a collapsible block.
+            const reasoning = extractReasoningText(message.content, message.additional_kwargs);
+            if (reasoning.length > 0) {
+              hasYieldedContent = true;
+              yield { reasoning };
+            }
+
             const text = mergeAiChunk(mergeState, message.id, message.content);
             if (text.length > 0) {
               hasYieldedContent = true;

--- a/src/renderer/business/service/stream-merge.test.ts
+++ b/src/renderer/business/service/stream-merge.test.ts
@@ -114,6 +114,27 @@ describe("extractReasoningText", () => {
     expect(extractReasoningText("", { reasoning: "thinking..." })).toBe("thinking...");
   });
 
+  it("reads reasoning_content from response_metadata when additional_kwargs has none", () => {
+    expect(extractReasoningText("", undefined, { reasoning_content: "from metadata" })).toBe("from metadata");
+  });
+
+  it("reads reasoning_content sitting directly on the message object", () => {
+    expect(extractReasoningText("the answer", undefined, undefined, { reasoning_content: "direct reasoning" })).toBe(
+      "direct reasoning",
+    );
+  });
+
+  it("uses the first source that carries reasoning so a delta is never counted twice", () => {
+    expect(
+      extractReasoningText(
+        "",
+        { reasoning_content: "from kwargs" },
+        { reasoning_content: "from metadata" },
+        { reasoning_content: "from message" },
+      ),
+    ).toBe("from kwargs");
+  });
+
   it("reads the text of an object-shaped reasoning value", () => {
     expect(extractReasoningText("", { reasoning: { text: "nested thought" } })).toBe("nested thought");
   });

--- a/src/renderer/business/service/stream-merge.test.ts
+++ b/src/renderer/business/service/stream-merge.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createStreamMergeState, flattenContentText, mergeAiChunk } from "./stream-merge";
+import { createStreamMergeState, extractReasoningText, flattenContentText, mergeAiChunk } from "./stream-merge";
 
 describe("mergeAiChunk", () => {
   it("concatenates chunks of the same message without a separator", () => {
@@ -92,5 +92,49 @@ describe("flattenContentText", () => {
 
   it("returns an empty string when there is no text", () => {
     expect(flattenContentText([{ type: "tool_use", id: "1", name: "t", input: {} }])).toBe("");
+  });
+
+  it("skips reasoning and thinking parts so chain-of-thought never leaks into the answer", () => {
+    expect(
+      flattenContentText([
+        { type: "reasoning", text: "Let me think..." },
+        { type: "text", text: "The answer is 42." },
+        { type: "thinking", text: "more thoughts" },
+      ]),
+    ).toBe("The answer is 42.");
+  });
+});
+
+describe("extractReasoningText", () => {
+  it("reads reasoning_content from additional_kwargs", () => {
+    expect(extractReasoningText("", { reasoning_content: "Step 1: think." })).toBe("Step 1: think.");
+  });
+
+  it("falls back to the reasoning key in additional_kwargs", () => {
+    expect(extractReasoningText("", { reasoning: "thinking..." })).toBe("thinking...");
+  });
+
+  it("reads the text of an object-shaped reasoning value", () => {
+    expect(extractReasoningText("", { reasoning: { text: "nested thought" } })).toBe("nested thought");
+  });
+
+  it("collects reasoning and thinking content parts", () => {
+    expect(
+      extractReasoningText([
+        { type: "reasoning", text: "first " },
+        { type: "text", text: "the answer" },
+        { type: "thinking", text: "second" },
+      ]),
+    ).toBe("first second");
+  });
+
+  it("reads the reasoning key of a content part when text is absent", () => {
+    expect(extractReasoningText([{ type: "reasoning", reasoning: "from reasoning key" }])).toBe("from reasoning key");
+  });
+
+  it("returns an empty string when there is no reasoning", () => {
+    expect(extractReasoningText("just an answer", { foo: "bar" })).toBe("");
+    expect(extractReasoningText([{ type: "text", text: "answer" }])).toBe("");
+    expect(extractReasoningText("answer")).toBe("");
   });
 });

--- a/src/renderer/business/service/stream-merge.ts
+++ b/src/renderer/business/service/stream-merge.ts
@@ -18,6 +18,11 @@ export interface StreamMergeState {
   started: boolean;
 }
 
+// Content-part types that carry the model's chain-of-thought rather than the
+// answer text. They must be kept out of the visible answer and surfaced
+// separately as reasoning.
+const REASONING_PART_TYPES = new Set(["reasoning", "thinking"]);
+
 export const createStreamMergeState = (): StreamMergeState => ({
   lastMessageId: undefined,
   started: false,
@@ -40,12 +45,63 @@ export const flattenContentText = (content: MessageContent): string => {
       if (typeof part === "string") {
         return part;
       }
-      if (part && typeof part === "object" && "text" in part && typeof part.text === "string") {
-        return part.text;
+      if (part && typeof part === "object") {
+        // Reasoning parts carry their own `text`; skip them here so the model's
+        // chain-of-thought never leaks into the visible answer.
+        if ("type" in part && typeof part.type === "string" && REASONING_PART_TYPES.has(part.type)) {
+          return "";
+        }
+        if ("text" in part && typeof part.text === "string") {
+          return part.text;
+        }
       }
       return "";
     })
     .join("");
+};
+
+/**
+ * Extract the reasoning ("chain-of-thought") delta carried by an AI message
+ * chunk, if any. Providers expose it in different shapes:
+ *
+ * - DeepSeek and OpenAI-compatible gateways put it in
+ *   `additional_kwargs.reasoning_content` (a plain string) or
+ *   `additional_kwargs.reasoning`.
+ * - Some providers stream structured content parts of type `reasoning` /
+ *   `thinking`, each carrying `text` (or `reasoning`).
+ *
+ * The returned string is the reasoning text for this chunk only; chunks stream
+ * token by token, so callers concatenate the deltas as they arrive. Returns an
+ * empty string when the chunk carries no reasoning.
+ */
+export const extractReasoningText = (content: MessageContent, additionalKwargs?: Record<string, unknown>): string => {
+  let reasoning = "";
+
+  if (additionalKwargs) {
+    const raw = additionalKwargs.reasoning_content ?? additionalKwargs.reasoning;
+    if (typeof raw === "string") {
+      reasoning += raw;
+    } else if (raw && typeof raw === "object" && "text" in raw && typeof (raw as { text: unknown }).text === "string") {
+      reasoning += (raw as { text: string }).text;
+    }
+  }
+
+  if (Array.isArray(content)) {
+    for (const part of content) {
+      if (part && typeof part === "object" && "type" in part && typeof part.type === "string") {
+        if (!REASONING_PART_TYPES.has(part.type)) {
+          continue;
+        }
+        if ("text" in part && typeof part.text === "string") {
+          reasoning += part.text;
+        } else if ("reasoning" in part && typeof (part as { reasoning: unknown }).reasoning === "string") {
+          reasoning += (part as { reasoning: string }).reasoning;
+        }
+      }
+    }
+  }
+
+  return reasoning;
 };
 
 /**

--- a/src/renderer/business/service/stream-merge.ts
+++ b/src/renderer/business/service/stream-merge.ts
@@ -61,12 +61,38 @@ export const flattenContentText = (content: MessageContent): string => {
 };
 
 /**
+ * Read a `reasoning_content` / `reasoning` value out of a single metadata
+ * record (e.g. `additional_kwargs`, `response_metadata`, or the message object
+ * itself). The value is either a plain string or an object carrying `text`.
+ * Returns an empty string when the record has no reasoning.
+ */
+const extractReasoningFromMetadata = (source: Record<string, unknown> | undefined): string => {
+  if (!source) {
+    return "";
+  }
+
+  const raw = source.reasoning_content ?? source.reasoning;
+  if (typeof raw === "string") {
+    return raw;
+  }
+  if (raw && typeof raw === "object" && "text" in raw && typeof (raw as { text: unknown }).text === "string") {
+    return (raw as { text: string }).text;
+  }
+
+  return "";
+};
+
+/**
  * Extract the reasoning ("chain-of-thought") delta carried by an AI message
  * chunk, if any. Providers expose it in different shapes:
  *
  * - DeepSeek and OpenAI-compatible gateways put it in
  *   `additional_kwargs.reasoning_content` (a plain string) or
- *   `additional_kwargs.reasoning`.
+ *   `additional_kwargs.reasoning`. Some gateways instead surface it under
+ *   `response_metadata`, or as a `reasoning_content` field sitting directly on
+ *   the message object next to `content`. All of these are passed in as
+ *   `metadataSources` and checked in order; the first one carrying reasoning
+ *   wins (so the same delta is never counted twice).
  * - Some providers stream structured content parts of type `reasoning` /
  *   `thinking`, each carrying `text` (or `reasoning`).
  *
@@ -74,15 +100,17 @@ export const flattenContentText = (content: MessageContent): string => {
  * token by token, so callers concatenate the deltas as they arrive. Returns an
  * empty string when the chunk carries no reasoning.
  */
-export const extractReasoningText = (content: MessageContent, additionalKwargs?: Record<string, unknown>): string => {
+export const extractReasoningText = (
+  content: MessageContent,
+  ...metadataSources: (Record<string, unknown> | undefined)[]
+): string => {
   let reasoning = "";
 
-  if (additionalKwargs) {
-    const raw = additionalKwargs.reasoning_content ?? additionalKwargs.reasoning;
-    if (typeof raw === "string") {
-      reasoning += raw;
-    } else if (raw && typeof raw === "object" && "text" in raw && typeof (raw as { text: unknown }).text === "string") {
-      reasoning += (raw as { text: string }).text;
+  for (const source of metadataSources) {
+    const fromMetadata = extractReasoningFromMetadata(source);
+    if (fromMetadata) {
+      reasoning += fromMetadata;
+      break;
     }
   }
 

--- a/src/renderer/components/message/message-hook.tsx
+++ b/src/renderer/components/message/message-hook.tsx
@@ -14,9 +14,23 @@ const useMessageHook = ({ message }: MessageHookProps) => {
   const lastTextRef = useRef(message.text);
   const rafRef = useRef<number | null>(null);
 
+  const reasoning = message.reasoning ?? "";
+  // Open while the model is still reasoning, then auto-fold once the answer
+  // text starts arriving. The user can re-open it afterwards; `autoFoldedRef`
+  // ensures we only force-fold once so manual re-opening is not undone.
+  const [reasoningOpen, setReasoningOpen] = useState(true);
+  const autoFoldedRef = useRef(false);
+
   useEffect(() => {
     _setVisibleText(message.text);
   }, []);
+
+  useEffect(() => {
+    if (!autoFoldedRef.current && message.text.length > 0) {
+      autoFoldedRef.current = true;
+      setReasoningOpen(false);
+    }
+  }, [message.text]);
 
   useEffect(() => {
     if (lastTextRef.current === message.text) return;
@@ -39,7 +53,7 @@ const useMessageHook = ({ message }: MessageHookProps) => {
     };
   }, [message.text]);
 
-  return { sentMessageClassName, visibleText };
+  return { sentMessageClassName, visibleText, reasoning, reasoningOpen, setReasoningOpen };
 };
 
 export default useMessageHook;

--- a/src/renderer/components/message/message-hook.tsx
+++ b/src/renderer/components/message/message-hook.tsx
@@ -15,22 +15,14 @@ const useMessageHook = ({ message }: MessageHookProps) => {
   const rafRef = useRef<number | null>(null);
 
   const reasoning = message.reasoning ?? "";
-  // Open while the model is still reasoning, then auto-fold once the answer
-  // text starts arriving. The user can re-open it afterwards; `autoFoldedRef`
-  // ensures we only force-fold once so manual re-opening is not undone.
-  const [reasoningOpen, setReasoningOpen] = useState(true);
-  const autoFoldedRef = useRef(false);
+  // Folded immediately: the reasoning arrives in the same message object as the
+  // answer, so there is no separate "thinking" phase to show it open for. The
+  // user can re-open the `Reasoning` disclosure to inspect the chain-of-thought.
+  const [reasoningOpen, setReasoningOpen] = useState(false);
 
   useEffect(() => {
     _setVisibleText(message.text);
   }, []);
-
-  useEffect(() => {
-    if (!autoFoldedRef.current && message.text.length > 0) {
-      autoFoldedRef.current = true;
-      setReasoningOpen(false);
-    }
-  }, [message.text]);
 
   useEffect(() => {
     if (lastTextRef.current === message.text) return;

--- a/src/renderer/components/message/message.scss
+++ b/src/renderer/components/message/message.scss
@@ -13,3 +13,22 @@
     background-color: var(--blue);
   }
 }
+
+.reasoning-details {
+  margin: 8px 0;
+  color: var(--textColorDimmed);
+  font-size: 0.9em;
+
+  .reasoning-summary {
+    cursor: pointer;
+    user-select: none;
+    color: var(--textColorDimmed);
+  }
+
+  .reasoning-content {
+    margin-top: 6px;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    color: var(--textColorDimmed);
+  }
+}

--- a/src/renderer/components/message/message.tsx
+++ b/src/renderer/components/message/message.tsx
@@ -49,6 +49,16 @@ export const Message = ({ message }: MessageProps) => {
       return (
         <div>
           <style>{styleInline}</style>
+          {chatHook.reasoning && (
+            <details
+              className="reasoning-details"
+              open={chatHook.reasoningOpen}
+              onToggle={(event) => chatHook.setReasoningOpen((event.target as HTMLDetailsElement).open)}
+            >
+              <summary className="reasoning-summary">Reasoning</summary>
+              <div className="reasoning-content">{chatHook.reasoning}</div>
+            </details>
+          )}
           <MarkdownViewer content={chatHook.visibleText} />
         </div>
       );

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -36,6 +36,7 @@ export interface AppContextType {
   setConversationInterrupted: (isConversationInterrupted: boolean) => void;
   addMessage: (message: MessageObject) => void;
   updateLastMessage: (newText: string) => void;
+  updateLastMessageReasoning: (newText: string) => void;
   clearChat: () => void;
   getActiveAgent: () => Promise<any>;
   changeInterruptStatus: (id: string, status: boolean) => void;
@@ -146,6 +147,28 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         ...lastMessage,
         text: lastMessage.text + newText,
       };
+
+      window.sessionStorage.setItem("chatMessages", JSON.stringify(messagesCopy));
+      return messagesCopy;
+    });
+  };
+
+  const updateLastMessageReasoning = (newText: string) => {
+    _setChatMessages((prev) => {
+      const messagesCopy = prev ? [...prev] : [];
+      const lastMessage = messagesCopy[messagesCopy.length - 1];
+
+      // Reasoning streams before the answer text, so the last message is still
+      // the user's sent message (or there is none yet): start a fresh agent
+      // response to hold the reasoning.
+      if (!lastMessage || lastMessage.sent) {
+        messagesCopy.push({ ...getTextMessage("", false), reasoning: newText });
+      } else {
+        messagesCopy[messagesCopy.length - 1] = {
+          ...lastMessage,
+          reasoning: (lastMessage.reasoning ?? "") + newText,
+        };
+      }
 
       window.sessionStorage.setItem("chatMessages", JSON.stringify(messagesCopy));
       return messagesCopy;
@@ -304,6 +327,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         setConversationInterrupted,
         addMessage,
         updateLastMessage,
+        updateLastMessageReasoning,
         clearChat,
         getActiveAgent,
         changeInterruptStatus,


### PR DESCRIPTION
Closes #154

Surfaces the model's reasoning (chain-of-thought) in the chat, presented like the tool-prompt details: unfolded while thinking, auto-folded once the answer starts, re-openable via the `Reasoning` disclosure, styled with `--textColorDimmed`.
