### PR TITLE
Present the backup before changing resources

### DIFF
--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -133,21 +133,76 @@ function resolveTarget(kind: string, apiVersion?: string): ResolvedTarget | stri
 }
 
 /**
- * Run the human-in-the-loop approval gate for a write operation.
+ * Run the human-in-the-loop approval gate for a write operation. When
+ * `resourcesYaml` is provided it carries the current full YAML of the resources
+ * the action will change, presented as a folded backup so the change can be
+ * reverted.
  */
-function requestApproval(action: string, payload: Record<string, unknown>): boolean {
+function requestApproval(action: string, payload: Record<string, unknown>, resourcesYaml?: string): boolean {
   const actionToApprove = { action, ...payload };
+  // Render the payload as YAML, the native format of the Kubernetes world,
+  // so the approval prompt is highlighted as YAML rather than JSON.
+  const actionString = stringifyYaml(actionToApprove);
   const interruptRequest = {
     question: "Do you want to approve this action?",
     options: ["yes", "no"],
     actionToApprove,
-    // Render the payload as YAML, the native format of the Kubernetes world,
-    // so the approval prompt is highlighted as YAML rather than JSON.
-    requestString: "```yaml\n" + stringifyYaml(actionToApprove) + "```",
+    // Structured fields consumed by the Interrupt component to render foldable
+    // "Action details" and "Resources that will be changed" sections.
+    actionString,
+    resourcesString: resourcesYaml,
+    // Markdown fallback for renderers that do not understand the structured
+    // fields (for example the MCP tool approval prompt).
+    requestString: "```yaml\n" + actionString + "```",
   };
   const review = interrupt(interruptRequest);
   console.log("Tool call review: ", review);
   return review === "yes";
+}
+
+/**
+ * Build a restorable manifest from a loaded host object: the full resource as it
+ * exists now, used as the backup presented before a destructive change.
+ */
+function toBackupManifest(object: KubeObject) {
+  return {
+    apiVersion: object.apiVersion,
+    kind: object.kind,
+    metadata: object.metadata,
+    spec: object.spec,
+    status: object.status,
+  };
+}
+
+// Minimal structural view of a store used only to load a resource for the
+// backup. The host's concrete stores (PodStore, DeploymentStore, ...) are more
+// specific than the generic `KubeObjectStore` alias and not mutually
+// assignable, so the capture helper depends on `load` alone.
+interface LoadableStore {
+  load(params: { name: string; namespace?: string }): Promise<KubeObject | null | undefined>;
+}
+
+/**
+ * Best-effort capture of the current YAML of a resource before it is changed.
+ * Returns `undefined` (rather than throwing) when the resource cannot be loaded,
+ * so a missing backup never blocks the approval prompt.
+ */
+async function captureResourceYaml(
+  store: LoadableStore,
+  namespaced: boolean,
+  name: string,
+  namespace?: string,
+): Promise<string | undefined> {
+  try {
+    const object = await store.load({ name, namespace: namespaced ? namespace : undefined });
+    if (!object) {
+      return undefined;
+    }
+    return stringifyYaml(toBackupManifest(object));
+  } catch (error) {
+    console.error("[Backup capture error] - ", error);
+    return undefined;
+  }
 }
 
 function projectObject(object: KubeObject) {
@@ -350,7 +405,8 @@ export async function updateKubernetesResource({
   }
   const manifest = prepareManifest(kind, validation.data);
 
-  if (!requestApproval(`UPDATE ${kind.toUpperCase()}`, { name, namespace, data: manifest })) {
+  const backup = await captureResourceYaml(store, api.isNamespaced, name, namespace);
+  if (!requestApproval(`UPDATE ${kind.toUpperCase()}`, { name, namespace, data: manifest }, backup)) {
     return "The user denied the action";
   }
 
@@ -398,7 +454,14 @@ export async function patchKubernetesResource({
     return `Kind "${kind}" is namespaced; please provide a namespace to patch "${name}".`;
   }
 
-  if (!requestApproval(`PATCH ${kind.toUpperCase()}`, { name, namespace, subresource: normalizedSubresource, data })) {
+  const backup = await captureResourceYaml(store, api.isNamespaced, name, namespace);
+  if (
+    !requestApproval(
+      `PATCH ${kind.toUpperCase()}`,
+      { name, namespace, subresource: normalizedSubresource, data },
+      backup,
+    )
+  ) {
     return "The user denied the action";
   }
 
@@ -461,7 +524,8 @@ export async function deleteKubernetesResource({
     return `Kind "${kind}" is namespaced; please provide a namespace to delete "${name}".`;
   }
 
-  if (!requestApproval(`DELETE ${kind.toUpperCase()}`, { name, namespace, mode })) {
+  const backup = await captureResourceYaml(store, api.isNamespaced, name, namespace);
+  if (!requestApproval(`DELETE ${kind.toUpperCase()}`, { name, namespace, mode }, backup)) {
     return "The user denied the action";
   }
 
@@ -513,8 +577,10 @@ export async function deletePod({ name, namespace, mode }: DeletePodInput): Prom
   }
 
   const podsApi = Renderer.K8sApi.podsApi;
+  const podsStore = Renderer.K8sApi.apiManager.getStore(podsApi);
+  const backup = podsStore ? await captureResourceYaml(podsStore, podsApi.isNamespaced, name, namespace) : undefined;
 
-  if (!requestApproval(`DELETE POD (${mode})`, { name, namespace, mode })) {
+  if (!requestApproval(`DELETE POD (${mode})`, { name, namespace, mode }, backup)) {
     return "The user denied the action";
   }
 
@@ -555,7 +621,9 @@ export async function restartKubernetesResource({ kind, name, namespace }: Resta
     return `Kind "${kind}" is namespaced; please provide a namespace to restart "${name}".`;
   }
 
-  if (!requestApproval(`RESTART ${kind.toUpperCase()}`, { name, namespace })) {
+  const store = Renderer.K8sApi.apiManager.getStore(api);
+  const backup = store ? await captureResourceYaml(store, api.isNamespaced, name, namespace) : undefined;
+  if (!requestApproval(`RESTART ${kind.toUpperCase()}`, { name, namespace }, backup)) {
     return "The user denied the action";
   }
 

--- a/src/renderer/business/objects/message-object-provider.tsx
+++ b/src/renderer/business/objects/message-object-provider.tsx
@@ -29,6 +29,8 @@ export function getInterruptMessage(chunk: Interrupt, sent: boolean): MessageObj
     action: chunk.value.actionToApprove.action,
     question: chunk.value.question,
     text: chunk.value.requestString,
+    actionDetails: chunk.value.actionString,
+    resources: chunk.value.resourcesString,
     options: chunk.value.options,
     approved: null,
     sent: sent,

--- a/src/renderer/business/objects/message-object.tsx
+++ b/src/renderer/business/objects/message-object.tsx
@@ -9,6 +9,12 @@ export interface MessageObject {
   reasoning?: string;
   question?: string;
   action?: string;
+  // The action payload rendered as YAML, shown in the approval prompt under a
+  // foldable "Action details" section. Absent for non-structured interrupts.
+  actionDetails?: string;
+  // The current full YAML of the resource(s) the action will change, shown as a
+  // folded "Resources that will be changed" backup so the change can be undone.
+  resources?: string;
   options?: string[];
   approved?: boolean | null;
   sent: boolean;

--- a/src/renderer/components/code-block/code-block.scss
+++ b/src/renderer/components/code-block/code-block.scss
@@ -26,8 +26,19 @@
   color: green;
 }
 
+.code-block-toolbar-collapsed {
+  border-bottom-left-radius: 0.5rem;
+  border-bottom-right-radius: 0.5rem;
+}
+
 .code-block-toolbar-language {
   color: white;
+}
+
+.code-block-toggle {
+  gap: 4px;
+  color: white;
+  user-select: none;
 }
 
 .code-block-copy-button {

--- a/src/renderer/components/code-block/code-block.tsx
+++ b/src/renderer/components/code-block/code-block.tsx
@@ -1,4 +1,5 @@
-import { Copy, Play } from "lucide-react";
+import { ChevronDown, ChevronRight, Copy, Play } from "lucide-react";
+import { useState } from "react";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import styleInline from "./code-block.scss?inline";
 import { useCodeBlockHook } from "./code-block-hook";
@@ -9,43 +10,73 @@ type CodeBlockProps = {
   inline?: boolean;
   children: ReactNode;
   language?: string;
+  // Replaces the language label in the toolbar (for example "Action details").
+  title?: string;
+  // When set, the toolbar title becomes a toggle that folds the code body.
+  collapsible?: boolean;
+  // Initial folded state when collapsible (default: expanded).
+  defaultCollapsed?: boolean;
   props: React.HTMLAttributes<HTMLElement>;
 };
 
-export const CodeBlock = ({ inline, children, language, props }: CodeBlockProps) => {
+export const CodeBlock = ({
+  inline,
+  children,
+  language,
+  title,
+  collapsible,
+  defaultCollapsed,
+  props,
+}: CodeBlockProps) => {
   const codeBlockHook = useCodeBlockHook({ children });
+  const [collapsed, setCollapsed] = useState(defaultCollapsed ?? false);
 
   if (!inline) {
+    const label = title ?? language;
+    const bodyHidden = collapsible && collapsed;
     return (
       <>
         <style>{styleInline}</style>
         <div className="code-block-container">
-          <div className={"code-block-toolbar"}>
+          <div className={`code-block-toolbar${bodyHidden ? " code-block-toolbar-collapsed" : ""}`}>
             <button onClick={codeBlockHook.executeCommand} className={"code-block-button code-block-run-button"}>
               {codeBlockHook.isExecutable(language) && <Play size={16} />}
             </button>
 
-            <div className={"code-block-toolbar-language"}>{language}</div>
+            {collapsible ? (
+              <button
+                type="button"
+                onClick={() => setCollapsed((value) => !value)}
+                className={"code-block-button code-block-toolbar-language code-block-toggle"}
+              >
+                {collapsed ? <ChevronRight size={16} /> : <ChevronDown size={16} />}
+                <span>{label}</span>
+              </button>
+            ) : (
+              <div className={"code-block-toolbar-language"}>{label}</div>
+            )}
 
             <button onClick={codeBlockHook.handleCopy} className={"code-block-button code-block-copy-button"}>
               {codeBlockHook.copied && <span className="code-block-copied-text">Copied!</span>}
               <Copy size={16} />
             </button>
           </div>
-          <SyntaxHighlighter
-            PreTag="div"
-            language={language}
-            style={codeBlockHook.getTheme()}
-            customStyle={{
-              margin: 0,
-              borderBottomLeftRadius: "0.5rem",
-              borderBottomRightRadius: "0.5rem",
-            }}
-            showLineNumbers={codeBlockHook.hasMultipleLines}
-            showInlineLineNumbers={codeBlockHook.hasMultipleLines}
-          >
-            {codeBlockHook.text}
-          </SyntaxHighlighter>
+          {!bodyHidden && (
+            <SyntaxHighlighter
+              PreTag="div"
+              language={language}
+              style={codeBlockHook.getTheme()}
+              customStyle={{
+                margin: 0,
+                borderBottomLeftRadius: "0.5rem",
+                borderBottomRightRadius: "0.5rem",
+              }}
+              showLineNumbers={codeBlockHook.hasMultipleLines}
+              showInlineLineNumbers={codeBlockHook.hasMultipleLines}
+            >
+              {codeBlockHook.text}
+            </SyntaxHighlighter>
+          )}
         </div>
       </>
     );

--- a/src/renderer/components/interrupt/interrupt.tsx
+++ b/src/renderer/components/interrupt/interrupt.tsx
@@ -88,11 +88,7 @@ const Interrupt = ({
           </div>
         </>
       )}
-      {!pending && detailsOpen && (
-        <div className="interrupt-details">
-          {renderBody()}
-        </div>
-      )}
+      {!pending && detailsOpen && <div className="interrupt-details">{renderBody()}</div>}
     </div>
   );
 };

--- a/src/renderer/components/interrupt/interrupt.tsx
+++ b/src/renderer/components/interrupt/interrupt.tsx
@@ -1,6 +1,7 @@
 import { Renderer } from "@freelensapp/extensions";
 import { CheckCircle, XCircle } from "lucide-react";
 import * as React from "react";
+import { CodeBlock } from "../code-block";
 import { MarkdownViewer } from "../markdown-viewer";
 import styleInline from "./interrupt.scss?inline";
 
@@ -12,14 +13,43 @@ export type InterruptProps = {
   header: string;
   question: string;
   text: string;
+  actionDetails?: string;
+  resources?: string;
   options: string[];
   approved: boolean | null;
   onAction: (option) => void;
 };
 
-const Interrupt = ({ header, question, text, options, approved, onAction }: InterruptProps) => {
+const Interrupt = ({
+  header,
+  question,
+  text,
+  actionDetails,
+  resources,
+  options,
+  approved,
+  onAction,
+}: InterruptProps) => {
   const pending = approved === null;
   const [detailsOpen, setDetailsOpen] = React.useState(false);
+
+  // Structured Kubernetes approvals carry the action payload and a backup of the
+  // resources to be changed as YAML; other interrupts fall back to markdown text.
+  const renderBody = () =>
+    actionDetails ? (
+      <>
+        <CodeBlock language="yaml" title="Action details" collapsible props={{}}>
+          {actionDetails}
+        </CodeBlock>
+        {resources && (
+          <CodeBlock language="yaml" title="Resources that will be changed" collapsible defaultCollapsed props={{}}>
+            {resources}
+          </CodeBlock>
+        )}
+      </>
+    ) : (
+      <MarkdownViewer content={text} />
+    );
 
   return (
     <div>
@@ -42,7 +72,7 @@ const Interrupt = ({ header, question, text, options, approved, onAction }: Inte
       </div>
       {pending && (
         <>
-          <MarkdownViewer content={text} />
+          {renderBody()}
           <div>
             {options.map((option) => (
               <Button
@@ -60,7 +90,7 @@ const Interrupt = ({ header, question, text, options, approved, onAction }: Inte
       )}
       {!pending && detailsOpen && (
         <div className="interrupt-details">
-          <MarkdownViewer content={text} />
+          {renderBody()}
         </div>
       )}
     </div>

--- a/src/renderer/components/message/message.tsx
+++ b/src/renderer/components/message/message.tsx
@@ -32,6 +32,8 @@ export const Message = ({ message }: MessageProps) => {
             header={message.action!}
             question={message.question!}
             text={message.text}
+            actionDetails={message.actionDetails}
+            resources={message.resources}
             options={message.options!}
             approved={message.approved!}
             onAction={(option) => {


### PR DESCRIPTION
Addresses #192.

The destructive-action approval prompt now renders the action payload under a foldable "Action details" section (open by default) and, below it, a folded "Resources that will be changed" section holding the current full YAML of the resource(s) to be modified, so the change can be reverted.

- `CodeBlock` gained optional collapsible title props.
- A best-effort backup of the current resource is captured before update/patch/delete/deletePod/restart.
- MCP tool approvals keep their plain-text fallback.
