### PR TITLE
Hide approval question after action is approved or rejected

### DIFF
--- a/src/renderer/components/interrupt/interrupt.tsx
+++ b/src/renderer/components/interrupt/interrupt.tsx
@@ -60,7 +60,6 @@ const Interrupt = ({ header, question, text, options, approved, onAction }: Inte
       )}
       {!pending && detailsOpen && (
         <div className="interrupt-details">
-          {question && <div className="interrupt-question">{question}</div>}
           <MarkdownViewer content={text} />
         </div>
       )}


### PR DESCRIPTION
Hides the "Do you want to approve this action?" question when an already-decided approval block is unfolded again. The question now only shows while the action is pending.

Fixes #196
