### PR TITLE
UX improvements for reasoning messages

### DIFF
--- a/src/renderer/components/message/message-hook.tsx
+++ b/src/renderer/components/message/message-hook.tsx
@@ -15,14 +15,36 @@ const useMessageHook = ({ message }: MessageHookProps) => {
   const rafRef = useRef<number | null>(null);
 
   const reasoning = message.reasoning ?? "";
-  // Folded immediately: the reasoning arrives in the same message object as the
-  // answer, so there is no separate "thinking" phase to show it open for. The
-  // user can re-open the `Reasoning` disclosure to inspect the chain-of-thought.
+  // While the answer is still empty the reasoning is the only thing to read, so
+  // it is shown unfolded as a live "thinking" view. Once the answer text starts
+  // to arrive the reasoning folds itself away. Both transitions happen at most
+  // once: after it has auto-folded it is never auto-unfolded again, so a later
+  // reasoning-only delta (another block before its answer) leaves it folded and
+  // the user stays in control of the `Reasoning` disclosure.
+  const hasAnswerText = message.text.trim().length > 0;
   const [reasoningOpen, setReasoningOpen] = useState(false);
+  const autoOpenedRef = useRef(false);
+  const autoFoldedRef = useRef(false);
 
   useEffect(() => {
     _setVisibleText(message.text);
   }, []);
+
+  useEffect(() => {
+    // Once the answer has appeared and the reasoning has folded, leave it alone.
+    if (autoFoldedRef.current) return;
+
+    if (hasAnswerText) {
+      autoFoldedRef.current = true;
+      setReasoningOpen(false);
+      return;
+    }
+
+    if (reasoning.length > 0 && !autoOpenedRef.current) {
+      autoOpenedRef.current = true;
+      setReasoningOpen(true);
+    }
+  }, [reasoning, hasAnswerText]);
 
   useEffect(() => {
     if (lastTextRef.current === message.text) return;


### PR DESCRIPTION
Drive the Reasoning disclosure from the streaming state: unfold it while the answer is empty, fold it once the answer arrives, and never auto-unfold it again.

Closes #205