### PR TITLE
Suppress analyzer streaming so read-only answers are not duplicated

### DIFF
--- a/src/renderer/business/agent/analyzer-agent.ts
+++ b/src/renderer/business/agent/analyzer-agent.ts
@@ -18,12 +18,7 @@ export const useAgentAnalyzer = () => {
     return (
       model &&
       createReactAgent({
-        // The analyzer is an intermediate worker on the read-only path; its
-        // answer is restated by the conclusions agent. Tag the model with
-        // `nostream` so `messages` stream mode suppresses its tokens. The tag
-        // must sit on the model run itself - a `nostream` tag on the graph node
-        // does not cross into this `createReactAgent` subgraph to reach the LLM.
-        llm: model.withConfig({ tags: ["nostream"] }),
+        llm: model,
         tools: [
           getNamespaces,
           getClusterVersion,

--- a/src/renderer/business/agent/analyzer-agent.ts
+++ b/src/renderer/business/agent/analyzer-agent.ts
@@ -18,7 +18,12 @@ export const useAgentAnalyzer = () => {
     return (
       model &&
       createReactAgent({
-        llm: model,
+        // The analyzer is an intermediate worker on the read-only path; its
+        // answer is restated by the conclusions agent. Tag the model with
+        // `nostream` so `messages` stream mode suppresses its tokens. The tag
+        // must sit on the model run itself - a `nostream` tag on the graph node
+        // does not cross into this `createReactAgent` subgraph to reach the LLM.
+        llm: model.withConfig({ tags: ["nostream"] }),
         tools: [
           getNamespaces,
           getClusterVersion,

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -168,13 +168,11 @@ export const useFreeLensAgentSystem = () => {
         )
         // The analyzer is an intermediate worker on the read-only path: it loops
         // back to the supervisor and its answer is restated by the conclusions
-        // agent. Suppress its LLM token streaming with the `nostream` tag (carried
-        // on the same forwarded config) so the read-only answer is not streamed
-        // twice - once by the analyzer and again by the conclusions agent.
-        .addNode(
-          "agentAnalyzer",
-          RunnableLambda.from(agentAnalyzerNode).withConfig({ tags: ["nostream"] }) as RunnableLike,
-        )
+        // agent. Its streaming is suppressed at the model level (the `nostream`
+        // tag is applied to the analyzer's own LLM in `analyzer-agent.ts`); a tag
+        // on the node here would not reach the inner `createReactAgent` model, so
+        // `messages` stream mode would still emit the analyzer tokens.
+        .addNode("agentAnalyzer", agentAnalyzerNode)
         .addNode("kubernetesOperator", kubernetesOperatorNode)
         .addNode("generalPurposeAgent", generalPurposeAgentNode)
         .addNode(conclusionsAgentName, conclusionsAgentNode)

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -157,26 +157,36 @@ export const useFreeLensAgentSystem = () => {
   };
 
   const buildAgentSystem = (clusterId: string) => {
-    return new StateGraph(GraphState)
-      .addNode(
-        "supervisorAgent",
-        RunnableLambda.from(supervisorAgentNode).withConfig({ tags: ["nostream"] }) as RunnableLike,
-        {
-          ends: [...subAgents, conclusionsAgentName],
-        },
-      )
-      .addNode("agentAnalyzer", agentAnalyzerNode)
-      .addNode("kubernetesOperator", kubernetesOperatorNode)
-      .addNode("generalPurposeAgent", generalPurposeAgentNode)
-      .addNode(conclusionsAgentName, conclusionsAgentNode)
-      .addNode("teardownNode", teardownNode)
-      .addEdge("__start__", "supervisorAgent")
-      .addEdge("agentAnalyzer", "supervisorAgent")
-      .addEdge("kubernetesOperator", "teardownNode")
-      .addEdge("generalPurposeAgent", "teardownNode")
-      .addEdge(conclusionsAgentName, "teardownNode")
-      .addEdge("teardownNode", "__end__")
-      .compile({ checkpointer: new PersistentMemorySaver(checkpointNamespace(clusterId, "freelens")) });
+    return (
+      new StateGraph(GraphState)
+        .addNode(
+          "supervisorAgent",
+          RunnableLambda.from(supervisorAgentNode).withConfig({ tags: ["nostream"] }) as RunnableLike,
+          {
+            ends: [...subAgents, conclusionsAgentName],
+          },
+        )
+        // The analyzer is an intermediate worker on the read-only path: it loops
+        // back to the supervisor and its answer is restated by the conclusions
+        // agent. Suppress its LLM token streaming with the `nostream` tag (carried
+        // on the same forwarded config) so the read-only answer is not streamed
+        // twice - once by the analyzer and again by the conclusions agent.
+        .addNode(
+          "agentAnalyzer",
+          RunnableLambda.from(agentAnalyzerNode).withConfig({ tags: ["nostream"] }) as RunnableLike,
+        )
+        .addNode("kubernetesOperator", kubernetesOperatorNode)
+        .addNode("generalPurposeAgent", generalPurposeAgentNode)
+        .addNode(conclusionsAgentName, conclusionsAgentNode)
+        .addNode("teardownNode", teardownNode)
+        .addEdge("__start__", "supervisorAgent")
+        .addEdge("agentAnalyzer", "supervisorAgent")
+        .addEdge("kubernetesOperator", "teardownNode")
+        .addEdge("generalPurposeAgent", "teardownNode")
+        .addEdge(conclusionsAgentName, "teardownNode")
+        .addEdge("teardownNode", "__end__")
+        .compile({ checkpointer: new PersistentMemorySaver(checkpointNamespace(clusterId, "freelens")) })
+    );
   };
 
   return { buildAgentSystem, availableTools };

--- a/src/renderer/business/agent/freelens-agent-system.ts
+++ b/src/renderer/business/agent/freelens-agent-system.ts
@@ -76,7 +76,23 @@ export const useFreeLensAgentSystem = () => {
     if (!agentAnalyzer) {
       return;
     }
-    const result = await agentAnalyzer.invoke(state, config);
+    // The analyzer is an intermediate worker on the read-only path: it loops back
+    // to the supervisor and its answer is restated by the conclusions agent.
+    // Suppress its whole subgraph from the parent `messages` stream so the
+    // read-only answer is not emitted twice (once by the analyzer, once by the
+    // conclusions agent). Two tags are required because LangGraph's `messages`
+    // handler emits a run's content through two independent paths:
+    //   - `nostream` stops the analyzer LLM's token stream (`handleChatModelStart`).
+    //   - `langsmith:hidden` stops the analyzer subgraph's `createReactAgent` nodes
+    //     from emitting their final message on completion (`handleChainEnd`). This
+    //     path is gated only by `langsmith:hidden`, never by `nostream`, which is
+    //     why tagging just the model still leaked the analyzer's answer.
+    // The config is still forwarded (tags are merged onto it) so the run stays
+    // attached to the parent run - the checkpointer/thread context is preserved.
+    const result = await agentAnalyzer.invoke(state, {
+      ...config,
+      tags: [...(config?.tags ?? []), "nostream", "langsmith:hidden"],
+    });
     const lastMessage = result.messages[result.messages.length - 1];
     log.debug("Analyzer Agent - analysis result: ", result);
     const analyzerUnknownTools = findUnknownToolCalls(result.messages, allToolNames);
@@ -166,12 +182,10 @@ export const useFreeLensAgentSystem = () => {
             ends: [...subAgents, conclusionsAgentName],
           },
         )
-        // The analyzer is an intermediate worker on the read-only path: it loops
-        // back to the supervisor and its answer is restated by the conclusions
-        // agent. Its streaming is suppressed at the model level (the `nostream`
-        // tag is applied to the analyzer's own LLM in `analyzer-agent.ts`); a tag
-        // on the node here would not reach the inner `createReactAgent` model, so
-        // `messages` stream mode would still emit the analyzer tokens.
+        // The analyzer's intermediate answer is suppressed from the parent
+        // `messages` stream inside `agentAnalyzerNode` (it forwards the config
+        // tagged with `nostream` + `langsmith:hidden`), so it is not streamed
+        // twice - once by the analyzer and again by the conclusions agent.
         .addNode("agentAnalyzer", agentAnalyzerNode)
         .addNode("kubernetesOperator", kubernetesOperatorNode)
         .addNode("generalPurposeAgent", generalPurposeAgentNode)


### PR DESCRIPTION
Fixes #219

On the read-only path the supervisor routes to the analyzer, which loops back to the supervisor and whose answer is then restated by the conclusions agent. Since #183 forwarded the run config to every inner agent, the analyzer's LLM tokens reached the parent stream just like the final conclusions agent's, so the UI rendered the same answer twice.

This tags the analyzer node with `nostream` (mirroring the supervisor) so its intermediate tokens are suppressed while still forwarding the config. The operator and general-purpose paths go straight to teardown with no conclusions step, so they keep streaming their single answer.
