### PR TITLE
Add a tool to read the Kubernetes cluster version

### DIFF
--- a/src/renderer/business/agent/analyzer-agent.ts
+++ b/src/renderer/business/agent/analyzer-agent.ts
@@ -2,6 +2,7 @@ import { createReactAgent } from "@langchain/langgraph/prebuilt";
 import { useModelProvider } from "../provider/model-provider";
 import { AGENT_ANALYZER_PROMPT_TEMPLATE } from "../provider/prompt-template-provider";
 import {
+  getClusterVersion,
   getKubernetesResource,
   getNamespaces,
   getPodLogs,
@@ -17,7 +18,14 @@ export const useAgentAnalyzer = () => {
       model &&
       createReactAgent({
         llm: model,
-        tools: [getNamespaces, getWarningEventsByNamespace, listKubernetesResources, getKubernetesResource, getPodLogs],
+        tools: [
+          getNamespaces,
+          getClusterVersion,
+          getWarningEventsByNamespace,
+          listKubernetesResources,
+          getKubernetesResource,
+          getPodLogs,
+        ],
         prompt: AGENT_ANALYZER_PROMPT_TEMPLATE,
       })
     );

--- a/src/renderer/business/agent/tools/cluster-version.test.ts
+++ b/src/renderer/business/agent/tools/cluster-version.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import { summarizeClusterVersion } from "./cluster-version";
+
+describe("summarizeClusterVersion", () => {
+  it("uses gitVersion as the human-readable version and keeps the relevant details", () => {
+    expect(
+      summarizeClusterVersion({
+        major: "1",
+        minor: "29",
+        gitVersion: "v1.29.2",
+        gitCommit: "abc1234",
+        gitTreeState: "clean",
+        buildDate: "2024-02-14T10:40:24Z",
+        goVersion: "go1.21.7",
+        compiler: "gc",
+        platform: "linux/amd64",
+      }),
+    ).toEqual({
+      version: "v1.29.2",
+      major: "1",
+      minor: "29",
+      gitCommit: "abc1234",
+      buildDate: "2024-02-14T10:40:24Z",
+      goVersion: "go1.21.7",
+      platform: "linux/amd64",
+    });
+  });
+
+  it("falls back to <major>.<minor> when gitVersion is missing", () => {
+    expect(summarizeClusterVersion({ major: "1", minor: "30+" })).toEqual({
+      version: "1.30+",
+      major: "1",
+      minor: "30+",
+      gitCommit: undefined,
+      buildDate: undefined,
+      goVersion: undefined,
+      platform: undefined,
+    });
+  });
+
+  it('falls back to "unknown" when neither gitVersion nor major/minor are present', () => {
+    expect(summarizeClusterVersion({})).toEqual({
+      version: "unknown",
+      major: undefined,
+      minor: undefined,
+      gitCommit: undefined,
+      buildDate: undefined,
+      goVersion: undefined,
+      platform: undefined,
+    });
+  });
+
+  it("treats blank strings as missing and trims surrounding whitespace", () => {
+    expect(summarizeClusterVersion({ major: "1", minor: "  ", gitVersion: "  v1.28.0  " })).toEqual({
+      version: "v1.28.0",
+      major: "1",
+      minor: undefined,
+      gitCommit: undefined,
+      buildDate: undefined,
+      goVersion: undefined,
+      platform: undefined,
+    });
+  });
+});

--- a/src/renderer/business/agent/tools/cluster-version.ts
+++ b/src/renderer/business/agent/tools/cluster-version.ts
@@ -1,0 +1,60 @@
+/**
+ * The shape of the Kubernetes `/version` endpoint response (apimachinery
+ * `version.Info`). Every field is optional because older or customized API
+ * servers may omit some of them.
+ */
+export interface KubernetesVersionInfo {
+  major?: string;
+  minor?: string;
+  gitVersion?: string;
+  gitCommit?: string;
+  gitTreeState?: string;
+  buildDate?: string;
+  goVersion?: string;
+  compiler?: string;
+  platform?: string;
+}
+
+/**
+ * A compact, model-friendly summary of the cluster version. Only fields that
+ * are actually reported by the API server are included.
+ */
+export interface ClusterVersionSummary {
+  version: string;
+  major?: string;
+  minor?: string;
+  gitCommit?: string;
+  buildDate?: string;
+  goVersion?: string;
+  platform?: string;
+}
+
+/** Return the trimmed string when it is a non-empty string, otherwise undefined. */
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Build a compact summary from the raw `/version` payload. `gitVersion` (for
+ * example "v1.29.2") is the human-readable cluster version; when it is missing
+ * we fall back to "<major>.<minor>" and finally to "unknown".
+ */
+export function summarizeClusterVersion(info: KubernetesVersionInfo): ClusterVersionSummary {
+  const major = nonEmptyString(info.major);
+  const minor = nonEmptyString(info.minor);
+  const gitVersion = nonEmptyString(info.gitVersion);
+  const version = gitVersion ?? (major && minor ? `${major}.${minor}` : "unknown");
+  return {
+    version,
+    major,
+    minor,
+    gitCommit: nonEmptyString(info.gitCommit),
+    buildDate: nonEmptyString(info.buildDate),
+    goVersion: nonEmptyString(info.goVersion),
+    platform: nonEmptyString(info.platform),
+  };
+}

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -2,6 +2,7 @@ import { Renderer } from "@freelensapp/extensions";
 import { interrupt } from "@langchain/langgraph";
 import { stringify as stringifyYaml } from "yaml";
 import { PreferencesStore } from "../../../../common/store";
+import { type KubernetesVersionInfo, summarizeClusterVersion } from "./cluster-version";
 import {
   capLogOutput,
   capTailLines,
@@ -178,6 +179,17 @@ interface SubresourcePatchApi {
   };
 }
 
+// The host KubeApi exposes the shared cluster `KubeJsonApi` client through a
+// protected `request` property with no public accessor. Describe the minimal
+// surface we rely on (a typed GET) and reach it through a structural cast via
+// `unknown`, mirroring the `SubresourcePatchApi` pattern above (the project
+// forbids `as any`).
+interface VersionRequestApi {
+  request: {
+    get<T>(path: string): Promise<T>;
+  };
+}
+
 // Kubernetes content-type for a strategic merge patch. Subresource patches such
 // as in-place Pod resize update entries inside arrays (spec.containers) that are
 // merged by their `name` key, so a strategic merge is required; a plain JSON
@@ -229,6 +241,31 @@ export async function getKubernetesResource({ kind, apiVersion, name, namespace 
     return JSON.stringify(projectObject(object));
   } catch (error) {
     console.error("[Tool invocation error: getKubernetesResource] - ", error);
+    return JSON.stringify(error);
+  }
+}
+
+/**
+ * Read the Kubernetes version of the currently connected cluster by querying
+ * the API server's `/version` endpoint directly (the same `version.Info` that
+ * `kubectl version` reports). This is the authoritative source for the server
+ * version and avoids heuristics such as inspecting node `kubeletVersion`s. Any
+ * registered KubeApi shares the cluster `KubeJsonApi` client, so the pods API
+ * is used to reach it.
+ */
+export async function getClusterVersion(): Promise<string> {
+  console.log("[Tool invocation: getClusterVersion]");
+  const api = Renderer.K8sApi.podsApi as unknown as VersionRequestApi;
+  try {
+    const info = await api.request.get<KubernetesVersionInfo>("/version");
+    if (!info || typeof info !== "object") {
+      return "Could not determine the Kubernetes cluster version.";
+    }
+    const summary = summarizeClusterVersion(info);
+    console.log("[Tool invocation result: getClusterVersion] - ", summary);
+    return JSON.stringify(summary);
+  } catch (error) {
+    console.error("[Tool invocation error: getClusterVersion] - ", error);
     return JSON.stringify(error);
   }
 }

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -5,6 +5,7 @@ import {
   createKubernetesResource as createKubernetesResourceImpl,
   deleteKubernetesResource as deleteKubernetesResourceImpl,
   deletePod as deletePodImpl,
+  getClusterVersion as getClusterVersionImpl,
   getKubernetesResource as getKubernetesResourceImpl,
   getPodLogs as getPodLogsImpl,
   listKubernetesResources as listKubernetesResourcesImpl,
@@ -57,6 +58,14 @@ export const getNamespaces = tool(
     description: "Get all namespaces of the Kubernetes cluster",
   },
 );
+
+export const getClusterVersion = tool(getClusterVersionImpl, {
+  name: "getClusterVersion",
+  description:
+    "Get the Kubernetes version of the currently connected cluster by querying the API server's /version endpoint " +
+    "directly (the same server version that 'kubectl version' reports). Prefer this over inspecting node " +
+    "kubeletVersions or other heuristics. Takes no arguments.",
+});
 
 export const getWarningEventsByNamespace = tool(
   ({ namespace }: { namespace: string }): string => {
@@ -243,6 +252,7 @@ export const restartKubernetesResource = tool(restartKubernetesResourceImpl, {
 
 export const allToolFunctions = [
   getNamespaces,
+  getClusterVersion,
   getWarningEventsByNamespace,
   listKubernetesResources,
   getKubernetesResource,
@@ -268,6 +278,13 @@ export const toolFunctionDescriptions = [
     description: "Get all namespaces of the Kubernetes cluster",
     arguments: "No arguments. The function does not require any input.",
     returnType: "Returns a list of all namespace names as strings.",
+  },
+  {
+    name: "getClusterVersion",
+    description: "Get the Kubernetes server version of the currently connected cluster",
+    arguments: "No arguments. The function does not require any input.",
+    returnType:
+      'Returns a JSON string with the cluster version (the gitVersion, e.g. "v1.29.2") and related details such as major, minor, gitCommit, buildDate, goVersion and platform.',
   },
   {
     name: "getWarningEventsByNamespace",


### PR DESCRIPTION
Adds a dedicated read-only `getClusterVersion` tool that queries the API server's `/version` endpoint directly (the same server version that `kubectl version` reports), instead of relying on heuristics.

The pure `summarizeClusterVersion` helper lives in `cluster-version.ts` with unit tests; the host-dependent implementation is in `kubernetes-resource.ts`, and the tool is registered in `tools.ts` and the read-only analyzer agent.

Closes #199
