### PR TITLE
Initialize AsyncLocalStorage in the renderer so write-tool approvals work

### DIFF
--- a/src/renderer/business/agent/runnable-context.test.ts
+++ b/src/renderer/business/agent/runnable-context.test.ts
@@ -1,0 +1,29 @@
+import { AsyncLocalStorageProviderSingleton } from "@langchain/core/singletons";
+import { describe, expect, it } from "vitest";
+import { ensureRunnableContextStorage } from "./runnable-context";
+
+describe("ensureRunnableContextStorage", () => {
+  it("installs a storage that survives across an await boundary", async () => {
+    ensureRunnableContextStorage();
+
+    const config = { tags: ["unit-test"] };
+    const storage = AsyncLocalStorageProviderSingleton.getInstance();
+
+    const seen = await storage.run({ extra: { [Symbol.for("lc:child_config")]: config } }, async () => {
+      // An await turns the synchronous run() body into a continuation; only a
+      // real AsyncLocalStorage preserves the store across it. The default mock
+      // returns undefined here, which is exactly the bug this guards against.
+      await Promise.resolve();
+      return AsyncLocalStorageProviderSingleton.getRunnableConfig();
+    });
+
+    expect(seen).toBe(config);
+  });
+
+  it("is idempotent — repeated calls keep the first instance", () => {
+    ensureRunnableContextStorage();
+    const first = AsyncLocalStorageProviderSingleton.getInstance();
+    ensureRunnableContextStorage();
+    expect(AsyncLocalStorageProviderSingleton.getInstance()).toBe(first);
+  });
+});

--- a/src/renderer/business/agent/runnable-context.ts
+++ b/src/renderer/business/agent/runnable-context.ts
@@ -1,0 +1,28 @@
+// Wires a real `AsyncLocalStorage` into LangChain's run-context singleton so the
+// renderer can propagate the active run config the way a Node process would.
+//
+// LangGraph's `interrupt()` — the human-in-the-loop approval gate for write
+// tools (create/update/patch/delete) — reads the active run config *only* from
+// `AsyncLocalStorageProviderSingleton.getRunnableConfig()`, which in turn reads
+// from a global `AsyncLocalStorage` instance. LangGraph initializes that
+// instance from its Node entry (`@langchain/langgraph/dist/index.js`, via
+// `node:async_hooks`). The renderer bundle resolves the package's `"browser"`
+// export to `dist/web.js`, which never initializes it, so `@langchain/core`
+// falls back to a `MockAsyncLocalStorage` whose `getStore()` always returns
+// `undefined`. With no store, `interrupt()` throws "Called interrupt() outside
+// the context of a graph" instead of suspending the graph, and the write-tool
+// approval prompt never reaches the UI (issue #181).
+//
+// The Freelens renderer is an Electron renderer with Node builtins available
+// (the bundler keeps `node:*` external on purpose — see electron.vite.config.js),
+// so we can do what LangGraph's Node entry would have done: install a real
+// `AsyncLocalStorage`. `initializeGlobalInstance` only accepts the first
+// instance, so this is idempotent and safe to call on every activation. This
+// restores both the approval gate and implicit run-context propagation.
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { AsyncLocalStorageProviderSingleton } from "@langchain/core/singletons";
+
+export function ensureRunnableContextStorage(): void {
+  AsyncLocalStorageProviderSingleton.initializeGlobalInstance(new AsyncLocalStorage());
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -5,6 +5,7 @@
 
 import { Renderer } from "@freelensapp/extensions";
 import { PreferencesStore } from "../common/store";
+import { ensureRunnableContextStorage } from "./business/agent/runnable-context";
 import { FreeLensAiIcon } from "./components/freelens-ai-icon";
 import { MenuEntry } from "./components/menu-entry";
 import { setExtensionPreferencesPath } from "./navigation/extension-preferences";
@@ -16,6 +17,11 @@ type KubeObjectMenuProps<TKubeObject extends KubeObject> = Renderer.Component.Ku
 
 export default class FreeLensAIRenderer extends Renderer.LensExtension {
   async onActivate() {
+    // Wire LangChain's AsyncLocalStorage run-context singleton before any agent
+    // graph runs. LangGraph's `interrupt()` (the write-tool approval gate) reads
+    // the run config from this singleton, which the renderer's browser bundle
+    // never initializes; without it the approval prompt cannot reach the UI.
+    ensureRunnableContextStorage();
     // Resolve the route to this extension's own preferences tab so the chat
     // "Configure agent" button can link straight to it.
     setExtensionPreferencesPath(this.sanitizedExtensionId);


### PR DESCRIPTION
Fixes the write-tool approval regression reported in #181.

LangGraph's `interrupt()` — the create/update/patch/delete approval gate — reads the active run config only from `AsyncLocalStorageProviderSingleton`, backed by a global `AsyncLocalStorage`. LangGraph initializes that store from its Node entry, but the renderer bundle resolves the package's browser export and never does, so `@langchain/core` falls back to a `MockAsyncLocalStorage` whose `getStore()` always returns `undefined`. With no store, `interrupt()` throws instead of suspending the graph, and the approval prompt never reaches the UI.

Install a real `AsyncLocalStorage` at renderer startup, matching what LangGraph's Node entry would do. `initializeGlobalInstance` only accepts the first instance, so it is idempotent.

Validated: `pnpm type:check`, `pnpm test:unit` (175 passed), `pnpm biome:check`.