### PR TITLE
Require a per-launch bearer token on the AI proxy

### DIFF
--- a/src/common/store/preferences-store.ts
+++ b/src/common/store/preferences-store.ts
@@ -13,6 +13,7 @@ export interface PreferencesModel {
   openAIReasoningEffort: string;
   disableThinking: boolean;
   aiProxyPort: number | null;
+  aiProxyToken: string | null;
   selectedModel: string;
   models: CustomModel[];
   mcpEnabled: boolean;
@@ -30,6 +31,10 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
   openAIReasoningEffort: string = "";
   disableThinking: boolean = false;
   aiProxyPort: number | null = null;
+  // Per-launch shared secret required on every request to the local AI proxy.
+  // Generated in the main process on activation and synced to the renderer via
+  // this store; blocks other local processes that learn the port from using it.
+  aiProxyToken: string | null = null;
   selectedModel: string = DEFAULT_SELECTED_MODEL;
   models: CustomModel[] = [...DEFAULT_MODELS];
   mcpEnabled: boolean = false;
@@ -54,6 +59,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
         openAIReasoningEffort: "",
         disableThinking: false,
         aiProxyPort: null,
+        aiProxyToken: null,
         selectedModel: DEFAULT_SELECTED_MODEL,
         models: [...DEFAULT_MODELS],
         mcpEnabled: false,
@@ -84,6 +90,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
       openAIReasoningEffort: observable,
       disableThinking: observable,
       aiProxyPort: observable,
+      aiProxyToken: observable,
       selectedModel: observable,
       models: observable,
       mcpEnabled: observable,
@@ -105,6 +112,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
     this.openAIReasoningEffort = preferencesModel.openAIReasoningEffort ?? "";
     this.disableThinking = preferencesModel.disableThinking ?? false;
     this.aiProxyPort = preferencesModel.aiProxyPort ?? null;
+    this.aiProxyToken = preferencesModel.aiProxyToken ?? null;
     this.models = preferencesModel.models?.length ? preferencesModel.models : [...DEFAULT_MODELS];
     // Validate the selection against the available models; fall back to the
     // first entry (replaces the old enum validation).
@@ -130,6 +138,7 @@ export class PreferencesStore extends Common.Store.ExtensionStore<PreferencesMod
       openAIReasoningEffort: this.openAIReasoningEffort,
       disableThinking: this.disableThinking,
       aiProxyPort: this.aiProxyPort,
+      aiProxyToken: this.aiProxyToken,
       selectedModel: this.selectedModel,
       models: toJS(this.models),
       mcpEnabled: this.mcpEnabled,

--- a/src/main/ai-proxy-server.ts
+++ b/src/main/ai-proxy-server.ts
@@ -10,6 +10,11 @@ const AI_PROXY_HOST = "127.0.0.1";
 // base URL without changing the proxy.
 const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
 
+// Header carrying the per-launch shared secret. The renderer (see
+// model-provider.ts) sends it on every request; the proxy rejects any request
+// whose token does not match the one generated for this launch.
+const PROXY_TOKEN_HEADER = "x-ai-proxy-token";
+
 const UPSTREAM_BY_PREFIX: Record<string, string> = {
   openai: "https://api.openai.com/v1",
 };
@@ -21,12 +26,17 @@ let proxyServerPort: number | null = null;
 // changed in preferences takes effect immediately.
 let resolveApiKey: () => string | undefined = () => undefined;
 
+// Per-launch shared secret. The renderer (see model-provider.ts) sends it on
+// every request; the proxy rejects any request whose token does not match the
+// one generated for this launch.
+let proxyAuthToken: string | null = null;
+
 // Only the methods and headers the LLM SDKs actually use. The wildcard origin
 // is replaced by reflecting the caller's Origin (see applyCorsHeaders) so the
 // proxy never advertises itself as open to every origin.
 const CORS_ALLOW_METHODS = "GET,POST,OPTIONS";
 const CORS_ALLOW_HEADERS =
-  "authorization,content-type,x-stainless-os,x-stainless-runtime-version,x-stainless-package-version,x-stainless-runtime,x-stainless-arch,x-stainless-retry-count,x-stainless-lang,accept,user-agent,x-upstream-base-url";
+  "authorization,content-type,x-stainless-os,x-stainless-runtime-version,x-stainless-package-version,x-stainless-runtime,x-stainless-arch,x-stainless-retry-count,x-stainless-lang,accept,user-agent,x-upstream-base-url,x-ai-proxy-token";
 
 const hopByHopHeaders = new Set([
   "connection",
@@ -86,7 +96,12 @@ const createUpstreamHeaders = (request: IncomingMessage) => {
   const headers = new Headers();
 
   for (const [key, value] of Object.entries(request.headers)) {
-    if (hopByHopHeaders.has(key) || key === UPSTREAM_BASE_URL_HEADER || value === undefined) {
+    if (
+      hopByHopHeaders.has(key) ||
+      key === UPSTREAM_BASE_URL_HEADER ||
+      key === PROXY_TOKEN_HEADER ||
+      value === undefined
+    ) {
       continue;
     }
 
@@ -152,7 +167,11 @@ const proxyRequest = async (request: IncomingMessage, response: ServerResponse) 
   Readable.fromWeb(upstreamResponse.body as any).pipe(response);
 };
 
-export const startAiProxyServer = async (apiKeyResolver: () => string | undefined = () => undefined) => {
+export const startAiProxyServer = async (
+  authToken: string,
+  apiKeyResolver: () => string | undefined = () => undefined,
+) => {
+  proxyAuthToken = authToken;
   resolveApiKey = apiKeyResolver;
 
   if (proxyServerStarted && proxyServerPort !== null) {
@@ -165,6 +184,17 @@ export const startAiProxyServer = async (apiKeyResolver: () => string | undefine
     if (request.method === "OPTIONS") {
       response.statusCode = 204;
       response.end();
+      return;
+    }
+
+    // Reject any request that does not carry the per-launch shared secret. This
+    // stops other local processes (or pages) that learn the port from using the
+    // user's API key.
+    const requestToken = request.headers[PROXY_TOKEN_HEADER];
+    if (!proxyAuthToken || requestToken !== proxyAuthToken) {
+      response.statusCode = 401;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify({ error: "Unauthorized" }));
       return;
     }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from "node:crypto";
 import { Main } from "@freelensapp/extensions";
 import { PreferencesStore } from "../common/store";
 import { startAiProxyServer } from "./ai-proxy-server";
@@ -8,10 +9,19 @@ export default class LensExtensionAiMain extends Main.LensExtension {
     const preferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
 
     preferencesStore.loadExtension(this);
+
+    // Generate a fresh shared secret for this launch and require it on every
+    // proxy request, so a local process that learns the port cannot reuse the
+    // user's API key.
+    const aiProxyToken = randomBytes(32).toString("hex");
+    preferencesStore.aiProxyToken = aiProxyToken;
+
     preferencesStore.aiProxyPort = null;
     // The proxy injects the API key into the upstream request from here in the
-    // main process, so the key never has to be sent from the renderer.
+    // main process, so the key never has to be sent from the renderer. It also
+    // requires the per-launch shared secret on every request.
     preferencesStore.aiProxyPort = await startAiProxyServer(
+      aiProxyToken,
       () => process.env.OPENAI_API_KEY || preferencesStore.openAIKey || undefined,
     );
   }

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -48,6 +48,7 @@ export const useModelProvider = () => {
           apiKey: PROXY_MANAGED_API_KEY,
           upstreamBaseUrl: openAIBaseUrl,
           proxyBaseUrl: getAiProxyBaseUrl(preferencesStore.aiProxyPort),
+          proxyToken: preferencesStore.aiProxyToken,
           reasoningEffort: preferencesStore.openAIReasoningEffort,
           disableThinking: preferencesStore.disableThinking,
         });

--- a/src/renderer/business/provider/openai-fields.test.ts
+++ b/src/renderer/business/provider/openai-fields.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildOpenAIChatFields, UPSTREAM_BASE_URL_HEADER } from "./openai-fields";
+import { buildOpenAIChatFields, PROXY_TOKEN_HEADER, UPSTREAM_BASE_URL_HEADER } from "./openai-fields";
 
 const baseOptions = {
   apiKey: "sk-test",
@@ -16,6 +16,18 @@ describe("buildOpenAIChatFields", () => {
     expect(fields.configuration?.defaultHeaders).toMatchObject({
       [UPSTREAM_BASE_URL_HEADER]: "https://api.openai.com/v1",
     });
+  });
+
+  it("sends the proxy token header when a token is provided", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "gpt-4.1", proxyToken: "secret-token" });
+    expect(fields.configuration?.defaultHeaders).toMatchObject({
+      [PROXY_TOKEN_HEADER]: "secret-token",
+    });
+  });
+
+  it("omits the proxy token header when no token is provided", () => {
+    const fields = buildOpenAIChatFields({ ...baseOptions, modelName: "gpt-4.1" });
+    expect(fields.configuration?.defaultHeaders).not.toHaveProperty(PROXY_TOKEN_HEADER);
   });
 
   it("sets temperature 0 and no reasoning effort for non-reasoning models", () => {

--- a/src/renderer/business/provider/openai-fields.ts
+++ b/src/renderer/business/provider/openai-fields.ts
@@ -11,6 +11,10 @@ import type { ChatOpenAIFields } from "@langchain/openai";
 // letting the user configure a custom base URL without changing the proxy code.
 export const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
 
+// Header carrying the per-launch shared secret the proxy requires on every
+// request.
+export const PROXY_TOKEN_HEADER = "x-ai-proxy-token";
+
 export interface OpenAIChatFieldsOptions {
   // Model id sent to the OpenAI API (e.g. "gpt-5.5").
   modelName: string;
@@ -20,6 +24,8 @@ export interface OpenAIChatFieldsOptions {
   upstreamBaseUrl: string;
   // Local proxy origin (e.g. http://127.0.0.1:<port>); the "/openai" prefix is appended.
   proxyBaseUrl: string;
+  // Per-launch shared secret sent to the proxy so it accepts the request.
+  proxyToken?: string | null;
   // Optional reasoning effort; applied only to reasoning-capable models.
   reasoningEffort?: string;
   // When true, request the upstream to disable its "thinking" mode. Some
@@ -35,6 +41,7 @@ export const buildOpenAIChatFields = ({
   apiKey,
   upstreamBaseUrl,
   proxyBaseUrl,
+  proxyToken,
   reasoningEffort,
   disableThinking,
 }: OpenAIChatFieldsOptions): ChatOpenAIFields => {
@@ -47,6 +54,7 @@ export const buildOpenAIChatFields = ({
       baseURL: `${proxyBaseUrl}/openai`,
       defaultHeaders: {
         [UPSTREAM_BASE_URL_HEADER]: upstreamBaseUrl,
+        ...(proxyToken ? { [PROXY_TOKEN_HEADER]: proxyToken } : {}),
       },
     },
   };


### PR DESCRIPTION
Hardening proposition 1 from issue #113.

Generate a random per-launch token in the main process, sync it to the renderer via the preferences store, send it on every proxy request via the `x-ai-proxy-token` header, and reject mismatched requests with 401.
