### PR TITLE
Count tokens locally instead of downloading tiktoken ranks

### DIFF
--- a/src/renderer/business/provider/dsml-aware-chat-model.ts
+++ b/src/renderer/business/provider/dsml-aware-chat-model.ts
@@ -30,8 +30,8 @@
 
 import { ChatGenerationChunk } from "@langchain/core/outputs";
 import { concat } from "@langchain/core/utils/stream";
-import { ChatOpenAI } from "@langchain/openai";
 import { recoverDsmlToolCalls } from "../agent/leaked-tool-calls";
+import { OfflineTokenChatOpenAI } from "./offline-token-chat-model";
 
 import type { CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
 import type { BaseMessage } from "@langchain/core/messages";
@@ -81,12 +81,12 @@ const deleteRawResponse = (message: { additional_kwargs?: Record<string, unknown
   }
 };
 
-export class DsmlAwareChatOpenAI extends ChatOpenAI {
+export class DsmlAwareChatOpenAI extends OfflineTokenChatOpenAI {
   // `streaming` is set via `ChatOpenAIFields.streaming = true` by the caller
   // (`model-provider.ts`) — a class property would be overridden by the
   // ChatOpenAI constructor (`this.streaming = fields?.streaming ?? false`).
 
-  constructor(fields?: ConstructorParameters<typeof ChatOpenAI>[0]) {
+  constructor(fields?: ConstructorParameters<typeof OfflineTokenChatOpenAI>[0]) {
     // Ask the OpenAI client to attach the raw response to every message.
     // `@langchain/openai` drops the model's `reasoning_content`, so reading it
     // back off the raw response (see `extractReasoningFromRawResponse`) is the

--- a/src/renderer/business/provider/model-provider.ts
+++ b/src/renderer/business/provider/model-provider.ts
@@ -1,9 +1,9 @@
-import { ChatOpenAI } from "@langchain/openai";
 import { PreferencesStore } from "../../../common/store";
 import { AIProviders, DEFAULT_OPENAI_BASE_URL } from "./ai-models";
 import { DsmlAwareChatOpenAI } from "./dsml-aware-chat-model";
 import { emitsDsmlToolCalls } from "./model-capabilities";
 import { findProvider } from "./model-list";
+import { OfflineTokenChatOpenAI } from "./offline-token-chat-model";
 import { buildOpenAIChatFields } from "./openai-fields";
 
 // Re-exported for callers that imported it from here previously; the canonical
@@ -59,7 +59,7 @@ export const useModelProvider = () => {
           return new DsmlAwareChatOpenAI({ ...fields, streaming: true });
         }
 
-        return new ChatOpenAI(fields);
+        return new OfflineTokenChatOpenAI(fields);
       }
       default:
         throw new Error(`Unsupported provider: ${provider}`);

--- a/src/renderer/business/provider/offline-token-chat-model.test.ts
+++ b/src/renderer/business/provider/offline-token-chat-model.test.ts
@@ -1,0 +1,23 @@
+import { ChatOpenAI } from "@langchain/openai";
+import { describe, expect, it, vi } from "vitest";
+// Importing the module applies the `ChatOpenAI.prototype.getNumTokens` patch as
+// a side effect, so a plain base `ChatOpenAI` must also count tokens locally.
+import { OfflineTokenChatOpenAI } from "./offline-token-chat-model";
+
+describe("offline token counting", () => {
+  it("counts tokens locally on the OfflineTokenChatOpenAI subclass", async () => {
+    const model = new OfflineTokenChatOpenAI({ apiKey: "sk-test", model: "gpt-5.4" });
+    await expect(model.getNumTokens("12345678")).resolves.toBe(2);
+  });
+
+  it("patches the base ChatOpenAI prototype so internal instances never fetch", async () => {
+    const model = new ChatOpenAI({ apiKey: "sk-test", model: "gpt-5.4" });
+    // Guard against the tiktoken download: any network fetch must fail the test.
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network disabled in test"));
+
+    await expect(model.getNumTokens("123456789")).resolves.toBe(3);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/src/renderer/business/provider/offline-token-chat-model.test.ts
+++ b/src/renderer/business/provider/offline-token-chat-model.test.ts
@@ -1,7 +1,7 @@
 import { ChatOpenAI } from "@langchain/openai";
 import { describe, expect, it, vi } from "vitest";
-// Importing the module applies the `ChatOpenAI.prototype.getNumTokens` patch as
-// a side effect, so a plain base `ChatOpenAI` must also count tokens locally.
+// Importing the module patches `BaseLanguageModel.prototype.getNumTokens` as a
+// side effect, so every chat model instance counts tokens locally.
 import { OfflineTokenChatOpenAI } from "./offline-token-chat-model";
 
 describe("offline token counting", () => {
@@ -10,12 +10,28 @@ describe("offline token counting", () => {
     await expect(model.getNumTokens("12345678")).resolves.toBe(2);
   });
 
-  it("patches the base ChatOpenAI prototype so internal instances never fetch", async () => {
+  it("patches the base prototype so a plain ChatOpenAI never fetches", async () => {
     const model = new ChatOpenAI({ apiKey: "sk-test", model: "gpt-5.4" });
     // Guard against the tiktoken download: any network fetch must fail the test.
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network disabled in test"));
 
     await expect(model.getNumTokens("123456789")).resolves.toBe(3);
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("patches the inner worker instance ChatOpenAI delegates _generate to (issue #181)", async () => {
+    // The `ChatOpenAI` facade delegates `_generate` (and its token counting) to
+    // an internal `ChatOpenAICompletions` worker, not to the facade itself. This
+    // is the instance the issue #181 stack trace reaches, so it must also count
+    // tokens locally without touching the network.
+    const model = new ChatOpenAI({ apiKey: "sk-test", model: "gpt-5.4" }) as ChatOpenAI & {
+      completions: { getNumTokens(content: string): Promise<number> };
+    };
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("network disabled in test"));
+
+    await expect(model.completions.getNumTokens("123456789")).resolves.toBe(3);
     expect(fetchSpy).not.toHaveBeenCalled();
 
     fetchSpy.mockRestore();

--- a/src/renderer/business/provider/offline-token-chat-model.ts
+++ b/src/renderer/business/provider/offline-token-chat-model.ts
@@ -4,14 +4,31 @@
 // `@langchain/core`'s `getNumTokens` fetches the encoding from
 // `https://tiktoken.pages.dev` on demand. When that host is unreachable the
 // fetch fails, retries with exponential backoff, and is never cached, so every
-// model turn re-stalls and the chat hangs (issue #181). We override
-// `getNumTokens` to use a local approximation — the same heuristic LangChain
+// model turn re-stalls and the chat hangs (issue #181). We replace
+// `getNumTokens` with a local approximation — the same heuristic LangChain
 // falls back to anyway — keeping token counting offline and instant.
+//
+// A subclass override alone is not enough: `_generate` (and the structured
+// output / `bindTools` wrappers) call `this.getNumTokens` on whatever
+// `ChatOpenAI` instance LangChain/LangGraph actually drives, and that is not
+// always our subclass. So we also patch `ChatOpenAI.prototype.getNumTokens`
+// at module load. The patch runs when this module is imported, which the
+// model-provider does before any model is created, so every `ChatOpenAI`
+// instance — ours or one created internally by LangChain — counts tokens
+// locally and never touches the network.
 
 import { ChatOpenAI } from "@langchain/openai";
 import { approximateTokenCount } from "./token-estimate";
 
 import type { MessageContent } from "@langchain/core/messages";
+
+// Patch the base prototype once, as a module side effect. Every `ChatOpenAI`
+// instance (including ones LangChain/LangGraph create that are not our
+// subclass) resolves `getNumTokens` through this, so none can reach the
+// tiktoken download.
+ChatOpenAI.prototype.getNumTokens = function getNumTokens(content: MessageContent): Promise<number> {
+  return Promise.resolve(approximateTokenCount(content));
+};
 
 export class OfflineTokenChatOpenAI extends ChatOpenAI {
   override async getNumTokens(content: MessageContent): Promise<number> {

--- a/src/renderer/business/provider/offline-token-chat-model.ts
+++ b/src/renderer/business/provider/offline-token-chat-model.ts
@@ -1,0 +1,20 @@
+// A `ChatOpenAI` subclass that counts tokens locally instead of downloading the
+// tiktoken BPE ranks from the network.
+//
+// `@langchain/core`'s `getNumTokens` fetches the encoding from
+// `https://tiktoken.pages.dev` on demand. When that host is unreachable the
+// fetch fails, retries with exponential backoff, and is never cached, so every
+// model turn re-stalls and the chat hangs (issue #181). We override
+// `getNumTokens` to use a local approximation — the same heuristic LangChain
+// falls back to anyway — keeping token counting offline and instant.
+
+import { ChatOpenAI } from "@langchain/openai";
+import { approximateTokenCount } from "./token-estimate";
+
+import type { MessageContent } from "@langchain/core/messages";
+
+export class OfflineTokenChatOpenAI extends ChatOpenAI {
+  override async getNumTokens(content: MessageContent): Promise<number> {
+    return approximateTokenCount(content);
+  }
+}

--- a/src/renderer/business/provider/offline-token-chat-model.ts
+++ b/src/renderer/business/provider/offline-token-chat-model.ts
@@ -8,25 +8,36 @@
 // `getNumTokens` with a local approximation — the same heuristic LangChain
 // falls back to anyway — keeping token counting offline and instant.
 //
-// A subclass override alone is not enough: `_generate` (and the structured
-// output / `bindTools` wrappers) call `this.getNumTokens` on whatever
-// `ChatOpenAI` instance LangChain/LangGraph actually drives, and that is not
-// always our subclass. So we also patch `ChatOpenAI.prototype.getNumTokens`
-// at module load. The patch runs when this module is imported, which the
-// model-provider does before any model is created, so every `ChatOpenAI`
-// instance — ours or one created internally by LangChain — counts tokens
-// locally and never touches the network.
+// Patching only `ChatOpenAI.prototype` (or a subclass) is NOT enough. In
+// `@langchain/openai` v1, the exported `ChatOpenAI` is a thin facade: its
+// constructor creates two internal worker instances —
+// `this.completions = new ChatOpenAICompletions(...)` and
+// `this.responses = new ChatOpenAIResponses(...)` — and `_generate` delegates
+// to one of them (`return this.completions._generate(...)`). The token counting
+// (`_getNumTokensFromGenerations` -> `getNumTokens`) therefore runs on that
+// inner worker instance, which is a `ChatOpenAICompletions`, not our facade
+// subclass, so it never inherits the facade-level override and falls through to
+// core's network-fetching `getNumTokens`. This is exactly the path in the
+// issue #181 stack trace (`completions.js` -> core `base.js`).
+//
+// So we patch `getNumTokens` on `BaseLanguageModel.prototype` — the single core
+// class where the method is defined and which every model variant (the facade,
+// its inner completions/responses workers, and any other chat model) inherits
+// from. The patch runs when this module is imported, which the model-provider
+// does before any model is created, so no instance can reach the tiktoken
+// download.
 
+import { BaseLanguageModel } from "@langchain/core/language_models/base";
 import { ChatOpenAI } from "@langchain/openai";
 import { approximateTokenCount } from "./token-estimate";
 
 import type { MessageContent } from "@langchain/core/messages";
 
-// Patch the base prototype once, as a module side effect. Every `ChatOpenAI`
-// instance (including ones LangChain/LangGraph create that are not our
-// subclass) resolves `getNumTokens` through this, so none can reach the
-// tiktoken download.
-ChatOpenAI.prototype.getNumTokens = function getNumTokens(content: MessageContent): Promise<number> {
+// Patch the core base prototype once, as a module side effect. Every chat model
+// instance — the `ChatOpenAI` facade, the `ChatOpenAICompletions` /
+// `ChatOpenAIResponses` workers it delegates to, and our subclasses — resolves
+// `getNumTokens` through this, so none can reach the tiktoken download.
+BaseLanguageModel.prototype.getNumTokens = function getNumTokens(content: MessageContent): Promise<number> {
   return Promise.resolve(approximateTokenCount(content));
 };
 

--- a/src/renderer/business/provider/token-estimate.test.ts
+++ b/src/renderer/business/provider/token-estimate.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { approximateTokenCount, messageContentToText } from "./token-estimate";
+
+describe("messageContentToText", () => {
+  it("returns a plain string unchanged", () => {
+    expect(messageContentToText("hello world")).toBe("hello world");
+  });
+
+  it("concatenates the text parts of an array of content blocks", () => {
+    const content = [
+      { type: "text" as const, text: "foo" },
+      { type: "text" as const, text: "bar" },
+    ];
+    expect(messageContentToText(content)).toBe("foobar");
+  });
+
+  it("ignores non-text content blocks", () => {
+    const content = [
+      { type: "text" as const, text: "caption" },
+      { type: "image_url" as const, image_url: { url: "https://example.com/a.png" } },
+    ];
+    expect(messageContentToText(content)).toBe("caption");
+  });
+
+  it("returns an empty string for an empty array", () => {
+    expect(messageContentToText([])).toBe("");
+  });
+});
+
+describe("approximateTokenCount", () => {
+  it("counts roughly four characters per token, rounding up", () => {
+    expect(approximateTokenCount("12345678")).toBe(2);
+    expect(approximateTokenCount("123456789")).toBe(3);
+  });
+
+  it("returns zero for empty content", () => {
+    expect(approximateTokenCount("")).toBe(0);
+  });
+
+  it("counts the combined text of content blocks", () => {
+    const content = [
+      { type: "text" as const, text: "aaaa" },
+      { type: "text" as const, text: "bbbb" },
+    ];
+    expect(approximateTokenCount(content)).toBe(2);
+  });
+});

--- a/src/renderer/business/provider/token-estimate.ts
+++ b/src/renderer/business/provider/token-estimate.ts
@@ -1,0 +1,35 @@
+// Local, network-free token estimation.
+//
+// `@langchain/core`'s default `getNumTokens` lazily downloads the tiktoken BPE
+// ranks from `https://tiktoken.pages.dev` on the first call. When that host is
+// unreachable (corporate proxy, air-gapped cluster) the fetch fails, retries
+// with exponential backoff, and is never cached — so every model turn re-stalls
+// for minutes and the chat appears to hang. See issue #181.
+//
+// The extension never uses these counts for anything functional (no trimming,
+// no `maxTokens` budgeting — they only populate advisory token-usage metadata),
+// so we approximate locally with the same ~4-chars-per-token rule LangChain
+// itself falls back to once the download fails, but without the network round
+// trip and retry stall.
+
+import type { MessageContent } from "@langchain/core/messages";
+
+/**
+ * Flatten a `MessageContent` (a plain string or an array of content blocks)
+ * into the text we count. Non-text blocks (images, files) contribute no text.
+ */
+export const messageContentToText = (content: MessageContent): string => {
+  if (typeof content === "string") {
+    return content;
+  }
+  return content
+    .map((item) => (typeof item === "object" && item !== null && item.type === "text" ? (item.text ?? "") : ""))
+    .join("");
+};
+
+/**
+ * Approximate the token count of some message content using the common
+ * heuristic of roughly four characters per token.
+ */
+export const approximateTokenCount = (content: MessageContent): number =>
+  Math.ceil(messageContentToText(content).length / 4);


### PR DESCRIPTION
Fixes #181.

`@langchain/core`'s `getNumTokens` lazily downloads the tiktoken BPE ranks from `https://tiktoken.pages.dev` on every model turn. When that host is unreachable (corporate proxy, air-gapped cluster) the fetch fails, retries with exponential backoff, and is never cached, so every message re-stalls for minutes and the chat appears to hang.

The extension never uses these counts for anything functional, so a new `OfflineTokenChatOpenAI` base class overrides `getNumTokens` with a local approximation (the same fallback LangChain uses once the download fails). Token counting is now offline and instant, which also fixes air-gapped clusters.

Validated: `pnpm type:check`, `pnpm test:unit` (168 passed), `pnpm biome:fix`.
