### PR TITLE
Move approval question right before the action buttons

### DIFF
--- a/src/renderer/components/interrupt/interrupt.scss
+++ b/src/renderer/components/interrupt/interrupt.scss
@@ -11,6 +11,10 @@
   font-size: 1rem;
 }
 
+.interrupt-question {
+  margin-bottom: 10px;
+}
+
 .interrupt-header {
   display: flex;
   align-items: center;

--- a/src/renderer/components/interrupt/interrupt.tsx
+++ b/src/renderer/components/interrupt/interrupt.tsx
@@ -68,11 +68,11 @@ const Interrupt = ({
           )}
           {header}
         </div>
-        {pending && <div className="interrupt-question">{question}</div>}
       </div>
       {pending && (
         <>
           {renderBody()}
+          <div className="interrupt-question">{question}</div>
           <div>
             {options.map((option) => (
               <Button


### PR DESCRIPTION
Moves the "Do you want to approve this action?" message out of the tool title header bar so it is presented just before the [yes] [no] buttons.

Closes #207