### PR TITLE
Persist chat session and LangGraph state across application restarts

### DIFF
--- a/src/common/store/agent-state-store.ts
+++ b/src/common/store/agent-state-store.ts
@@ -1,0 +1,59 @@
+import { Common } from "@freelensapp/extensions";
+import { makeObservable, observable, toJS } from "mobx";
+
+export interface AgentStateModel {
+  // Serialized LangGraph checkpointer state, keyed by saver namespace
+  // (e.g. "freelens", "mcp"). Each value is produced by
+  // `serializeSaverState` in the renderer and is opaque to this store.
+  checkpoints: Record<string, string>;
+}
+
+/**
+ * Durable, host-managed persistence for the agents' LangGraph checkpointer
+ * state. This is the Freelens-native place to store extension state: the host
+ * writes it to a JSON file in the extension's data directory, so it survives an
+ * application restart (unlike `MemorySaver`, whose state lives only in memory).
+ *
+ * The renderer's `PersistentMemorySaver` reads/writes the serialized blob here;
+ * the store itself never interprets it.
+ */
+export class AgentStateStore extends Common.Store.ExtensionStore<AgentStateModel> {
+  checkpoints: Record<string, string> = {};
+
+  constructor() {
+    super({
+      configName: "freelens-ai-agent-state-store",
+      defaults: {
+        checkpoints: {},
+      },
+    });
+    // Explicit annotation form instead of `@observable` decorators; see the
+    // note in preferences-store.ts for why decorators do not work here.
+    makeObservable(this, {
+      checkpoints: observable,
+    });
+  }
+
+  getCheckpoint(namespace: string): string | undefined {
+    return this.checkpoints[namespace];
+  }
+
+  setCheckpoint(namespace: string, blob: string): void {
+    // Replace the map so MobX sees a new reference and the host persists it.
+    this.checkpoints = { ...this.checkpoints, [namespace]: blob };
+  }
+
+  clear(): void {
+    this.checkpoints = {};
+  }
+
+  fromStore(model: AgentStateModel): void {
+    this.checkpoints = model.checkpoints ?? {};
+  }
+
+  toJSON(): AgentStateModel {
+    return {
+      checkpoints: toJS(this.checkpoints),
+    };
+  }
+}

--- a/src/common/store/index.ts
+++ b/src/common/store/index.ts
@@ -1,1 +1,2 @@
+export * from "./agent-state-store";
 export * from "./preferences-store";

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,6 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { Main } from "@freelensapp/extensions";
-import { PreferencesStore } from "../common/store";
+import { AgentStateStore, PreferencesStore } from "../common/store";
 import { startAiProxyServer } from "./ai-proxy-server";
 
 export default class LensExtensionAiMain extends Main.LensExtension {
@@ -9,6 +9,12 @@ export default class LensExtensionAiMain extends Main.LensExtension {
     const preferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
 
     preferencesStore.loadExtension(this);
+
+    // Owns the on-disk file for the persisted LangGraph checkpointer state. The
+    // main process must load it so the renderer receives the persisted value
+    // over IPC and the agent can restore its conversation after a restart.
+    // @ts-ignore
+    AgentStateStore.getInstanceOrCreate<AgentStateStore>().loadExtension(this);
 
     // Generate a fresh shared secret for this launch and require it on every
     // proxy request, so a local process that learns the port cannot reuse the

--- a/src/renderer/business/agent/checkpoint-serialization.test.ts
+++ b/src/renderer/business/agent/checkpoint-serialization.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { deserializeSaverState, serializeSaverState } from "./checkpoint-serialization";
+
+// Mirrors the nested shape a `MemorySaver` keeps: plain-object containers with
+// `Uint8Array` leaves produced by its serde.
+const sampleState = () => ({
+  storage: {
+    "thread-1": {
+      "": {
+        "checkpoint-a": [new Uint8Array([123, 34, 118, 34, 58, 52, 125]), new Uint8Array([1, 2, 3]), undefined],
+      },
+    },
+  },
+  writes: {
+    '["thread-1","","checkpoint-a"]': {
+      "task-1,0": ["task-1", "messages", new Uint8Array([255, 0, 128])],
+    },
+  },
+});
+
+describe("checkpoint-serialization", () => {
+  it("round-trips storage and writes including Uint8Array leaves", () => {
+    const state = sampleState();
+    const blob = serializeSaverState(state);
+    const restored = deserializeSaverState(blob);
+
+    expect(restored).toEqual(state);
+  });
+
+  it("restores Uint8Array leaves as actual Uint8Array instances", () => {
+    const blob = serializeSaverState(sampleState());
+    const restored = deserializeSaverState(blob) as ReturnType<typeof sampleState>;
+
+    const leaf = restored.storage["thread-1"][""]["checkpoint-a"][0];
+    expect(leaf).toBeInstanceOf(Uint8Array);
+    expect(Array.from(leaf as Uint8Array)).toEqual([123, 34, 118, 34, 58, 52, 125]);
+  });
+
+  it("preserves binary (non-UTF8) byte values through base64 encoding", () => {
+    const state = { storage: { t: new Uint8Array([0, 255, 254, 1, 200]) }, writes: {} };
+    const restored = deserializeSaverState(serializeSaverState(state)) as { storage: { t: Uint8Array } };
+
+    expect(Array.from(restored.storage.t)).toEqual([0, 255, 254, 1, 200]);
+  });
+
+  it("returns empty containers for a missing blob", () => {
+    expect(deserializeSaverState(null)).toEqual({ storage: {}, writes: {} });
+    expect(deserializeSaverState(undefined)).toEqual({ storage: {}, writes: {} });
+    expect(deserializeSaverState("")).toEqual({ storage: {}, writes: {} });
+  });
+
+  it("returns empty containers for a corrupt blob instead of throwing", () => {
+    expect(deserializeSaverState("{not valid json")).toEqual({ storage: {}, writes: {} });
+  });
+
+  it("defaults missing storage/writes keys to empty objects", () => {
+    expect(deserializeSaverState(JSON.stringify({}))).toEqual({ storage: {}, writes: {} });
+  });
+});

--- a/src/renderer/business/agent/checkpoint-serialization.ts
+++ b/src/renderer/business/agent/checkpoint-serialization.ts
@@ -1,0 +1,96 @@
+/**
+ * Pure serialization helpers for a `MemorySaver`'s in-memory state so it can be
+ * persisted as a JSON string in an `ExtensionStore` and restored after an
+ * application restart.
+ *
+ * `MemorySaver` keeps its checkpoints in two nested plain objects (`storage`
+ * and `writes`) whose leaf values are `Uint8Array`s produced by the saver's
+ * serde. `JSON.stringify` cannot round-trip a `Uint8Array` (it turns into a
+ * `{ "0": .., "1": .. }` object), so the binary leaves are tagged and base64
+ * encoded here and decoded back on load. The intermediate container objects are
+ * plain JSON and survive `JSON.stringify`/`JSON.parse` unchanged.
+ *
+ * No host, MobX, or LangGraph runtime dependency, so it is unit-tested directly.
+ */
+
+export interface SaverState {
+  storage: unknown;
+  writes: unknown;
+}
+
+// Marker key identifying an encoded `Uint8Array` leaf in the serialized JSON.
+const UINT8_TAG = "$u8";
+// Marker for an explicit `undefined`. `MemorySaver` stores `undefined` as the
+// parent-checkpoint-id of every thread's root checkpoint and later branches on
+// `parentCheckpointId !== undefined`; plain JSON would turn that `undefined`
+// into `null` (which is `!== undefined`), fabricating a parent. Tagging keeps
+// the distinction across a round-trip.
+const UNDEFINED_TAG = "$undef";
+
+const uint8ToBase64 = (bytes: Uint8Array): string => {
+  let binary = "";
+  // Chunk to avoid blowing the argument limit of `String.fromCharCode` on
+  // large checkpoints.
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+};
+
+const base64ToUint8 = (base64: string): Uint8Array => {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+};
+
+const isTagged = (value: unknown, tag: string): boolean =>
+  typeof value === "object" && value !== null && tag in (value as Record<string, unknown>);
+
+/**
+ * Serialize a saver's `storage`/`writes` into a JSON string. Returns output that
+ * {@link deserializeSaverState} can read back, with `Uint8Array` leaves and
+ * explicit `undefined` values preserved.
+ */
+export const serializeSaverState = (state: SaverState): string =>
+  JSON.stringify(state, (_key, value) => {
+    if (value instanceof Uint8Array) {
+      return { [UINT8_TAG]: uint8ToBase64(value) };
+    }
+    if (value === undefined) {
+      return { [UNDEFINED_TAG]: true };
+    }
+    return value;
+  });
+
+/**
+ * Parse a blob produced by {@link serializeSaverState}. A missing, empty, or
+ * corrupt blob yields empty containers rather than throwing, so a bad persisted
+ * value can never crash agent initialization.
+ */
+export const deserializeSaverState = (blob: string | null | undefined): SaverState => {
+  if (!blob) {
+    return { storage: {}, writes: {} };
+  }
+
+  try {
+    const parsed = JSON.parse(blob, (_key, value) => {
+      if (isTagged(value, UINT8_TAG)) {
+        return base64ToUint8((value as Record<string, string>)[UINT8_TAG]);
+      }
+      if (isTagged(value, UNDEFINED_TAG)) {
+        return undefined;
+      }
+      return value;
+    });
+    return {
+      storage: parsed?.storage ?? {},
+      writes: parsed?.writes ?? {},
+    };
+  } catch {
+    return { storage: {}, writes: {} };
+  }
+};

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -1,6 +1,6 @@
 import { HumanMessage } from "@langchain/core/messages";
 import { RunnableConfig, RunnableLambda, RunnableLike } from "@langchain/core/runnables";
-import { Command, MemorySaver, StateGraph } from "@langchain/langgraph";
+import { Command, StateGraph } from "@langchain/langgraph";
 import useLog from "../../../common/utils/logger/logger-service";
 import { useAgentAnalyzer } from "./analyzer-agent";
 import { useConclusionsAgent } from "./conclusions-agent";
@@ -13,6 +13,7 @@ import {
   LEAKED_TOOL_CALL_MESSAGE,
 } from "./leaked-tool-calls";
 import { teardownNode } from "./nodes/teardown";
+import { PersistentMemorySaver } from "./persistent-memory-saver";
 import { GraphState } from "./state/graph-state";
 import { useAgentSupervisor } from "./supervisor-agent";
 import { allToolNames, toolFunctionDescriptions } from "./tools/tools";
@@ -174,7 +175,7 @@ export const useFreeLensAgentSystem = () => {
       .addEdge("generalPurposeAgent", "teardownNode")
       .addEdge(conclusionsAgentName, "teardownNode")
       .addEdge("teardownNode", "__end__")
-      .compile({ checkpointer: new MemorySaver() });
+      .compile({ checkpointer: new PersistentMemorySaver("freelens") });
   };
 
   return { buildAgentSystem, availableTools };

--- a/src/renderer/business/agent/mcp-agent.ts
+++ b/src/renderer/business/agent/mcp-agent.ts
@@ -1,10 +1,11 @@
 import { AIMessage, ToolMessage } from "@langchain/core/messages";
-import { Command, interrupt, MemorySaver, StateGraph } from "@langchain/langgraph";
+import { Command, interrupt, StateGraph } from "@langchain/langgraph";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
 import { MultiServerMCPClient } from "@langchain/mcp-adapters";
 import useLog from "../../../common/utils/logger/logger-service";
 import { useModelProvider } from "../provider/model-provider";
 import { teardownNode } from "./nodes/teardown";
+import { PersistentMemorySaver } from "./persistent-memory-saver";
 import { GraphState } from "./state/graph-state";
 
 export type MPCAgent = Awaited<ReturnType<ReturnType<typeof useMcpAgent>["buildAgentSystem"]>>;
@@ -107,7 +108,7 @@ export const useMcpAgent = (mcpConfiguration: string) => {
       .addEdge("tools", "agent")
       .addEdge("agent", "shouldContinue")
       .addEdge("teardownNode", "__end__")
-      .compile({ checkpointer: new MemorySaver() });
+      .compile({ checkpointer: new PersistentMemorySaver("mcp") });
   };
 
   return { buildAgentSystem, loadMcpTools };

--- a/src/renderer/business/agent/persistent-memory-saver.ts
+++ b/src/renderer/business/agent/persistent-memory-saver.ts
@@ -1,0 +1,82 @@
+import { MemorySaver } from "@langchain/langgraph";
+import { AgentStateStore } from "../../../common/store/agent-state-store";
+import { deserializeSaverState, serializeSaverState } from "./checkpoint-serialization";
+
+/**
+ * A `MemorySaver` whose checkpoint state is mirrored into the durable,
+ * host-managed `AgentStateStore`. The base `MemorySaver` keeps everything in
+ * memory and is wiped on every application restart; this subclass restores the
+ * previous state on first use and writes it back after every mutation, so the
+ * agent retains the prior conversation as live context across restarts. The
+ * persisted transcript shown in the UI is handled separately (chat-session
+ * storage); this is the model-side counterpart.
+ *
+ * Each saver instance owns a `namespace` (e.g. "freelens", "mcp") so the
+ * Freelens and MCP agents persist independently and never overwrite each other.
+ */
+export class PersistentMemorySaver extends MemorySaver {
+  private hydrated = false;
+
+  constructor(
+    private readonly namespace: string,
+    private readonly store: AgentStateStore = AgentStateStore.getInstanceOrCreate<AgentStateStore>(),
+  ) {
+    super();
+  }
+
+  // Restore persisted state lazily on first use rather than in the constructor:
+  // the store loads asynchronously at extension activation, while the agent
+  // graph is built eagerly during the first React render. Deferring hydration to
+  // the first checkpoint operation (which only happens once the user interacts)
+  // guarantees the store is populated by then.
+  private ensureHydrated(): void {
+    if (this.hydrated) {
+      return;
+    }
+    this.hydrated = true;
+
+    const blob = this.store.getCheckpoint(this.namespace);
+    if (!blob) {
+      return;
+    }
+
+    const { storage, writes } = deserializeSaverState(blob);
+    Object.assign(this.storage, storage);
+    Object.assign(this.writes, writes);
+  }
+
+  private persist(): void {
+    this.store.setCheckpoint(this.namespace, serializeSaverState({ storage: this.storage, writes: this.writes }));
+  }
+
+  async getTuple(...args: Parameters<MemorySaver["getTuple"]>): ReturnType<MemorySaver["getTuple"]> {
+    this.ensureHydrated();
+    return super.getTuple(...args);
+  }
+
+  async *list(...args: Parameters<MemorySaver["list"]>): ReturnType<MemorySaver["list"]> {
+    this.ensureHydrated();
+    yield* super.list(...args);
+  }
+
+  async put(...args: Parameters<MemorySaver["put"]>): ReturnType<MemorySaver["put"]> {
+    // Hydrate before writing so a new run merges onto the restored threads
+    // instead of overwriting them with an empty store.
+    this.ensureHydrated();
+    const result = await super.put(...args);
+    this.persist();
+    return result;
+  }
+
+  async putWrites(...args: Parameters<MemorySaver["putWrites"]>): ReturnType<MemorySaver["putWrites"]> {
+    this.ensureHydrated();
+    await super.putWrites(...args);
+    this.persist();
+  }
+
+  async deleteThread(...args: Parameters<MemorySaver["deleteThread"]>): ReturnType<MemorySaver["deleteThread"]> {
+    this.ensureHydrated();
+    await super.deleteThread(...args);
+    this.persist();
+  }
+}

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -6,6 +6,7 @@ const { observer } = MobxReact;
 const { createContext, useContext, useEffect, useRef, useState } = React;
 
 import { PreferencesStore } from "../../common/store";
+import { AgentStateStore } from "../../common/store/agent-state-store";
 import { AgentsStore } from "../../common/store/agents-store";
 import useLog from "../../common/utils/logger/logger-service";
 import { generateUuid } from "../../common/utils/uuid";
@@ -206,6 +207,9 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         saveChatMessages(window.localStorage, []);
       });
     }
+    // Wipe the durable LangGraph checkpointer state so a restart right after a
+    // clear does not restore the model-side conversation context.
+    AgentStateStore.getInstanceOrCreate<AgentStateStore>().clear();
   };
 
   const cleanAgentMessageHistory = async (agent: FreeLensAgent | MPCAgent) => {

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -14,6 +14,14 @@ import { MPCAgent, useMcpAgent } from "../business/agent/mcp-agent";
 import { getTextMessage } from "../business/objects/message-object-provider";
 import { MessageType } from "../business/objects/message-type";
 import { AIProviders } from "../business/provider/ai-models";
+import {
+  IS_CONVERSATION_INTERRUPTED_KEY,
+  IS_LOADING_KEY,
+  loadChatMessages,
+  loadConversationId,
+  saveChatMessages,
+  saveConversationId,
+} from "./chat-session-storage";
 
 import type { MessageObject } from "../business/objects/message-object";
 
@@ -66,8 +74,8 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
 
   // Init variables
   useEffect(() => {
-    _setLoading(window.sessionStorage.getItem("isLoading") === "true");
-    _setConversationInterrupted(window.sessionStorage.getItem("isConversationInterrupted") === "true");
+    _setLoading(window.sessionStorage.getItem(IS_LOADING_KEY) === "true");
+    _setConversationInterrupted(window.sessionStorage.getItem(IS_CONVERSATION_INTERRUPTED_KEY) === "true");
     _getConversationId();
     _loadChatMessages();
     _initFreeLensAgent();
@@ -89,12 +97,14 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   }, [freeLensAgent]);
 
   const _loadChatMessages = () => {
-    const stringMessages = window.sessionStorage.getItem("chatMessages");
-    stringMessages ? _setChatMessages(JSON.parse(stringMessages)) : _setChatMessages([]);
+    // Durable: persisted in localStorage so the transcript survives an app restart.
+    _setChatMessages(loadChatMessages(window.localStorage));
   };
 
   const _getConversationId = () => {
-    const storedConversationId = window.sessionStorage.getItem("conversationId");
+    // Durable: persisted in localStorage so the conversation thread stays stable
+    // across an app restart, matching the restored transcript.
+    const storedConversationId = loadConversationId(window.localStorage);
     if (storedConversationId) {
       _setConversationId(storedConversationId);
       log.debug("Using stored conversation ID: ", storedConversationId);
@@ -102,19 +112,22 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
       log.debug("Generating conversation ID");
       const newConverstionId = generateUuid();
       _setConversationId(newConverstionId);
-      window.sessionStorage.setItem("conversationId", newConverstionId);
+      saveConversationId(window.localStorage, newConverstionId);
       log.debug("No stored conversation ID found, generating a new one.");
     }
   };
 
   const setLoading = (isLoading: boolean) => {
     _setLoading(isLoading);
-    window.sessionStorage.setItem("isLoading", String(isLoading));
+    // Transient: kept in sessionStorage so a fresh app start never restores a
+    // spinner for a run that is no longer active.
+    window.sessionStorage.setItem(IS_LOADING_KEY, String(isLoading));
   };
 
   const setConversationInterrupted = (isConversationInterrupted: boolean) => {
     _setConversationInterrupted(isConversationInterrupted);
-    window.sessionStorage.setItem("isConversationInterrupted", String(isConversationInterrupted));
+    // Transient: see setLoading above.
+    window.sessionStorage.setItem(IS_CONVERSATION_INTERRUPTED_KEY, String(isConversationInterrupted));
   };
 
   const addMessage = (message: MessageObject) => {
@@ -123,7 +136,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         prev = [];
       }
       const updated = [...prev, message];
-      window.sessionStorage.setItem("chatMessages", JSON.stringify(updated));
+      saveChatMessages(window.localStorage, updated);
       return updated;
     });
   };
@@ -143,7 +156,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
       if (lastMessage.sent || lastMessage.type === MessageType.INTERRUPT) {
         // Agent response does not exist, add a new empty one
         messagesCopy.push(getTextMessage(newText, false));
-        window.sessionStorage.setItem("chatMessages", JSON.stringify(messagesCopy));
+        saveChatMessages(window.localStorage, messagesCopy);
         return messagesCopy;
       }
 
@@ -153,7 +166,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         text: lastMessage.text + newText,
       };
 
-      window.sessionStorage.setItem("chatMessages", JSON.stringify(messagesCopy));
+      saveChatMessages(window.localStorage, messagesCopy);
       return messagesCopy;
     });
   };
@@ -175,7 +188,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         };
       }
 
-      window.sessionStorage.setItem("chatMessages", JSON.stringify(messagesCopy));
+      saveChatMessages(window.localStorage, messagesCopy);
       return messagesCopy;
     });
   };
@@ -184,13 +197,13 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     if (freeLensAgent) {
       cleanAgentMessageHistory(freeLensAgent).finally(() => {
         _setChatMessages([]);
-        window.sessionStorage.setItem("chatMessages", JSON.stringify([]));
+        saveChatMessages(window.localStorage, []);
       });
     }
     if (mcpAgent) {
       await cleanAgentMessageHistory(mcpAgent).finally(() => {
         _setChatMessages([]);
-        window.sessionStorage.setItem("chatMessages", JSON.stringify([]));
+        saveChatMessages(window.localStorage, []);
       });
     }
   };

--- a/src/renderer/context/chat-session-storage.test.ts
+++ b/src/renderer/context/chat-session-storage.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  CHAT_MESSAGES_KEY,
+  CONVERSATION_ID_KEY,
+  type KeyValueStorage,
+  loadChatMessages,
+  loadConversationId,
+  saveChatMessages,
+  saveConversationId,
+} from "./chat-session-storage";
+
+import type { MessageObject } from "../business/objects/message-object";
+
+const createStorage = (initial: Record<string, string> = {}): KeyValueStorage & { data: Record<string, string> } => {
+  const data: Record<string, string> = { ...initial };
+  return {
+    data,
+    getItem: (key: string) => (key in data ? data[key] : null),
+    setItem: (key: string, value: string) => {
+      data[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete data[key];
+    },
+  };
+};
+
+const message = (text: string): MessageObject => ({ text }) as MessageObject;
+
+describe("chat-session-storage", () => {
+  describe("loadChatMessages", () => {
+    it("returns an empty array when nothing is stored", () => {
+      expect(loadChatMessages(createStorage())).toEqual([]);
+    });
+
+    it("returns the persisted transcript", () => {
+      const messages = [message("hello"), message("world")];
+      const storage = createStorage({ [CHAT_MESSAGES_KEY]: JSON.stringify(messages) });
+      expect(loadChatMessages(storage)).toEqual(messages);
+    });
+
+    it("returns an empty array when the stored value is corrupt", () => {
+      const storage = createStorage({ [CHAT_MESSAGES_KEY]: "{ not json" });
+      expect(loadChatMessages(storage)).toEqual([]);
+    });
+
+    it("returns an empty array when the stored value is not an array", () => {
+      const storage = createStorage({ [CHAT_MESSAGES_KEY]: JSON.stringify({ foo: "bar" }) });
+      expect(loadChatMessages(storage)).toEqual([]);
+    });
+  });
+
+  describe("saveChatMessages", () => {
+    it("round-trips through loadChatMessages", () => {
+      const storage = createStorage();
+      const messages = [message("a"), message("b")];
+      saveChatMessages(storage, messages);
+      expect(loadChatMessages(storage)).toEqual(messages);
+    });
+
+    it("persists an empty transcript when cleared", () => {
+      const storage = createStorage({ [CHAT_MESSAGES_KEY]: JSON.stringify([message("a")]) });
+      saveChatMessages(storage, []);
+      expect(storage.data[CHAT_MESSAGES_KEY]).toBe("[]");
+      expect(loadChatMessages(storage)).toEqual([]);
+    });
+  });
+
+  describe("conversation id", () => {
+    it("returns null when none is stored", () => {
+      expect(loadConversationId(createStorage())).toBeNull();
+    });
+
+    it("round-trips the conversation id", () => {
+      const storage = createStorage();
+      saveConversationId(storage, "abc-123");
+      expect(storage.data[CONVERSATION_ID_KEY]).toBe("abc-123");
+      expect(loadConversationId(storage)).toBe("abc-123");
+    });
+  });
+});

--- a/src/renderer/context/chat-session-storage.ts
+++ b/src/renderer/context/chat-session-storage.ts
@@ -1,0 +1,49 @@
+import type { MessageObject } from "../business/objects/message-object";
+
+// Storage keys backing the chat session. The chat transcript and its
+// conversation id are the durable "session": they live in `localStorage` so
+// they survive an application restart and are wiped only by the "clear session"
+// button. The loading / interrupted flags are transient run-state and live in
+// `sessionStorage`, so a fresh app start never resurrects a spinner or a
+// half-finished approval prompt for a run that is no longer active.
+export const CHAT_MESSAGES_KEY = "chatMessages";
+export const CONVERSATION_ID_KEY = "conversationId";
+export const IS_LOADING_KEY = "isLoading";
+export const IS_CONVERSATION_INTERRUPTED_KEY = "isConversationInterrupted";
+
+// Minimal subset of the DOM `Storage` API used here; accepting it as a
+// parameter keeps these helpers free of `window` so they can be unit-tested.
+export type KeyValueStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+/**
+ * Read the persisted chat transcript. Returns an empty array when nothing is
+ * stored or when the stored value is corrupt, so a bad entry can never crash
+ * the provider during initialization.
+ */
+export const loadChatMessages = (storage: KeyValueStorage): MessageObject[] => {
+  const raw = storage.getItem(CHAT_MESSAGES_KEY);
+  if (!raw) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? (parsed as MessageObject[]) : [];
+  } catch {
+    return [];
+  }
+};
+
+/** Persist the chat transcript. */
+export const saveChatMessages = (storage: KeyValueStorage, messages: MessageObject[]): void => {
+  storage.setItem(CHAT_MESSAGES_KEY, JSON.stringify(messages));
+};
+
+/** Read the persisted conversation id, or `null` when none is stored. */
+export const loadConversationId = (storage: KeyValueStorage): string | null => {
+  return storage.getItem(CONVERSATION_ID_KEY);
+};
+
+/** Persist the conversation id. */
+export const saveConversationId = (storage: KeyValueStorage, conversationId: string): void => {
+  storage.setItem(CONVERSATION_ID_KEY, conversationId);
+};

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -4,7 +4,7 @@
  */
 
 import { Renderer } from "@freelensapp/extensions";
-import { PreferencesStore } from "../common/store";
+import { AgentStateStore, PreferencesStore } from "../common/store";
 import { ensureRunnableContextStorage } from "./business/agent/runnable-context";
 import { FreeLensAiIcon } from "./components/freelens-ai-icon";
 import { MenuEntry } from "./components/menu-entry";
@@ -27,6 +27,10 @@ export default class FreeLensAIRenderer extends Renderer.LensExtension {
     setExtensionPreferencesPath(this.sanitizedExtensionId);
     // @ts-ignore
     PreferencesStore.getInstanceOrCreate<PreferencesStore>().loadExtension(this);
+    // Durable, host-managed storage for the agents' LangGraph checkpointer
+    // state, so the conversation context survives an application restart.
+    // @ts-ignore
+    AgentStateStore.getInstanceOrCreate<AgentStateStore>().loadExtension(this);
   }
 
   clusterPages = [


### PR DESCRIPTION
Persists both the chat transcript and the agent's LangGraph checkpointer state so a session survives an application restart, cleared only by the existing "clear session" button.

The transcript is persisted in localStorage; the LangGraph state is persisted in a host-managed ExtensionStore (the Freelens-native place for durable extension state) via a PersistentMemorySaver that hydrates on first use and writes back after every mutation.

Closes #187