### PR TITLE
Make builds deterministic by replacing vite-plugin-external

### DIFF
--- a/build/global-externals.js
+++ b/build/global-externals.js
@@ -1,0 +1,175 @@
+// Vite/Rolldown plugin that maps bare module ids (react, mobx, ...) to runtime
+// globals provided by the Freelens host (global.React, global.Mobx, ...).
+//
+// This replaces `vite-plugin-external`, whose CommonJS shim
+// (`module.exports = global.React`) only exposes a statically detectable
+// `default` export. Rolldown discovers the *named* exports of such a CJS shim
+// through a non-deterministic static-analysis / dep pre-bundle step, so builds
+// intermittently failed with errors such as:
+//
+//   [MISSING_EXPORT] "forwardRef" is not exported by ".vite_external/react.js"
+//
+// when a third-party dependency (lucide-react, react-syntax-highlighter, ...)
+// did `import { forwardRef } from "react"` and the detection lost the race.
+//
+// Instead, this plugin emits an ESM shim with *explicit* named exports, so the
+// module graph is fully static and the build is deterministic:
+//
+//   const __m = global.React;
+//   export default __m;
+//   export const forwardRef = __m.forwardRef;
+//   ...
+//
+// (Rolldown 1.0.3 does not support `syntheticNamedExports`, so the names must
+// be materialized explicitly.) The export names are discovered at config time
+// from the installed package, with no hardcoded lists.
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+// electron-vite bundles this config helper before running it, so __dirname is
+// unreliable. Builds always run from the project root, so use the cwd.
+const ROOT = process.cwd();
+
+const IDENTIFIER_RE = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+// Names that are valid object keys but cannot be used as `export const <name>`.
+const RESERVED = new Set([
+  "default",
+  "__esModule",
+  "break",
+  "case",
+  "catch",
+  "class",
+  "const",
+  "continue",
+  "debugger",
+  "delete",
+  "do",
+  "else",
+  "enum",
+  "export",
+  "extends",
+  "false",
+  "finally",
+  "for",
+  "function",
+  "if",
+  "import",
+  "in",
+  "instanceof",
+  "new",
+  "null",
+  "return",
+  "super",
+  "switch",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typeof",
+  "var",
+  "void",
+  "while",
+  "with",
+  "yield",
+]);
+
+function packageNameOf(id) {
+  const parts = id.split("/");
+  return id.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+}
+
+// Resolve the on-disk entry of a module, falling back to the pnpm virtual store
+// for host-only peer dependencies (react-dom, react-router-dom) that are not
+// hoisted to the project root.
+function resolveEntry(id) {
+  try {
+    return require.resolve(id, { paths: [ROOT] });
+  } catch {}
+  const pnpmDir = path.join(ROOT, "node_modules", ".pnpm");
+  let entries = [];
+  try {
+    entries = fs.readdirSync(pnpmDir);
+  } catch {
+    return null;
+  }
+  const prefix = `${packageNameOf(id).replace(/\//g, "+")}@`;
+  for (const dir of entries.filter((e) => e.startsWith(prefix)).sort()) {
+    const base = path.join(pnpmDir, dir, "node_modules", packageNameOf(id));
+    try {
+      return require.resolve(id, { paths: [path.dirname(base)] });
+    } catch {}
+  }
+  return null;
+}
+
+// Extract export names from a CJS/webpack bundle without executing it. Some host
+// packages (e.g. @freelensapp/extensions) run browser-only code on require and
+// cannot be loaded in Node at build time.
+function namesFromSource(src) {
+  const found = new Set();
+  // webpack harmony exports: __webpack_require__.d(exports, { Name: () => ... })
+  for (const block of src.matchAll(/__webpack_require__\.d\(\s*\w+\s*,\s*\{([\s\S]*?)\}\s*\)/g)) {
+    for (const m of block[1].matchAll(/([A-Za-z_$][A-Za-z0-9_$]*)\s*:/g)) found.add(m[1]);
+  }
+  // plain CJS: exports.Name = ... / Object.defineProperty(exports, "Name", ...)
+  for (const m of src.matchAll(/exports\.([A-Za-z_$][A-Za-z0-9_$]*)\s*=/g)) found.add(m[1]);
+  for (const m of src.matchAll(/Object\.defineProperty\(\s*exports\s*,\s*["']([A-Za-z_$][A-Za-z0-9_$]*)["']/g))
+    found.add(m[1]);
+  return [...found];
+}
+
+function resolveExportNames(id) {
+  const entry = resolveEntry(id);
+  // Preferred: require the real module and read its keys.
+  try {
+    const real = require(entry || id);
+    const keys = Object.keys(real).filter((n) => IDENTIFIER_RE.test(n) && !RESERVED.has(n));
+    if (keys.length > 0) return keys;
+  } catch {}
+  // Fallback: static parse for modules that cannot be required in Node.
+  if (entry) {
+    try {
+      return namesFromSource(fs.readFileSync(entry, "utf8")).filter((n) => IDENTIFIER_RE.test(n) && !RESERVED.has(n));
+    } catch {}
+  }
+  return [];
+}
+
+/**
+ * @param {Record<string, string>} globals map of module id -> global expression
+ *   (e.g. { react: "global.React" }).
+ */
+function globalExternals(globals) {
+  const PREFIX = "\0global-external:";
+  const codeCache = new Map();
+  return {
+    name: "global-externals",
+    enforce: "pre",
+    resolveId(id) {
+      if (Object.prototype.hasOwnProperty.call(globals, id)) {
+        return { id: PREFIX + id, moduleSideEffects: false };
+      }
+      return null;
+    },
+    load(id) {
+      if (!id.startsWith(PREFIX)) return null;
+      const moduleId = id.slice(PREFIX.length);
+      let code = codeCache.get(moduleId);
+      if (code == null) {
+        const globalName = globals[moduleId];
+        const names = resolveExportNames(moduleId);
+        code = [
+          `const __m = ${globalName};`,
+          `export default __m;`,
+          ...names.map((name) => `export const ${name} = __m.${name};`),
+        ].join("\n");
+        codeCache.set(moduleId, code);
+      }
+      return { code, moduleSideEffects: false };
+    },
+  };
+}
+
+module.exports = { globalExternals };

--- a/electron.vite.config.js
+++ b/electron.vite.config.js
@@ -1,8 +1,15 @@
+import { builtinModules } from "node:module";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
-import { defineConfig, externalizeDepsPlugin } from "electron-vite";
-import pluginExternal from "vite-plugin-external";
+import { defineConfig } from "electron-vite";
 import sassDts from "vite-plugin-sass-dts";
+import { globalExternals } from "./build/global-externals.js";
+
+// Modules provided by the Node.js/Electron runtime in the Freelens host. They
+// must stay external (left as `require(...)`) instead of being bundled. We list
+// them explicitly because setting `rolldownOptions` opts out of the
+// `rollupOptions.external` that electron-vite would otherwise apply.
+const runtimeExternals = ["electron", /^electron\//, ...builtinModules, ...builtinModules.map((m) => `node:${m}`)];
 
 export default defineConfig({
   // main process has full access to Node.js APIs
@@ -14,6 +21,7 @@ export default defineConfig({
         formats: ["cjs"],
       },
       rolldownOptions: {
+        external: runtimeExternals,
         output: {
           // silence warning about using `chunk.default` to access the default export
           exports: "named",
@@ -43,16 +51,10 @@ export default defineConfig({
           ],
         },
       }),
-      externalizeDepsPlugin({
-        // do not bundle modules provided by the host app
-        include: ["@freelensapp/extensions", "mobx"],
-      }),
-      pluginExternal({
+      globalExternals({
         // the modules are provided by the host app as a global variable
-        externals: {
-          "@freelensapp/extensions": "global.LensExtensions",
-          mobx: "global.Mobx",
-        },
+        "@freelensapp/extensions": "global.LensExtensions",
+        mobx: "global.Mobx",
       }),
     ],
   },
@@ -67,6 +69,7 @@ export default defineConfig({
       },
       outDir: "out/renderer",
       rolldownOptions: {
+        external: runtimeExternals,
         output: {
           // silence warning about using `chunk.default` to access the default export
           exports: "named",
@@ -104,31 +107,15 @@ export default defineConfig({
           ],
         },
       }),
-      externalizeDepsPlugin({
-        // do not bundle modules provided by the host app
-        include: [
-          "@freelensapp/extensions",
-          "electron",
-          "mobx",
-          "mobx-react",
-          "react",
-          "react-dom",
-          "react-router-dom",
-        ],
-        // bundle all other modules
-        exclude: [],
-      }),
-      pluginExternal({
+      globalExternals({
         // the modules are provided by the host app as a global variable
-        externals: {
-          "@freelensapp/extensions": "global.LensExtensions",
-          mobx: "global.Mobx",
-          "mobx-react": "global.MobxReact",
-          react: "global.React",
-          "react-dom": "global.ReactDom",
-          "react-router-dom": "global.ReactRouterDom",
-          "react/jsx-runtime": "global.ReactJsxRuntime",
-        },
+        "@freelensapp/extensions": "global.LensExtensions",
+        mobx: "global.Mobx",
+        "mobx-react": "global.MobxReact",
+        react: "global.React",
+        "react-dom": "global.ReactDom",
+        "react-router-dom": "global.ReactRouterDom",
+        "react/jsx-runtime": "global.ReactJsxRuntime",
       }),
     ],
   },

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "sass": "^1.89.2",
     "typescript": "5.9.3",
     "vite": "^8.0.16",
-    "vite-plugin-external": "^6.2.2",
     "vite-plugin-sass-dts": "^1.3.37",
     "vitest": "^4.1.9",
     "yaml": "^2.8.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,9 +80,6 @@ importers:
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.9.0)
-      vite-plugin-external:
-        specifier: ^6.2.2
-        version: 6.2.2
       vite-plugin-sass-dts:
         specifier: ^1.3.37
         version: 1.3.37(postcss@8.5.15)(prettier@3.8.4)(sass-embedded@1.100.0)(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.9.0))
@@ -1134,17 +1131,11 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/debug@4.1.12':
-    resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
-
-  '@types/fs-extra@11.0.4':
-    resolution: {integrity: sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==}
 
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -1161,17 +1152,11 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
-  '@types/jsonfile@6.1.4':
-    resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
-
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
 
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
-
-  '@types/ms@2.1.0':
-    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/node@22.15.33':
     resolution: {integrity: sha512-wzoocdnnpSxZ+6CjW4ADCK1jVmd1S/J3ArNWfn8FDDQtRm8dkDg7TA+mvek2wNrfCgwuZxqEOiB9B1XCJ6+dbw==}
@@ -1379,17 +1364,8 @@ packages:
       bare-events:
         optional: true
 
-  base-log-factory@2.1.4:
-    resolution: {integrity: sha512-FK1tHOB+rXvlBcGYYhSNR2QS2juEG4SZ1ekXQRQ2XscYNtDxllzqkzfgBFr12EVrKb2/07NLdbr0cSwVoc378A==}
-
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
-
-  blf-colorful-appender@1.0.6:
-    resolution: {integrity: sha512-MdwOI17J8iOC2XKi5b4VagAJg308R4QesRoCAPw/w7ihzwkTst91LvkTAF3GvPJCEaHXptiUS2UsFkCNiBIEGg==}
-
-  blf-debug-appender@1.0.5:
-    resolution: {integrity: sha512-ftNcGiVW2nxzG0WJ8Hcs58CbygPl2vMuLDDSxsfhGZmVl2NFGmZOuXhDDeJifvWmP0FHzP/L8dblxn65eQjgEA==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -1620,9 +1596,6 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
-
-  date-manip@2.0.6:
-    resolution: {integrity: sha512-QGLawF3lq5NOqJ5+pIgvrmE1jL8W9iwwHPAdKyV6gydtmDPngty+87YpSpzMPk9lAMnBIXcf57OKSDEjfuyRyw==}
 
   debounce-fn@4.0.0:
     resolution: {integrity: sha512-8pYCQiL9Xdcg0UPSD3d+0KMlOjp+KGU5EPwYddgzQ7DATsg4fuUDjQtsYLmWjnk2obnNHgV3vE2Y4jejSOJVBQ==}
@@ -1894,11 +1867,6 @@ packages:
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
-
-  figlet@1.8.1:
-    resolution: {integrity: sha512-kEC3Sme+YvA8Hkibv0NR1oClGcWia0VB2fC1SlMy027cwe795Xx40Xiv/nw/iFAwQLupymWh+uhAAErn/7hwPg==}
-    engines: {node: '>= 0.4.0'}
-    hasBin: true
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2203,9 +2171,6 @@ packages:
 
   is-url@1.2.4:
     resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
-
-  is-what-type@1.1.4:
-    resolution: {integrity: sha512-120PeT8LdXO7m503rQtOapWA7lHBtWErN+asRxKyxF/SFGeqLEAZhlItjNynNVABHteRMSjomQCdAnxEJldMMQ==}
 
   is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
@@ -3679,10 +3644,6 @@ packages:
   vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
 
-  vite-plugin-external@6.2.2:
-    resolution: {integrity: sha512-OpdFlWgVfWyZgx9nym3LAQp4DciutbqwSKzbA1l2Bg7CNzlDd3jnHfv1uWTY4y5h2gRfgT60ZtOgF5+W95i+3A==}
-    engines: {node: '>=14.18.0', vite: '>=3.1.0'}
-
   vite-plugin-sass-dts@1.3.37:
     resolution: {integrity: sha512-R3TgyrMhHh81sBuFFt5FjEWRbFeukoqwIeUmQDxJKYhOk8lafkftvoSqKsfWMepXQL73cu3HFk6FD6nLZ2mDjA==}
     engines: {node: '>=20'}
@@ -3775,10 +3736,6 @@ packages:
         optional: true
       jsdom:
         optional: true
-
-  vp-runtime-helper@1.0.10:
-    resolution: {integrity: sha512-2HUCkqI0uwgBti1/+utRu7Hvk/I3HeowBQfRlEL3487r+LpW1w91kk6uTZbwOd6I2Sj3aAxBE0HxYNC/NLbuhA==}
-    engines: {node: '>=14.18.0', vite: '>=3.1.0'}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5237,18 +5194,9 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/debug@4.1.12':
-    dependencies:
-      '@types/ms': 2.1.0
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.9': {}
-
-  '@types/fs-extra@11.0.4':
-    dependencies:
-      '@types/jsonfile': 6.1.4
-      '@types/node': 24.12.4
 
   '@types/hast@2.3.10':
     dependencies:
@@ -5265,10 +5213,6 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
-  '@types/jsonfile@6.1.4':
-    dependencies:
-      '@types/node': 24.12.4
-
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 24.12.4
@@ -5276,8 +5220,6 @@ snapshots:
   '@types/mdast@3.0.15':
     dependencies:
       '@types/unist': 2.0.11
-
-  '@types/ms@2.1.0': {}
 
   '@types/node@22.15.33':
     dependencies:
@@ -5469,27 +5411,7 @@ snapshots:
       bare-events: 2.5.4
     optional: true
 
-  base-log-factory@2.1.4:
-    dependencies:
-      date-manip: 2.0.6
-      is-what-type: 1.1.4
-
   base64-js@1.5.1: {}
-
-  blf-colorful-appender@1.0.6:
-    dependencies:
-      base-log-factory: 2.1.4
-      picocolors: 1.1.1
-
-  blf-debug-appender@1.0.5:
-    dependencies:
-      '@types/debug': 4.1.12
-      base-log-factory: 2.1.4
-      blf-colorful-appender: 1.0.6
-      date-manip: 2.0.6
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   body-parser@2.3.0:
     dependencies:
@@ -5722,8 +5644,6 @@ snapshots:
       tiny-invariant: 1.3.3
 
   csstype@3.2.3: {}
-
-  date-manip@2.0.6: {}
 
   debounce-fn@4.0.0:
     dependencies:
@@ -6026,8 +5946,6 @@ snapshots:
       picomatch: 4.0.4
 
   fecha@4.2.3: {}
-
-  figlet@1.8.1: {}
 
   fill-range@7.1.1:
     dependencies:
@@ -6332,8 +6250,6 @@ snapshots:
   is-stream@2.0.1: {}
 
   is-url@1.2.4: {}
-
-  is-what-type@1.1.4: {}
 
   is-what@3.14.1:
     optional: true
@@ -7843,15 +7759,6 @@ snapshots:
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
 
-  vite-plugin-external@6.2.2:
-    dependencies:
-      '@types/fs-extra': 11.0.4
-      fs-extra: 11.3.5
-      is-what-type: 1.1.4
-      vp-runtime-helper: 1.0.10
-    transitivePeerDependencies:
-      - supports-color
-
   vite-plugin-sass-dts@1.3.37(postcss@8.5.15)(prettier@3.8.4)(sass-embedded@1.100.0)(vite@8.0.16(@types/node@24.12.4)(less@4.3.0)(sass-embedded@1.100.0)(sass@1.100.0)(stylus@0.62.0)(terser@5.39.1)(yaml@2.9.0)):
     dependencies:
       postcss: 8.5.15
@@ -7903,17 +7810,6 @@ snapshots:
       '@types/node': 24.12.4
     transitivePeerDependencies:
       - msw
-
-  vp-runtime-helper@1.0.10:
-    dependencies:
-      '@types/fs-extra': 11.0.4
-      base-log-factory: 2.1.4
-      blf-debug-appender: 1.0.5
-      figlet: 1.8.1
-      fs-extra: 11.3.5
-      picocolors: 1.1.1
-    transitivePeerDependencies:
-      - supports-color
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Fixes #176.

The flaky `[MISSING_EXPORT]` build failures came from `vite-plugin-external` providing host modules as a CommonJS shim (`module.exports = global.React`), whose named exports Rolldown detected non-deterministically. Replaced it with an inline `globalExternals` plugin that emits explicit named exports, making the module graph static and the build deterministic. Export names are discovered at config time (no hardcoded lists). Runtime externals (electron, node builtins) are now listed explicitly in `rolldownOptions.external`. Keeps TypeScript 5, CommonJS output, and Vite 8 unchanged.
