### PR TITLE
Inject the API key in the main process instead of the renderer

### DIFF
--- a/src/main/ai-proxy-server.test.ts
+++ b/src/main/ai-proxy-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { applyCorsHeaders } from "./ai-proxy-server";
+import { applyCorsHeaders, applyManagedAuthorization } from "./ai-proxy-server";
 import type { ServerResponse } from "node:http";
 
 // Minimal ServerResponse stand-in that records setHeader calls.
@@ -32,5 +32,25 @@ describe("applyCorsHeaders", () => {
     const response = createResponseStub();
     applyCorsHeaders(response, "lens://extension");
     expect(response.headers["access-control-allow-methods"]).toBe("GET,POST,OPTIONS");
+  });
+});
+
+describe("applyManagedAuthorization", () => {
+  it("sets the Authorization header from the resolved key", () => {
+    const headers = new Headers();
+    applyManagedAuthorization(headers, "sk-secret");
+    expect(headers.get("authorization")).toBe("Bearer sk-secret");
+  });
+
+  it("overrides any Authorization sent by the renderer placeholder", () => {
+    const headers = new Headers({ authorization: "Bearer freelens-proxy-managed" });
+    applyManagedAuthorization(headers, "sk-real");
+    expect(headers.get("authorization")).toBe("Bearer sk-real");
+  });
+
+  it("leaves the headers untouched when no key is resolved", () => {
+    const headers = new Headers({ authorization: "Bearer placeholder" });
+    applyManagedAuthorization(headers, undefined);
+    expect(headers.get("authorization")).toBe("Bearer placeholder");
   });
 });

--- a/src/main/ai-proxy-server.ts
+++ b/src/main/ai-proxy-server.ts
@@ -16,6 +16,10 @@ const UPSTREAM_BY_PREFIX: Record<string, string> = {
 
 let proxyServerStarted = false;
 let proxyServerPort: number | null = null;
+// Resolves the upstream API key inside the main process so the secret never has
+// to be sent from (or stored in) the renderer. Evaluated per request so a key
+// changed in preferences takes effect immediately.
+let resolveApiKey: () => string | undefined = () => undefined;
 
 // Only the methods and headers the LLM SDKs actually use. The wildcard origin
 // is replaced by reflecting the caller's Origin (see applyCorsHeaders) so the
@@ -66,6 +70,18 @@ const readRequestBody = async (request: IncomingMessage) => {
   return chunks.length > 0 ? Buffer.concat(chunks) : undefined;
 };
 
+// Override the Authorization header with the API key resolved in the main
+// process. The renderer sends only a placeholder, so the real key never travels
+// through (or is exposed to) the renderer / DevTools. No-op when no key is set,
+// letting the upstream reject the request with its own 401.
+export const applyManagedAuthorization = (headers: Headers, apiKey: string | undefined): Headers => {
+  if (apiKey) {
+    headers.set("authorization", `Bearer ${apiKey}`);
+  }
+
+  return headers;
+};
+
 const createUpstreamHeaders = (request: IncomingMessage) => {
   const headers = new Headers();
 
@@ -81,7 +97,7 @@ const createUpstreamHeaders = (request: IncomingMessage) => {
     }
   }
 
-  return headers;
+  return applyManagedAuthorization(headers, resolveApiKey());
 };
 
 const proxyRequest = async (request: IncomingMessage, response: ServerResponse) => {
@@ -136,7 +152,9 @@ const proxyRequest = async (request: IncomingMessage, response: ServerResponse) 
   Readable.fromWeb(upstreamResponse.body as any).pipe(response);
 };
 
-export const startAiProxyServer = async () => {
+export const startAiProxyServer = async (apiKeyResolver: () => string | undefined = () => undefined) => {
+  resolveApiKey = apiKeyResolver;
+
   if (proxyServerStarted && proxyServerPort !== null) {
     return proxyServerPort;
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,10 @@ export default class LensExtensionAiMain extends Main.LensExtension {
 
     preferencesStore.loadExtension(this);
     preferencesStore.aiProxyPort = null;
-    preferencesStore.aiProxyPort = await startAiProxyServer();
+    // The proxy injects the API key into the upstream request from here in the
+    // main process, so the key never has to be sent from the renderer.
+    preferencesStore.aiProxyPort = await startAiProxyServer(
+      () => process.env.OPENAI_API_KEY || preferencesStore.openAIKey || undefined,
+    );
   }
 }

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -10,6 +10,11 @@ import { buildOpenAIChatFields } from "./openai-fields";
 // definition now lives next to the field builder.
 export { UPSTREAM_BASE_URL_HEADER } from "./openai-fields";
 
+// Placeholder key sent to the SDK so it populates the Authorization header; the
+// AI proxy overrides it with the real key resolved in the main process, so the
+// secret never travels through the renderer.
+const PROXY_MANAGED_API_KEY = "freelens-proxy-managed";
+
 const getAiProxyBaseUrl = (aiProxyPort: number | null) => {
   if (aiProxyPort === null) {
     throw new Error("AI proxy is not ready yet. Retry in a moment.");
@@ -36,12 +41,11 @@ export const useModelProvider = () => {
 
     switch (provider) {
       case AIProviders.OPEN_AI: {
-        const openAiApiKey = process.env.OPENAI_API_KEY || preferencesStore.openAIKey;
         const openAIBaseUrl = preferencesStore.openAIBaseUrl || DEFAULT_OPENAI_BASE_URL;
 
         const fields = buildOpenAIChatFields({
           modelName,
-          apiKey: openAiApiKey,
+          apiKey: PROXY_MANAGED_API_KEY,
           upstreamBaseUrl: openAIBaseUrl,
           proxyBaseUrl: getAiProxyBaseUrl(preferencesStore.aiProxyPort),
           reasoningEffort: preferencesStore.openAIReasoningEffort,


### PR DESCRIPTION
Hardening proposition 2 from issue #113.

Resolve the API key in the main process and have the proxy set the Authorization header itself. The renderer now sends only a placeholder key, so the secret never travels through the renderer or DevTools.
