### PR TITLE
Support patching subresources so in-place Pod resize works

### DIFF
--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -15,6 +15,7 @@ import {
   type DeleteMode,
   isRestartableKind,
   type Manifest,
+  normalizeSubresource,
   type PodDeleteMode,
   prepareManifest,
   RESTARTABLE_KINDS,
@@ -60,6 +61,10 @@ export interface WriteResourceInput {
   name: string;
   namespace?: string;
   data: Manifest;
+  // Only consumed by patchKubernetesResource: the subresource to patch instead
+  // of the main resource (for example "resize" to change a running Pod's
+  // CPU/memory in place, or "scale").
+  subresource?: string;
 }
 
 export interface DeleteResourceInput {
@@ -160,6 +165,24 @@ function projectObject(object: KubeObject) {
 type CreateData = Parameters<KubeObjectStore["create"]>[1];
 type UpdateData = Parameters<KubeObjectStore["update"]>[1];
 type DeleteOptions = Parameters<KubeObjectStore["removeWithOptions"]>[1];
+
+// The host KubeApi has no public method to patch a subresource: its `patch`
+// builds the URL from `formatUrlForNotListing` and never appends a subresource,
+// and the underlying KubeJsonApi `request` client is protected. Describe the
+// minimal surface we rely on and reach it through a structural cast (the
+// project forbids `as any`, so we go through `unknown` to a precise shape).
+interface SubresourcePatchApi {
+  formatUrlForNotListing(desc: { name?: string; namespace?: string }): string;
+  request: {
+    patch(path: string, params: { data: unknown }, reqInit: { headers: Record<string, string> }): Promise<unknown>;
+  };
+}
+
+// Kubernetes content-type for a strategic merge patch. Subresource patches such
+// as in-place Pod resize update entries inside arrays (spec.containers) that are
+// merged by their `name` key, so a strategic merge is required; a plain JSON
+// merge patch would replace the whole array.
+const STRATEGIC_MERGE_PATCH_CONTENT_TYPE = "application/strategic-merge-patch+json";
 
 /**
  * List resources of a kind, loading them from the store on demand. Namespaced
@@ -318,8 +341,17 @@ export async function patchKubernetesResource({
   name,
   namespace,
   data,
+  subresource,
 }: WriteResourceInput): Promise<string> {
-  console.log("[Tool invocation: patchKubernetesResource] - kind:", kind, "name:", name);
+  const normalizedSubresource = normalizeSubresource(subresource);
+  console.log(
+    "[Tool invocation: patchKubernetesResource] - kind:",
+    kind,
+    "name:",
+    name,
+    "subresource:",
+    normalizedSubresource,
+  );
   const target = resolveTarget(kind, apiVersion);
   if (typeof target === "string") {
     return target;
@@ -329,7 +361,7 @@ export async function patchKubernetesResource({
     return `Kind "${kind}" is namespaced; please provide a namespace to patch "${name}".`;
   }
 
-  if (!requestApproval(`PATCH ${kind.toUpperCase()}`, { name, namespace, data })) {
+  if (!requestApproval(`PATCH ${kind.toUpperCase()}`, { name, namespace, subresource: normalizedSubresource, data })) {
     return "The user denied the action";
   }
 
@@ -337,6 +369,24 @@ export async function patchKubernetesResource({
     const item = await store.load({ name, namespace: api.isNamespaced ? namespace : undefined });
     if (!item) {
       return `The ${kind} "${name}" you want to patch does not exist`;
+    }
+    if (normalizedSubresource) {
+      // The host store/api cannot target a subresource, so build the resource
+      // URL, append the subresource and PATCH it directly through the KubeApi
+      // request client. This is how an in-place Pod resize reaches
+      // `pods/{name}/resize`.
+      const patchApi = api as unknown as SubresourcePatchApi;
+      const baseUrl = patchApi.formatUrlForNotListing({
+        name,
+        namespace: api.isNamespaced ? namespace : undefined,
+      });
+      const result = await patchApi.request.patch(
+        `${baseUrl}/${normalizedSubresource}`,
+        { data },
+        { headers: { "content-type": STRATEGIC_MERGE_PATCH_CONTENT_TYPE } },
+      );
+      console.log("[Tool invocation result: patchKubernetesResource] - ", result);
+      return `${kind} "${name}" ${normalizedSubresource} subresource patched successfully`;
     }
     const result = await store.patch(item, data as unknown as UpdateData, "merge");
     console.log("[Tool invocation result: patchKubernetesResource] - ", result);

--- a/src/renderer/business/agent/tools/resource-handlers.test.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.test.ts
@@ -7,6 +7,7 @@ import {
   isDeleteMode,
   isPodDeleteMode,
   isRestartableKind,
+  normalizeSubresource,
   POD_DELETE_MODES,
   prepareManifest,
   RESTARTABLE_KINDS,
@@ -83,6 +84,27 @@ describe("isPodDeleteMode", () => {
     expect(isPodDeleteMode("force_finalize")).toBe(false);
     expect(isPodDeleteMode("delete")).toBe(false);
     expect(isPodDeleteMode("")).toBe(false);
+  });
+});
+
+describe("normalizeSubresource", () => {
+  it("returns undefined when no subresource is given", () => {
+    expect(normalizeSubresource(undefined)).toBeUndefined();
+    expect(normalizeSubresource("")).toBeUndefined();
+    expect(normalizeSubresource("   ")).toBeUndefined();
+  });
+
+  it("trims whitespace and surrounding slashes", () => {
+    expect(normalizeSubresource("resize")).toBe("resize");
+    expect(normalizeSubresource("  resize  ")).toBe("resize");
+    expect(normalizeSubresource("/resize")).toBe("resize");
+    expect(normalizeSubresource("resize/")).toBe("resize");
+    expect(normalizeSubresource("/resize/")).toBe("resize");
+  });
+
+  it("keeps an inner path intact", () => {
+    expect(normalizeSubresource("status")).toBe("status");
+    expect(normalizeSubresource("scale")).toBe("scale");
   });
 });
 

--- a/src/renderer/business/agent/tools/resource-handlers.ts
+++ b/src/renderer/business/agent/tools/resource-handlers.ts
@@ -212,6 +212,20 @@ export function isPodDeleteMode(mode: string): mode is PodDeleteMode {
   return (POD_DELETE_MODES as readonly string[]).includes(mode);
 }
 
+/**
+ * Normalize a subresource name supplied by the model. Trims surrounding
+ * whitespace and any leading/trailing slashes (so both "resize" and "/resize"
+ * work), returning `undefined` when nothing is left so callers can treat it as
+ * "no subresource" and fall back to a normal patch.
+ */
+export function normalizeSubresource(subresource?: string): string | undefined {
+  if (typeof subresource !== "string") {
+    return undefined;
+  }
+  const trimmed = subresource.trim().replace(/^\/+|\/+$/g, "");
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
 export function getResourceHandler(kind: string): ResourceHandler | undefined {
   return RESOURCE_HANDLERS[kind];
 }

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -26,6 +26,15 @@ const apiVersionSchema = z
     'The apiVersion (group/version) of the resource, e.g. "v1" or "apps/v1". Required for kinds without a built-in default.',
   );
 const manifestSchema = z.record(z.any()).describe("The Kubernetes resource manifest as a JSON object.");
+const subresourceSchema = z
+  .string()
+  .optional()
+  .describe(
+    'Optional subresource to patch instead of the main resource. Use "resize" to change the CPU/memory ' +
+      "requests and limits of a running Pod in place (Kubernetes 1.33+) without recreating it; the patch data " +
+      "must carry the target container by name, e.g. { spec: { containers: [{ name, resources: { requests, limits } }] } }. " +
+      'Use "scale" to change replicas. Omit for a normal patch.',
+  );
 
 export const getNamespaces = tool(
   (): string[] => {
@@ -137,13 +146,18 @@ export const updateKubernetesResource = tool(updateKubernetesResourceImpl, {
 
 export const patchKubernetesResource = tool(patchKubernetesResourceImpl, {
   name: "patchKubernetesResource",
-  description: "Patch (via PATCH) an existing Kubernetes resource with a partial manifest",
+  description:
+    "Patch (via PATCH) an existing Kubernetes resource with a partial manifest. " +
+    'Set the optional "subresource" to patch a subresource instead of the main resource: use "resize" to change ' +
+    "the CPU/memory requests and limits of a running Pod in place (Kubernetes 1.33+) instead of recreating it, " +
+    'or "scale" to change replicas.',
   schema: z.object({
     kind: kindSchema,
     apiVersion: apiVersionSchema,
     name: z.string().describe("The name of the resource to patch"),
     namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
     data: manifestSchema.describe("The partial Kubernetes manifest to merge into the resource"),
+    subresource: subresourceSchema,
   }),
 });
 
@@ -303,7 +317,7 @@ export const toolFunctionDescriptions = [
     name: "patchKubernetesResource",
     description: "Patch (via PATCH) an existing Kubernetes resource with a partial manifest",
     arguments:
-      "Requires the resource kind (string), name (string) and the partial manifest data (object), and optionally the apiVersion (string) and namespace (string).",
+      'Requires the resource kind (string), name (string) and the partial manifest data (object), and optionally the apiVersion (string), namespace (string) and subresource (string; e.g. "resize" to change a running Pod\'s CPU/memory in place, or "scale").',
     returnType: "Returns a message string indicating success or error after attempting to patch the resource.",
   },
   {

--- a/src/renderer/business/provider/prompt-template-provider.ts
+++ b/src/renderer/business/provider/prompt-template-provider.ts
@@ -77,6 +77,12 @@ If the user provides a specific value for a parameter (for example provided in q
 Carefully analyze descriptive terms in the request as they may indicate required parameter values that should be included even if not explicitly quoted.
 DO NOT repeat or loop if there is an error surface it to the user and ask for clarification.
 
+<subresources>
+Some changes must be applied to a resource's subresource rather than the resource itself. When patching, set the patch tool's "subresource" parameter for these cases:
+- To change the CPU or memory requests/limits of a running Pod in place (for example "change cpu request and limit for pod X to 200m"), patch the Pod with subresource "resize". Provide the target container by name with its updated resources, e.g. { spec: { containers: [{ name: "<container>", resources: { requests: { cpu: "200m" }, limits: { cpu: "200m" } } }] } }. Do NOT delete and recreate the Pod for a resize.
+- To change the replica count of a workload, patch with subresource "scale".
+</subresources>
+
 REMEMBER:
 - You are an AI assistant with full write access to the cluster, don't try to call a tool more than one time.
 `;


### PR DESCRIPTION
Adds an optional `subresource` parameter to the patch tool so the agent can change a running Pod's CPU/memory in place via the `resize` subresource instead of failing or recreating the Pod.

- Routes subresource patches through the host KubeApi request client as a strategic merge patch so `spec.containers` merges by name.
- Adds a pure `normalizeSubresource` helper with unit tests.
- Hints the operator agent and tool descriptions to use `resize` for in-place resource changes.

Closes #185