### PR TITLE
Give the approval question the standard text color

### DIFF
--- a/src/renderer/components/interrupt/interrupt.scss
+++ b/src/renderer/components/interrupt/interrupt.scss
@@ -13,6 +13,7 @@
 
 .interrupt-question {
   margin-bottom: 10px;
+  color: var(--textColorPrimary);
 }
 
 .interrupt-header {


### PR DESCRIPTION
The "Do you want to approve this action?" message rendered white after it was moved out of the interrupt header box (#210), since it no longer inherited that box's `--textColorPrimary`. This sets the standard text color on `.interrupt-question`.

Closes #207