### PR TITLE
Render Kubernetes operator system prompt as a literal message

### DIFF
--- a/src/renderer/business/agent/kubernetes-operator-agent.ts
+++ b/src/renderer/business/agent/kubernetes-operator-agent.ts
@@ -1,4 +1,4 @@
-import { AIMessage } from "@langchain/core/messages";
+import { AIMessage, SystemMessage } from "@langchain/core/messages";
 import { ChatPromptTemplate, MessagesPlaceholder } from "@langchain/core/prompts";
 import { MessagesAnnotation, StateGraph } from "@langchain/langgraph";
 import { ToolNode } from "@langchain/langgraph/prebuilt";
@@ -38,7 +38,7 @@ export const useAgentKubernetesOperator = () => {
 
     const callModel = async (state: typeof MessagesAnnotation.State) => {
       const prompt = ChatPromptTemplate.fromMessages([
-        ["system", KUBERNETES_OPERATOR_PROMPT_TEMPLATE],
+        new SystemMessage(KUBERNETES_OPERATOR_PROMPT_TEMPLATE),
         new MessagesPlaceholder("messages"),
       ]);
       const response = await prompt.pipe(boundModel).invoke({ messages: state.messages });

--- a/src/renderer/business/provider/prompt-template-provider.ts
+++ b/src/renderer/business/provider/prompt-template-provider.ts
@@ -53,12 +53,15 @@ DO NOT make up values for or ask about optional parameters.
 Carefully analyze descriptive terms in the request as they may indicate required parameter values that should be included even if not explicitly quoted.
 `;
 
+// NOTE: This prompt is rendered as a literal `SystemMessage` (see
+// kubernetes-operator-agent.ts), NOT as a LangChain f-string template, so the
+// JSON example in <subresources> can use raw `{`/`}` braces without escaping
+// them as `{{`/`}}`. Do not pass this string through `["system", ...]` (which
+// triggers f-string parsing) or the literal braces will throw "Single '}' in
+// template".
 export const KUBERNETES_OPERATOR_PROMPT_TEMPLATE = `
 You are an expert Kubernetes Operator Agent, powered by Freelens-AI, with full write access to the cluster.
 Your primary role is to help users modify and manage their Kubernetes cluster state.
-
-Current conversation:
-{messages}
 
 <tool_calling>
 You have tools at your disposal to solve the coding task. Follow these rules regarding tool calls:


### PR DESCRIPTION
Fixes #193

The `<subresources>` JSON example in `KUBERNETES_OPERATOR_PROMPT_TEMPLATE` contains literal braces. Passing it as a `["system", template]` tuple made LangChain parse it as an f-string, so the unbalanced braces threw "Single '}' in template". The prompt is now rendered as a literal `SystemMessage` and the redundant `{messages}` placeholder removed.
