### PR TITLE
Split the chat context for each cluster

### DIFF
--- a/src/common/store/agent-state-store.ts
+++ b/src/common/store/agent-state-store.ts
@@ -1,9 +1,12 @@
 import { Common } from "@freelensapp/extensions";
 import { makeObservable, observable, toJS } from "mobx";
+import { belongsToCluster } from "../../renderer/business/agent/checkpoint-namespace";
 
 export interface AgentStateModel {
-  // Serialized LangGraph checkpointer state, keyed by saver namespace
-  // (e.g. "freelens", "mcp"). Each value is produced by
+  // Serialized LangGraph checkpointer state, keyed by saver namespace. The
+  // namespace is cluster-qualified (e.g. "<clusterId>::freelens",
+  // "<clusterId>::mcp", see `checkpointNamespace`) so each cluster's agent
+  // memory is stored independently. Each value is produced by
   // `serializeSaverState` in the renderer and is opaque to this store.
   checkpoints: Record<string, string>;
 }
@@ -45,6 +48,19 @@ export class AgentStateStore extends Common.Store.ExtensionStore<AgentStateModel
 
   clear(): void {
     this.checkpoints = {};
+  }
+
+  // Drop only the checkpoints that belong to the given cluster, leaving every
+  // other cluster's agent memory untouched. Used when the user clears the chat
+  // so a "Clear" in one cluster does not wipe another cluster's conversation.
+  clearForCluster(clusterId: string): void {
+    const remaining: Record<string, string> = {};
+    for (const [namespace, blob] of Object.entries(this.checkpoints)) {
+      if (!belongsToCluster(namespace, clusterId)) {
+        remaining[namespace] = blob;
+      }
+    }
+    this.checkpoints = remaining;
   }
 
   fromStore(model: AgentStateModel): void {

--- a/src/common/store/chat-session-store.ts
+++ b/src/common/store/chat-session-store.ts
@@ -3,60 +3,87 @@ import { makeObservable, observable, toJS } from "mobx";
 
 import type { MessageObject } from "../../renderer/business/objects/message-object";
 
-export interface ChatSessionModel {
+export interface ChatSession {
   // The rendered chat transcript and the conversation id that ties it to the
   // agent's LangGraph thread. Both make up the durable "session".
   messages: MessageObject[];
   conversationId: string;
 }
 
+export interface ChatSessionModel {
+  // One chat session per cluster, keyed by the cluster id. The store is backed
+  // by a single host-managed JSON file shared across every cluster frame, so the
+  // transcript and conversation thread are kept apart by this key rather than
+  // every cluster sharing one session.
+  sessions: Record<string, ChatSession>;
+}
+
+const emptySession = (): ChatSession => ({ messages: [], conversationId: "" });
+
 /**
- * Durable, host-managed persistence for the rendered chat session (the
- * transcript shown in the UI and its conversation id). This is the
- * Freelens-native place to store extension state: the host writes it to a JSON
- * file in the extension's data directory, so it survives an application restart.
+ * Durable, host-managed persistence for the rendered chat sessions (the
+ * transcript shown in the UI and its conversation id), one per cluster. This is
+ * the Freelens-native place to store extension state: the host writes it to a
+ * JSON file in the extension's data directory, so it survives an application
+ * restart.
  *
  * The transcript previously lived in `window.localStorage`, which is not
  * durable across restarts in the Freelens renderer: the model-side LangGraph
  * state (persisted via `AgentStateStore`, an `ExtensionStore`) came back after a
  * restart while the chat HTML did not. Backing the transcript with the same
  * host-managed mechanism keeps the two in sync.
+ *
+ * Sessions are keyed by cluster id so switching clusters shows that cluster's
+ * own chat rather than a single shared one.
  */
 export class ChatSessionStore extends Common.Store.ExtensionStore<ChatSessionModel> {
-  messages: MessageObject[] = [];
-  conversationId: string = "";
+  sessions: Record<string, ChatSession> = {};
 
   constructor() {
     super({
       configName: "freelens-ai-chat-session-store",
       defaults: {
-        messages: [],
-        conversationId: "",
+        sessions: {},
       },
     });
     // Explicit annotation form instead of `@observable` decorators; see the
     // note in preferences-store.ts for why decorators do not work here.
     makeObservable(this, {
-      messages: observable,
-      conversationId: observable,
+      sessions: observable,
     });
   }
 
-  setMessages(messages: MessageObject[]): void {
-    this.messages = messages;
+  private session(clusterId: string): ChatSession {
+    return this.sessions[clusterId] ?? emptySession();
   }
 
-  setConversationId(conversationId: string): void {
-    this.conversationId = conversationId;
+  // Replace the map so MobX sees a new reference and the host persists it.
+  private patch(clusterId: string, partial: Partial<ChatSession>): void {
+    this.sessions = { ...this.sessions, [clusterId]: { ...this.session(clusterId), ...partial } };
   }
 
-  clear(): void {
-    this.messages = [];
+  getMessages(clusterId: string): MessageObject[] {
+    return this.session(clusterId).messages;
+  }
+
+  setMessages(clusterId: string, messages: MessageObject[]): void {
+    this.patch(clusterId, { messages });
+  }
+
+  getConversationId(clusterId: string): string {
+    return this.session(clusterId).conversationId;
+  }
+
+  setConversationId(clusterId: string, conversationId: string): void {
+    this.patch(clusterId, { conversationId });
+  }
+
+  clear(clusterId: string): void {
+    this.patch(clusterId, { messages: [] });
   }
 
   fromStore(model: ChatSessionModel): void {
-    this.messages = model.messages ?? [];
-    this.conversationId = model.conversationId ?? "";
+    this.sessions = model.sessions ?? {};
   }
 
   toJSON(): ChatSessionModel {
@@ -64,9 +91,13 @@ export class ChatSessionStore extends Common.Store.ExtensionStore<ChatSessionMod
     // it over IPC, which structure-clones it. A live MobX proxy cannot be
     // cloned ("An object could not be cloned"), so convert it to a plain array
     // with `toJS` before returning. See preferences-store.ts for the same note.
-    return {
-      messages: toJS(this.messages),
-      conversationId: this.conversationId,
-    };
+    const sessions: Record<string, ChatSession> = {};
+    for (const [clusterId, session] of Object.entries(this.sessions)) {
+      sessions[clusterId] = {
+        messages: toJS(session.messages),
+        conversationId: session.conversationId,
+      };
+    }
+    return { sessions };
   }
 }

--- a/src/renderer/business/agent/checkpoint-namespace.test.ts
+++ b/src/renderer/business/agent/checkpoint-namespace.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { belongsToCluster, checkpointNamespace } from "./checkpoint-namespace";
+
+describe("checkpointNamespace", () => {
+  it("qualifies the agent kind with the cluster id", () => {
+    expect(checkpointNamespace("cluster-a", "freelens")).toBe("cluster-a::freelens");
+    expect(checkpointNamespace("cluster-b", "mcp")).toBe("cluster-b::mcp");
+  });
+
+  it("keeps different clusters in distinct namespaces", () => {
+    expect(checkpointNamespace("cluster-a", "freelens")).not.toBe(checkpointNamespace("cluster-b", "freelens"));
+  });
+});
+
+describe("belongsToCluster", () => {
+  it("matches namespaces created for the same cluster", () => {
+    const namespace = checkpointNamespace("cluster-a", "freelens");
+    expect(belongsToCluster(namespace, "cluster-a")).toBe(true);
+  });
+
+  it("does not match another cluster's namespace", () => {
+    const namespace = checkpointNamespace("cluster-a", "freelens");
+    expect(belongsToCluster(namespace, "cluster-b")).toBe(false);
+  });
+
+  it("does not match on a cluster id that is only a prefix of another", () => {
+    const namespace = checkpointNamespace("cluster-a-extra", "mcp");
+    expect(belongsToCluster(namespace, "cluster-a")).toBe(false);
+  });
+});

--- a/src/renderer/business/agent/checkpoint-namespace.ts
+++ b/src/renderer/business/agent/checkpoint-namespace.ts
@@ -1,0 +1,26 @@
+// The `PersistentMemorySaver` persists each agent's LangGraph checkpointer state
+// under a namespace key in the shared, host-managed `AgentStateStore`. Because
+// that store is backed by a single JSON file shared across every cluster frame,
+// the namespace must include the cluster id so each connected cluster keeps its
+// own agent memory instead of overwriting (or reading) another cluster's blob.
+//
+// Pure helpers with no host/MobX dependencies so they can be unit-tested
+// directly (see checkpoint-namespace.test.ts).
+
+const SEPARATOR = "::";
+
+/**
+ * Build the checkpoint namespace for a given cluster and agent kind
+ * (e.g. "freelens", "mcp").
+ */
+export function checkpointNamespace(clusterId: string, agentKind: string): string {
+  return `${clusterId}${SEPARATOR}${agentKind}`;
+}
+
+/**
+ * Whether a stored checkpoint namespace belongs to the given cluster. Used to
+ * clear only the current cluster's checkpoints without touching other clusters.
+ */
+export function belongsToCluster(namespace: string, clusterId: string): boolean {
+  return namespace.startsWith(`${clusterId}${SEPARATOR}`);
+}

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -3,6 +3,7 @@ import { RunnableConfig, RunnableLambda, RunnableLike } from "@langchain/core/ru
 import { Command, StateGraph } from "@langchain/langgraph";
 import useLog from "../../../common/utils/logger/logger-service";
 import { useAgentAnalyzer } from "./analyzer-agent";
+import { checkpointNamespace } from "./checkpoint-namespace";
 import { useConclusionsAgent } from "./conclusions-agent";
 import { useGeneralPurposeAgent } from "./general-purpose-agent";
 import { useAgentKubernetesOperator } from "./kubernetes-operator-agent";
@@ -155,7 +156,7 @@ export const useFreeLensAgentSystem = () => {
     };
   };
 
-  const buildAgentSystem = () => {
+  const buildAgentSystem = (clusterId: string) => {
     return new StateGraph(GraphState)
       .addNode(
         "supervisorAgent",
@@ -175,7 +176,7 @@ export const useFreeLensAgentSystem = () => {
       .addEdge("generalPurposeAgent", "teardownNode")
       .addEdge(conclusionsAgentName, "teardownNode")
       .addEdge("teardownNode", "__end__")
-      .compile({ checkpointer: new PersistentMemorySaver("freelens") });
+      .compile({ checkpointer: new PersistentMemorySaver(checkpointNamespace(clusterId, "freelens")) });
   };
 
   return { buildAgentSystem, availableTools };

--- a/src/renderer/business/agent/mcp-agent.ts
+++ b/src/renderer/business/agent/mcp-agent.ts
@@ -4,6 +4,7 @@ import { ToolNode } from "@langchain/langgraph/prebuilt";
 import { MultiServerMCPClient } from "@langchain/mcp-adapters";
 import useLog from "../../../common/utils/logger/logger-service";
 import { useModelProvider } from "../provider/model-provider";
+import { checkpointNamespace } from "./checkpoint-namespace";
 import { teardownNode } from "./nodes/teardown";
 import { PersistentMemorySaver } from "./persistent-memory-saver";
 import { GraphState } from "./state/graph-state";
@@ -49,7 +50,7 @@ export const useMcpAgent = (mcpConfiguration: string) => {
     return mcpTools;
   };
 
-  const buildAgentSystem = async () => {
+  const buildAgentSystem = async (clusterId: string) => {
     const mcpTools = await loadMcpTools();
     const toolNode = new ToolNode(mcpTools);
 
@@ -108,7 +109,7 @@ export const useMcpAgent = (mcpConfiguration: string) => {
       .addEdge("tools", "agent")
       .addEdge("agent", "shouldContinue")
       .addEdge("teardownNode", "__end__")
-      .compile({ checkpointer: new PersistentMemorySaver("mcp") });
+      .compile({ checkpointer: new PersistentMemorySaver(checkpointNamespace(clusterId, "mcp")) });
   };
 
   return { buildAgentSystem, loadMcpTools };

--- a/src/renderer/business/cluster/active-cluster.ts
+++ b/src/renderer/business/cluster/active-cluster.ts
@@ -1,0 +1,29 @@
+import { Renderer } from "@freelensapp/extensions";
+
+// Fallback key used when no active cluster can be resolved (for example on an
+// older host that does not expose the catalog API). It keeps the chat usable
+// instead of throwing, while still giving every unresolved frame a single,
+// stable bucket.
+export const DEFAULT_CLUSTER_ID = "default";
+
+/**
+ * The id of the cluster whose Freelens cluster frame this renderer code runs in.
+ *
+ * Each connected cluster gets its own cluster frame, but the durable, host-
+ * managed stores (chat transcript, conversation thread id, agent checkpoint
+ * state) are backed by single JSON files shared across every frame. Keying those
+ * stores by this id is what keeps the chat session, conversation thread, and
+ * agent memory separate per cluster instead of every cluster sharing one chat.
+ *
+ * Resolved once when the chat page mounts: the frame belongs to exactly one
+ * cluster for its whole lifetime, so the active cluster at mount time is the
+ * frame's own cluster.
+ */
+export function getActiveClusterId(): string {
+  try {
+    const id = Renderer.Catalog.getActiveCluster()?.id;
+    return id && id.length > 0 ? id : DEFAULT_CLUSTER_ID;
+  } catch {
+    return DEFAULT_CLUSTER_ID;
+  }
+}

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -13,6 +13,7 @@ import useLog from "../../common/utils/logger/logger-service";
 import { generateUuid } from "../../common/utils/uuid";
 import { FreeLensAgent, useFreeLensAgentSystem } from "../business/agent/freelens-agent-system";
 import { MPCAgent, useMcpAgent } from "../business/agent/mcp-agent";
+import { getActiveClusterId } from "../business/cluster/active-cluster";
 import { getTextMessage } from "../business/objects/message-object-provider";
 import { MessageType } from "../business/objects/message-type";
 import { AIProviders } from "../business/provider/ai-models";
@@ -60,6 +61,10 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const [chatSessionStore, _setChatSessionStore] = useState<ChatSessionStore>(
     ChatSessionStore.getInstanceOrCreate<ChatSessionStore>(),
   );
+  // Resolved once: this cluster frame belongs to exactly one cluster for its
+  // whole lifetime. All durable session data (transcript, conversation thread,
+  // agent checkpoints) is keyed by this id so each cluster keeps its own chat.
+  const [clusterId] = useState<string>(() => getActiveClusterId());
   const [conversationId, _setConversationId] = useState("");
   const [isLoading, _setLoading] = useState(false);
   const [isConversationInterrupted, _setConversationInterrupted] = useState(false);
@@ -99,13 +104,13 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const _loadChatMessages = () => {
     // Durable: persisted in the host-managed ChatSessionStore so the transcript
     // survives an app restart (window.localStorage is not durable here).
-    _setChatMessages(chatSessionStore.messages);
+    _setChatMessages(chatSessionStore.getMessages(clusterId));
   };
 
   const _getConversationId = () => {
     // Durable: persisted in the host-managed ChatSessionStore so the conversation
     // thread stays stable across an app restart, matching the restored transcript.
-    const storedConversationId = chatSessionStore.conversationId;
+    const storedConversationId = chatSessionStore.getConversationId(clusterId);
     if (storedConversationId) {
       _setConversationId(storedConversationId);
       log.debug("Using stored conversation ID: ", storedConversationId);
@@ -113,7 +118,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
       log.debug("Generating conversation ID");
       const newConverstionId = generateUuid();
       _setConversationId(newConverstionId);
-      chatSessionStore.setConversationId(newConverstionId);
+      chatSessionStore.setConversationId(clusterId, newConverstionId);
       log.debug("No stored conversation ID found, generating a new one.");
     }
   };
@@ -137,7 +142,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         prev = [];
       }
       const updated = [...prev, message];
-      chatSessionStore.setMessages(updated);
+      chatSessionStore.setMessages(clusterId, updated);
       return updated;
     });
   };
@@ -146,7 +151,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     _setChatMessages((prev) => {
       if (!prev) return prev;
       const updated = prev.filter((message) => message.messageId !== messageId);
-      chatSessionStore.setMessages(updated);
+      chatSessionStore.setMessages(clusterId, updated);
       return updated;
     });
   };
@@ -159,7 +164,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
       if (!prev) return prev;
       const updated = prev.filter((message) => !message.error);
       if (updated.length === prev.length) return prev;
-      chatSessionStore.setMessages(updated);
+      chatSessionStore.setMessages(clusterId, updated);
       return updated;
     });
   };
@@ -179,7 +184,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
       if (lastMessage.sent || lastMessage.type === MessageType.INTERRUPT) {
         // Agent response does not exist, add a new empty one
         messagesCopy.push(getTextMessage(newText, false));
-        chatSessionStore.setMessages(messagesCopy);
+        chatSessionStore.setMessages(clusterId, messagesCopy);
         return messagesCopy;
       }
 
@@ -189,7 +194,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         text: lastMessage.text + newText,
       };
 
-      chatSessionStore.setMessages(messagesCopy);
+      chatSessionStore.setMessages(clusterId, messagesCopy);
       return messagesCopy;
     });
   };
@@ -211,7 +216,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         };
       }
 
-      chatSessionStore.setMessages(messagesCopy);
+      chatSessionStore.setMessages(clusterId, messagesCopy);
       return messagesCopy;
     });
   };
@@ -220,18 +225,19 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     if (freeLensAgent) {
       cleanAgentMessageHistory(freeLensAgent).finally(() => {
         _setChatMessages([]);
-        chatSessionStore.clear();
+        chatSessionStore.clear(clusterId);
       });
     }
     if (mcpAgent) {
       await cleanAgentMessageHistory(mcpAgent).finally(() => {
         _setChatMessages([]);
-        chatSessionStore.clear();
+        chatSessionStore.clear(clusterId);
       });
     }
-    // Wipe the durable LangGraph checkpointer state so a restart right after a
-    // clear does not restore the model-side conversation context.
-    AgentStateStore.getInstanceOrCreate<AgentStateStore>().clear();
+    // Wipe this cluster's durable LangGraph checkpointer state so a restart right
+    // after a clear does not restore the model-side conversation context. Other
+    // clusters' memory is left untouched.
+    AgentStateStore.getInstanceOrCreate<AgentStateStore>().clearForCluster(clusterId);
   };
 
   const cleanAgentMessageHistory = async (agent: FreeLensAgent | MPCAgent) => {
@@ -277,7 +283,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
 
     if (mcpAgent === null || forceInitialization) {
       log.debug("initializing MCP agent with configuration", preferencesStore.mcpConfiguration);
-      setMcpAgent(await mcpAgentSystem.buildAgentSystem());
+      setMcpAgent(await mcpAgentSystem.buildAgentSystem(clusterId));
       log.debug("MCP agent initialized!");
     } else {
       log.debug("The MCP Agent was already initialized: ", mcpAgent);
@@ -286,7 +292,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
 
   const _initFreeLensAgent = () => {
     if (freeLensAgent === null) {
-      setFreeLensAgent(freeLensAgentSystem.buildAgentSystem());
+      setFreeLensAgent(freeLensAgentSystem.buildAgentSystem(clusterId));
     } else {
       log.debug("Freelens Agent was already initialized: ", freeLensAgent);
     }
@@ -295,7 +301,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const getActiveAgent = async () => {
     if (preferencesStore.mcpEnabled) {
       if (mcpAgent === null) {
-        const _mcpAgent = await mcpAgentSystem.buildAgentSystem();
+        const _mcpAgent = await mcpAgentSystem.buildAgentSystem(clusterId);
         setMcpAgent(_mcpAgent);
         return _mcpAgent;
       }
@@ -304,7 +310,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     }
 
     if (freeLensAgent === null) {
-      const _freeLensAgent = freeLensAgentSystem.buildAgentSystem();
+      const _freeLensAgent = freeLensAgentSystem.buildAgentSystem(clusterId);
       setFreeLensAgent(_freeLensAgent);
       log.debug("Freelens Agent initialized: ", freeLensAgent);
       return _freeLensAgent;
@@ -346,7 +352,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const changeInterruptStatus = (id: string, status: boolean) => {
     _setChatMessages((prevMessages) => {
       const updated = prevMessages!.map((msg) => (msg.messageId === id ? { ...msg, approved: status } : msg));
-      chatSessionStore.setMessages(updated);
+      chatSessionStore.setMessages(clusterId, updated);
       return updated;
     });
   };


### PR DESCRIPTION
Closes #214

Keys the chat transcript, conversation thread id, and agent checkpoint state by the active cluster id so each connected cluster has its own session, context, and persistency. Previously these lived in single host-managed files shared across every cluster frame, so switching clusters showed the same chat.
