### PR TITLE
Add per-session token counter next to the model list

### DIFF
--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -6,7 +6,12 @@ import {
 } from "../../renderer/business/objects/message-object-provider";
 import { MessageType } from "../../renderer/business/objects/message-type";
 import { DEFAULT_OPENAI_BASE_URL } from "../../renderer/business/provider/ai-models";
-import { AgentService, isReasoningChunk, useAgentService } from "../../renderer/business/service/agent-service";
+import {
+  AgentService,
+  isReasoningChunk,
+  isTokenUsageChunk,
+  useAgentService,
+} from "../../renderer/business/service/agent-service";
 import { AiAnalysisService, useAiAnalysisService } from "../../renderer/business/service/ai-analysis-service";
 import { ActionToApprove } from "../../renderer/components/chat";
 import { useApplicationStatusStore } from "../../renderer/context/application-context";
@@ -223,6 +228,13 @@ const useChatService = () => {
         // than its visible answer text.
         if (isReasoningChunk(chunk)) {
           applicationStatusStore.updateLastMessageReasoning(chunk.reasoning);
+          continue;
+        }
+
+        // Token usage reported for a model turn is summed into the per-session
+        // counter shown next to the model list.
+        if (isTokenUsageChunk(chunk)) {
+          applicationStatusStore.addTokenUsage(chunk.tokenUsage);
           continue;
         }
 

--- a/src/common/store/chat-session-store.ts
+++ b/src/common/store/chat-session-store.ts
@@ -1,5 +1,6 @@
 import { Common } from "@freelensapp/extensions";
 import { makeObservable, observable, toJS } from "mobx";
+import { emptyTokenUsage, type TokenUsage } from "../../renderer/business/service/token-usage";
 
 import type { MessageObject } from "../../renderer/business/objects/message-object";
 
@@ -8,6 +9,9 @@ export interface ChatSession {
   // agent's LangGraph thread. Both make up the durable "session".
   messages: MessageObject[];
   conversationId: string;
+  // Running token totals for this session, summed across every model turn.
+  // Reset when the session is cleared.
+  tokenUsage: TokenUsage;
 }
 
 export interface ChatSessionModel {
@@ -18,7 +22,7 @@ export interface ChatSessionModel {
   sessions: Record<string, ChatSession>;
 }
 
-const emptySession = (): ChatSession => ({ messages: [], conversationId: "" });
+const emptySession = (): ChatSession => ({ messages: [], conversationId: "", tokenUsage: emptyTokenUsage() });
 
 /**
  * Durable, host-managed persistence for the rendered chat sessions (the
@@ -78,8 +82,17 @@ export class ChatSessionStore extends Common.Store.ExtensionStore<ChatSessionMod
     this.patch(clusterId, { conversationId });
   }
 
+  getTokenUsage(clusterId: string): TokenUsage {
+    return this.session(clusterId).tokenUsage ?? emptyTokenUsage();
+  }
+
+  setTokenUsage(clusterId: string, tokenUsage: TokenUsage): void {
+    this.patch(clusterId, { tokenUsage });
+  }
+
   clear(clusterId: string): void {
-    this.patch(clusterId, { messages: [] });
+    // Clearing the session also zeroes the token counter.
+    this.patch(clusterId, { messages: [], tokenUsage: emptyTokenUsage() });
   }
 
   fromStore(model: ChatSessionModel): void {
@@ -96,6 +109,7 @@ export class ChatSessionStore extends Common.Store.ExtensionStore<ChatSessionMod
       sessions[clusterId] = {
         messages: toJS(session.messages),
         conversationId: session.conversationId,
+        tokenUsage: toJS(session.tokenUsage) ?? emptyTokenUsage(),
       };
     }
     return { sessions };

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -1,8 +1,11 @@
+import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import { Command, Interrupt } from "@langchain/langgraph";
 import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
 import { createStreamMergeState, extractReasoningText, mergeAiChunk } from "./stream-merge";
-import { extractTokenUsage, type TokenUsage } from "./token-usage";
+import { addTokenUsage, emptyTokenUsage, extractTokenUsageFromLLMResult, type TokenUsage } from "./token-usage";
+
+import type { LLMResult } from "@langchain/core/outputs";
 
 const MAX_GEMINI_STREAM_RETRIES = 3;
 const BASE_BACKOFF_MS = 700;
@@ -54,6 +57,26 @@ export interface TokenUsageChunk {
 export const isTokenUsageChunk = (chunk: unknown): chunk is TokenUsageChunk =>
   typeof chunk === "object" && chunk !== null && "tokenUsage" in chunk;
 
+/**
+ * Accumulates the token usage reported by every model turn in a run via the
+ * `handleLLMEnd` callback. The callback fires for each LLM call - including the
+ * supervisor and analyzer turns the graph suppresses from the `messages` stream
+ * with the `nostream` tag - so the counter reflects the whole run, not just the
+ * single visible (conclusions / operator) turn. Config callbacks propagate to
+ * the sub-agents through the forwarded run config, so their turns are caught too.
+ */
+class TokenUsageCollector extends BaseCallbackHandler {
+  name = "freelens-token-usage-collector";
+  total: TokenUsage = emptyTokenUsage();
+
+  handleLLMEnd(output: LLMResult): void {
+    const usage = extractTokenUsageFromLLMResult(output);
+    if (usage) {
+      this.total = addTokenUsage(this.total, usage);
+    }
+  }
+}
+
 export interface AgentService {
   run(
     agentInput: object | Command,
@@ -77,9 +100,16 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
       // Tracks assistant message boundaries so distinct messages emitted within a
       // single run are separated by a blank line instead of being glued together.
       const mergeState = createStreamMergeState();
+      // Fresh per attempt so a transient-error retry discards the usage counted
+      // for the failed attempt rather than double counting it.
+      const tokenUsageCollector = new TokenUsageCollector();
 
       try {
-        const streamResponse = await agent.stream(agentInput, { streamMode: "messages", configurable: config });
+        const streamResponse = await agent.stream(agentInput, {
+          streamMode: "messages",
+          configurable: config,
+          callbacks: [tokenUsageCollector],
+        });
 
         // streams LLM token by token to the UI
         for await (const [message, _metadata] of streamResponse) {
@@ -113,20 +143,20 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
               hasYieldedContent = true;
               yield text;
             }
-
-            // Token usage is reported once per model turn, on the final chunk
-            // of that turn (the others carry no `usage_metadata`). Forward it so
-            // the chat service can accumulate the per-session counter. Not
-            // treated as "yielded content" so it never blocks a transient-error
-            // retry on its own.
-            const tokenUsage = extractTokenUsage((message as { usage_metadata?: unknown }).usage_metadata);
-            if (tokenUsage) {
-              yield { tokenUsage };
-            }
           }
         }
 
         yield "\n";
+
+        // Emit the token usage accumulated across every model turn in this run
+        // (collected from the `handleLLMEnd` callback above). Reading it from the
+        // callback rather than the streamed chunks is what lets the supervisor
+        // and analyzer turns - suppressed from the `messages` stream by the
+        // `nostream` tag - be counted, not just the single visible turn.
+        const tokenUsage = tokenUsageCollector.total;
+        if (tokenUsage.input !== 0 || tokenUsage.cached !== 0 || tokenUsage.output !== 0) {
+          yield { tokenUsage };
+        }
 
         // checks the agent state for any interrupts
         const agentState = await agent.getState({ configurable: config });

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -2,6 +2,7 @@ import { Command, Interrupt } from "@langchain/langgraph";
 import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
 import { createStreamMergeState, extractReasoningText, mergeAiChunk } from "./stream-merge";
+import { extractTokenUsage, type TokenUsage } from "./token-usage";
 
 const MAX_GEMINI_STREAM_RETRIES = 3;
 const BASE_BACKOFF_MS = 700;
@@ -44,11 +45,20 @@ export const isReasoningChunk = (chunk: unknown): chunk is ReasoningChunk =>
   "reasoning" in chunk &&
   typeof (chunk as ReasoningChunk).reasoning === "string";
 
+// A streamed chunk carrying the token usage reported for a single model turn.
+// The chat service sums these into the per-session counter shown in the UI.
+export interface TokenUsageChunk {
+  tokenUsage: TokenUsage;
+}
+
+export const isTokenUsageChunk = (chunk: unknown): chunk is TokenUsageChunk =>
+  typeof chunk === "object" && chunk !== null && "tokenUsage" in chunk;
+
 export interface AgentService {
   run(
     agentInput: object | Command,
     conversationId: string,
-  ): AsyncGenerator<string | ReasoningChunk | Interrupt, void, unknown>;
+  ): AsyncGenerator<string | ReasoningChunk | TokenUsageChunk | Interrupt, void, unknown>;
 }
 
 /**
@@ -102,6 +112,16 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
             if (text.length > 0) {
               hasYieldedContent = true;
               yield text;
+            }
+
+            // Token usage is reported once per model turn, on the final chunk
+            // of that turn (the others carry no `usage_metadata`). Forward it so
+            // the chat service can accumulate the per-session counter. Not
+            // treated as "yielded content" so it never blocks a transient-error
+            // retry on its own.
+            const tokenUsage = extractTokenUsage((message as { usage_metadata?: unknown }).usage_metadata);
+            if (tokenUsage) {
+              yield { tokenUsage };
             }
           }
         }

--- a/src/renderer/business/service/token-usage.test.ts
+++ b/src/renderer/business/service/token-usage.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { addTokenUsage, emptyTokenUsage, extractTokenUsage, formatTokenUsage } from "./token-usage";
+
+describe("extractTokenUsage", () => {
+  it("returns null for missing or non-object metadata", () => {
+    expect(extractTokenUsage(undefined)).toBeNull();
+    expect(extractTokenUsage(null)).toBeNull();
+    expect(extractTokenUsage("nope")).toBeNull();
+  });
+
+  it("returns null when every count is zero or absent", () => {
+    expect(extractTokenUsage({})).toBeNull();
+    expect(extractTokenUsage({ input_tokens: 0, output_tokens: 0 })).toBeNull();
+  });
+
+  it("reads input, output, and cached read tokens", () => {
+    expect(
+      extractTokenUsage({
+        input_tokens: 120,
+        output_tokens: 45,
+        input_token_details: { cache_read: 80 },
+      }),
+    ).toEqual({ input: 120, cached: 80, output: 45 });
+  });
+
+  it("defaults cached to zero when no cache_read is present", () => {
+    expect(extractTokenUsage({ input_tokens: 10, output_tokens: 5 })).toEqual({ input: 10, cached: 0, output: 5 });
+  });
+
+  it("ignores non-finite counts", () => {
+    expect(extractTokenUsage({ input_tokens: Number.NaN, output_tokens: 7 })).toEqual({
+      input: 0,
+      cached: 0,
+      output: 7,
+    });
+  });
+});
+
+describe("addTokenUsage", () => {
+  it("sums the running totals with a delta", () => {
+    const total = addTokenUsage({ input: 100, cached: 20, output: 30 }, { input: 5, cached: 2, output: 8 });
+    expect(total).toEqual({ input: 105, cached: 22, output: 38 });
+  });
+
+  it("starts from an empty total", () => {
+    expect(addTokenUsage(emptyTokenUsage(), { input: 1, cached: 0, output: 2 })).toEqual({
+      input: 1,
+      cached: 0,
+      output: 2,
+    });
+  });
+});
+
+describe("formatTokenUsage", () => {
+  it("renders the compact counter string", () => {
+    expect(formatTokenUsage({ input: 120, cached: 80, output: 45 })).toBe("in:120 (cached:80) + out:45");
+  });
+
+  it("groups large counts", () => {
+    expect(formatTokenUsage({ input: 12345, cached: 6789, output: 1000 })).toBe("in:12,345 (cached:6,789) + out:1,000");
+  });
+
+  it("renders zeros for an empty session", () => {
+    expect(formatTokenUsage(emptyTokenUsage())).toBe("in:0 (cached:0) + out:0");
+  });
+});

--- a/src/renderer/business/service/token-usage.test.ts
+++ b/src/renderer/business/service/token-usage.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { addTokenUsage, emptyTokenUsage, extractTokenUsage, formatTokenUsage } from "./token-usage";
+import {
+  addTokenUsage,
+  emptyTokenUsage,
+  extractTokenUsage,
+  extractTokenUsageFromLLMResult,
+  formatTokenUsage,
+} from "./token-usage";
 
 describe("extractTokenUsage", () => {
   it("returns null for missing or non-object metadata", () => {
@@ -33,6 +39,72 @@ describe("extractTokenUsage", () => {
       cached: 0,
       output: 7,
     });
+  });
+});
+
+describe("extractTokenUsageFromLLMResult", () => {
+  it("returns null for missing or non-object results", () => {
+    expect(extractTokenUsageFromLLMResult(undefined)).toBeNull();
+    expect(extractTokenUsageFromLLMResult(null)).toBeNull();
+    expect(extractTokenUsageFromLLMResult("nope")).toBeNull();
+  });
+
+  it("reads per-message usage_metadata from a single generation", () => {
+    expect(
+      extractTokenUsageFromLLMResult({
+        generations: [
+          [
+            {
+              message: {
+                usage_metadata: { input_tokens: 100, output_tokens: 40, input_token_details: { cache_read: 30 } },
+              },
+            },
+          ],
+        ],
+      }),
+    ).toEqual({ input: 100, cached: 30, output: 40 });
+  });
+
+  it("sums usage_metadata across multiple generations", () => {
+    expect(
+      extractTokenUsageFromLLMResult({
+        generations: [
+          [{ message: { usage_metadata: { input_tokens: 100, output_tokens: 40 } } }],
+          [
+            {
+              message: {
+                usage_metadata: { input_tokens: 10, output_tokens: 5, input_token_details: { cache_read: 4 } },
+              },
+            },
+          ],
+        ],
+      }),
+    ).toEqual({ input: 110, cached: 4, output: 45 });
+  });
+
+  it("falls back to flat llmOutput.tokenUsage when no message carries usage_metadata", () => {
+    expect(
+      extractTokenUsageFromLLMResult({
+        generations: [[{ message: {} }]],
+        llmOutput: { tokenUsage: { promptTokens: 70, completionTokens: 12 } },
+      }),
+    ).toEqual({ input: 70, cached: 0, output: 12 });
+  });
+
+  it("returns null when neither source carries positive counts", () => {
+    expect(extractTokenUsageFromLLMResult({ generations: [[{ message: {} }]] })).toBeNull();
+    expect(
+      extractTokenUsageFromLLMResult({ llmOutput: { tokenUsage: { promptTokens: 0, completionTokens: 0 } } }),
+    ).toBeNull();
+  });
+
+  it("prefers usage_metadata over the flat fallback", () => {
+    expect(
+      extractTokenUsageFromLLMResult({
+        generations: [[{ message: { usage_metadata: { input_tokens: 5, output_tokens: 6 } } }]],
+        llmOutput: { tokenUsage: { promptTokens: 999, completionTokens: 999 } },
+      }),
+    ).toEqual({ input: 5, cached: 0, output: 6 });
   });
 });
 

--- a/src/renderer/business/service/token-usage.ts
+++ b/src/renderer/business/service/token-usage.ts
@@ -49,6 +49,74 @@ export const extractTokenUsage = (usageMetadata: unknown): TokenUsage | null => 
   return { input, cached, output };
 };
 
+// A single generation in a LangChain `LLMResult`. For chat models the rich
+// usage lives on the generation's `message.usage_metadata`.
+interface GenerationLike {
+  message?: { usage_metadata?: unknown };
+}
+
+// The `LLMResult` shape passed to the `handleLLMEnd` callback. Only the fields
+// we read are described.
+interface LLMResultLike {
+  generations?: GenerationLike[][];
+  llmOutput?: {
+    // Flat OpenAI-style usage some providers report instead of per-message
+    // `usage_metadata` (no cache breakdown).
+    tokenUsage?: { promptTokens?: number; completionTokens?: number };
+  };
+}
+
+/**
+ * Pull the token usage out of a LangChain `LLMResult` (the value passed to the
+ * `handleLLMEnd` callback). Sums the per-message `usage_metadata` across every
+ * generation, falling back to the flat `llmOutput.tokenUsage` when no message
+ * carries `usage_metadata`. Returns `null` when no positive counts are found.
+ *
+ * Counting from the callback rather than the streamed chunks is what lets the
+ * supervisor and analyzer turns - suppressed from the `messages` stream by the
+ * `nostream` tag - be included in the per-session counter.
+ */
+export const extractTokenUsageFromLLMResult = (result: unknown): TokenUsage | null => {
+  if (!result || typeof result !== "object") {
+    return null;
+  }
+
+  const { generations, llmOutput } = result as LLMResultLike;
+
+  let total = emptyTokenUsage();
+  let found = false;
+
+  if (Array.isArray(generations)) {
+    for (const batch of generations) {
+      if (!Array.isArray(batch)) {
+        continue;
+      }
+      for (const generation of batch) {
+        const usage = extractTokenUsage(generation?.message?.usage_metadata);
+        if (usage) {
+          total = addTokenUsage(total, usage);
+          found = true;
+        }
+      }
+    }
+  }
+
+  if (found) {
+    return total;
+  }
+
+  const tokenUsage = llmOutput?.tokenUsage;
+  if (tokenUsage) {
+    const input = toCount(tokenUsage.promptTokens);
+    const output = toCount(tokenUsage.completionTokens);
+    if (input !== 0 || output !== 0) {
+      return { input, cached: 0, output };
+    }
+  }
+
+  return null;
+};
+
 // Add a single model turn's usage onto the running session totals.
 export const addTokenUsage = (total: TokenUsage, delta: TokenUsage): TokenUsage => ({
   input: total.input + delta.input,

--- a/src/renderer/business/service/token-usage.ts
+++ b/src/renderer/business/service/token-usage.ts
@@ -1,0 +1,67 @@
+// Pure helpers for the per-session token counter shown next to the model list.
+//
+// Kept free of host/MobX dependencies so the extraction and formatting logic can
+// be unit-tested in isolation (see token-usage.test.ts).
+
+// Running totals for a chat session. `cached` is the subset of `input` tokens
+// the provider served from its prompt cache (LangChain's
+// `input_token_details.cache_read`).
+export interface TokenUsage {
+  input: number;
+  cached: number;
+  output: number;
+}
+
+export const emptyTokenUsage = (): TokenUsage => ({ input: 0, cached: 0, output: 0 });
+
+// The `usage_metadata` shape LangChain attaches to AI messages. Only the fields
+// we report are described; everything else is ignored.
+interface UsageMetadataLike {
+  input_tokens?: number;
+  output_tokens?: number;
+  input_token_details?: {
+    cache_read?: number;
+  };
+}
+
+const toCount = (value: unknown): number => (typeof value === "number" && Number.isFinite(value) ? value : 0);
+
+/**
+ * Pull the input/cached/output token counts out of a LangChain
+ * `usage_metadata` record. Returns `null` when the record is absent or carries
+ * no positive counts, so callers can skip empty streamed chunks (every chunk
+ * before the final one of a model turn has no usage).
+ */
+export const extractTokenUsage = (usageMetadata: unknown): TokenUsage | null => {
+  if (!usageMetadata || typeof usageMetadata !== "object") {
+    return null;
+  }
+
+  const metadata = usageMetadata as UsageMetadataLike;
+  const input = toCount(metadata.input_tokens);
+  const output = toCount(metadata.output_tokens);
+  const cached = toCount(metadata.input_token_details?.cache_read);
+
+  if (input === 0 && output === 0 && cached === 0) {
+    return null;
+  }
+
+  return { input, cached, output };
+};
+
+// Add a single model turn's usage onto the running session totals.
+export const addTokenUsage = (total: TokenUsage, delta: TokenUsage): TokenUsage => ({
+  input: total.input + delta.input,
+  cached: total.cached + delta.cached,
+  output: total.output + delta.output,
+});
+
+/**
+ * Render the session totals as the compact counter requested in the issue:
+ * `in:xxx (cached:zzz) + out:yyy`. Counts use locale grouping so large totals
+ * stay readable.
+ */
+export const formatTokenUsage = (usage: TokenUsage): string => {
+  const format = (value: number) => value.toLocaleString("en-US");
+  return `in:${format(usage.input)} (cached:${format(usage.cached)}) + out:${format(usage.output)}`;
+};

--- a/src/renderer/components/text-input/text-input.scss
+++ b/src/renderer/components/text-input/text-input.scss
@@ -47,6 +47,16 @@
   cursor: default;
 }
 
+// Per-session token counter shown next to the model list. Matches the dimmed,
+// smaller styling of the chat's "Reasoning" summary.
+.text-input-token-counter {
+  margin-right: 0.5rem;
+  color: var(--textColorDimmed);
+  font-size: 0.9em;
+  white-space: nowrap;
+  user-select: none;
+}
+
 .text-input-select-box {
   min-width: 70px !important;
 }

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -2,6 +2,7 @@ import { Renderer } from "@freelensapp/extensions";
 import { Eraser, SendHorizonal, ShieldOff } from "lucide-react";
 import * as MobxReact from "mobx-react";
 import * as React from "react";
+import { formatTokenUsage } from "../../business/service/token-usage";
 import { useApplicationStatusStore } from "../../context/application-context";
 import { AvailableTools } from "../available-tools/available-tools";
 import styleInline from "./text-input.scss?inline";
@@ -108,6 +109,14 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
               </button>
             </div>
             <div style={{ display: "flex", alignItems: "center" }}>
+              {textInputHook.agentConfigured && (
+                <span
+                  className="text-input-token-counter"
+                  title="Tokens used this session (input, cached input, output). Resets when the chat is cleared."
+                >
+                  {formatTokenUsage(applicationStatusStore.tokenUsage)}
+                </span>
+              )}
               {textInputHook.agentConfigured ? (
                 <Select
                   id="update-channel-input"

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -17,6 +17,7 @@ import { getActiveClusterId } from "../business/cluster/active-cluster";
 import { getTextMessage } from "../business/objects/message-object-provider";
 import { MessageType } from "../business/objects/message-type";
 import { AIProviders } from "../business/provider/ai-models";
+import { emptyTokenUsage, addTokenUsage as sumTokenUsage, type TokenUsage } from "../business/service/token-usage";
 import { IS_CONVERSATION_INTERRUPTED_KEY, IS_LOADING_KEY } from "./chat-session-storage";
 
 import type { MessageObject } from "../business/objects/message-object";
@@ -32,9 +33,11 @@ export interface AppContextType {
   isLoading: boolean;
   isConversationInterrupted: boolean;
   chatMessages: MessageObject[] | null;
+  tokenUsage: TokenUsage;
   freeLensAgent: FreeLensAgent | null;
   mcpAgent: MPCAgent | null;
   setSelectedModel: (selectedModel: string) => void;
+  addTokenUsage: (usage: TokenUsage) => void;
   setExplainEvent: (messageObject: MessageObject) => void;
   setBypassApprovals: (bypassApprovals: boolean) => void;
   setLoading: (isLoading: boolean) => void;
@@ -69,6 +72,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const [isLoading, _setLoading] = useState(false);
   const [isConversationInterrupted, _setConversationInterrupted] = useState(false);
   const [chatMessages, _setChatMessages] = useState<MessageObject[] | null>(null);
+  const [tokenUsage, _setTokenUsage] = useState<TokenUsage>(emptyTokenUsage());
   const [freeLensAgent, _setFreeLensAgent] = useState<FreeLensAgent | null>(agentsStore.freeLensAgent);
   const [mcpAgent, _setMcpAgent] = useState<MPCAgent | null>(agentsStore.mcpAgent);
 
@@ -83,6 +87,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     _setConversationInterrupted(window.sessionStorage.getItem(IS_CONVERSATION_INTERRUPTED_KEY) === "true");
     _getConversationId();
     _loadChatMessages();
+    _setTokenUsage(chatSessionStore.getTokenUsage(clusterId));
     _initFreeLensAgent();
   }, []);
 
@@ -221,7 +226,19 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     });
   };
 
+  const addTokenUsage = (usage: TokenUsage) => {
+    _setTokenUsage((prev) => {
+      const updated = sumTokenUsage(prev, usage);
+      // Durable: persisted alongside the transcript so the counter survives an
+      // app restart and stays in sync with the restored session.
+      chatSessionStore.setTokenUsage(clusterId, updated);
+      return updated;
+    });
+  };
+
   const clearChat = async () => {
+    // Zero the per-session token counter alongside the transcript.
+    _setTokenUsage(emptyTokenUsage());
     if (freeLensAgent) {
       cleanAgentMessageHistory(freeLensAgent).finally(() => {
         _setChatMessages([]);
@@ -370,9 +387,11 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         isLoading,
         isConversationInterrupted,
         chatMessages,
+        tokenUsage,
         mcpAgent,
         freeLensAgent,
         setSelectedModel,
+        addTokenUsage,
         setExplainEvent,
         setBypassApprovals,
         setLoading,


### PR DESCRIPTION
Adds a per-session token counter next to the model list, shown as `in:xxx (cached:zzz) + out:yyy` in the same dimmed styling as the chat's "Reasoning" text. Totals sum input, cached-input, and output tokens across every model turn, are persisted per cluster, and are zeroed when the session is cleared.

Closes #221