### PR TITLE
Stop showing the rejected interrupt answer as a fake chat message

### DIFF
--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -150,6 +150,28 @@ const useChatService = () => {
     }
   };
 
+  // Resume a paused run with the answer picked from an interrupt's approval
+  // buttons ("yes"/"no"). The answer is never added to the transcript: it was
+  // not typed by the user, and the approval/rejection is already conveyed by the
+  // interrupt's status icon. Resuming through this dedicated path (instead of
+  // sendMessageToAgent) makes that independent of the transient
+  // `isConversationInterrupted` flag, which is not restored after an app restart
+  // even though the pending interrupt itself is.
+  const resumeInterrupt = (option: string) => {
+    try {
+      // A fresh user action supersedes any earlier failure: drop stale error
+      // messages (and their "Retry" buttons) before resuming the run.
+      applicationStatusStore.removeErrorMessages();
+      applicationStatusStore.setLoading(true);
+      log.debug("Resuming interrupted conversation with answer: ", option);
+      runAgent(new Command({ resume: option }), { kind: "resume", text: option }).finally(() => {
+        applicationStatusStore.setLoading(false);
+      });
+    } catch {
+      applicationStatusStore.setLoading(false);
+    }
+  };
+
   const changeInterruptStatus = (id: string, status: boolean) => {
     applicationStatusStore.changeInterruptStatus(id, status);
   };
@@ -232,7 +254,7 @@ const useChatService = () => {
     }
   };
 
-  return { sendMessageToAgent, changeInterruptStatus, retry };
+  return { sendMessageToAgent, resumeInterrupt, changeInterruptStatus, retry };
 };
 
 export default useChatService;

--- a/src/renderer/components/message/message.tsx
+++ b/src/renderer/components/message/message.tsx
@@ -1,6 +1,5 @@
 import { RotateCcw } from "lucide-react";
 import useChatService from "../../../common/service/chat-service";
-import { getTextMessage } from "../../business/objects/message-object-provider";
 import { MessageType } from "../../business/objects/message-type";
 import Interrupt from "../interrupt/interrupt";
 import { MarkdownViewer } from "../markdown-viewer";
@@ -43,7 +42,7 @@ export const Message = ({ message }: MessageProps) => {
               } else if ("no" === option) {
                 chatService.changeInterruptStatus(message.messageId, false);
               }
-              chatService.sendMessageToAgent(getTextMessage(option, true));
+              chatService.resumeInterrupt(option);
             }}
           />
         </>


### PR DESCRIPTION
Fixes #209.

Resolving a tool-approval interrupt no longer renders the picked answer ("yes"/"no") as a user chat message. The answer is now resumed through a dedicated `resumeInterrupt` path that never adds it to the transcript, independent of the transient `isConversationInterrupted` flag (which is not restored after an app restart even though the pending interrupt is). The approval/rejection stays visible through the interrupt's status icon.
