### PR TITLE
Recover supervisor routing from text when the model skips the tool call

### DIFF
--- a/src/renderer/business/agent/leaked-tool-calls.ts
+++ b/src/renderer/business/agent/leaked-tool-calls.ts
@@ -51,6 +51,10 @@ const toText = (content: MessageContent): string => {
     .join("");
 };
 
+// Public alias: flatten LangChain message content to plain text. Reused by the
+// supervisor routing recovery to scan assistant text for a routing decision.
+export const messageContentToText = (content: MessageContent): string => toText(content);
+
 // True when the assistant content contains tool-call tokens that leaked as text.
 export const containsLeakedToolCallMarkup = (content: MessageContent): boolean => {
   const text = toText(content);

--- a/src/renderer/business/agent/supervisor-agent.ts
+++ b/src/renderer/business/agent/supervisor-agent.ts
@@ -1,42 +1,40 @@
-import { JsonOutputKeyToolsParser } from "@langchain/core/output_parsers/openai_tools";
 import { ChatPromptTemplate, MessagesPlaceholder } from "@langchain/core/prompts";
+import { RunnableLambda } from "@langchain/core/runnables";
 import { toJsonSchema } from "@langchain/core/utils/json_schema";
 import { z } from "zod";
 import { requiresAutoToolChoice } from "../provider/model-capabilities";
 import { useModelProvider } from "../provider/model-provider";
 import { SUPERVISOR_PROMPT_TEMPLATE } from "../provider/prompt-template-provider";
+import { recoverSupervisorRouting, SUPERVISOR_TOOL_NAME, type SupervisorRouting } from "./supervisor-routing";
 
 import type { BaseLanguageModelInput } from "@langchain/core/language_models/base";
+import type { BaseMessage } from "@langchain/core/messages";
 import type { Runnable } from "@langchain/core/runnables";
 import type { ChatOpenAI } from "@langchain/openai";
 
-// Name of the single structured-output tool bound for the supervisor. Matches
-// the default `withStructuredOutput` function-calling tool name so the parser
-// behaves identically across the forced and "auto" tool_choice paths.
-const SUPERVISOR_TOOL_NAME = "extract";
-
 // Build the supervisor's structured-output runnable.
 //
-// By default we force function calling: `withStructuredOutput(..., { method:
-// "functionCalling" })` binds a single tool and sets a forced `tool_choice`.
-// This is deliberate: some models (e.g. gpt-5.4) occasionally emit the JSON
-// object twice in a row with `response_format=json_schema` during streaming,
-// which breaks the parser with "Unexpected non-whitespace character after JSON".
-// Function calling avoids that because the payload is returned in a dedicated
-// tool_call argument instead of being concatenated into the assistant text.
+// We bind a single `extract` tool that carries the routing decision instead of
+// using `response_format=json_schema`. This is deliberate: some models (e.g.
+// gpt-5.4) occasionally emit the JSON object twice in a row with
+// `response_format=json_schema` during streaming, which breaks the parser with
+// "Unexpected non-whitespace character after JSON". Function calling avoids that
+// because the payload is returned in a dedicated tool_call argument instead of
+// being concatenated into the assistant text.
 //
-// Some thinking models (DeepSeek, Qwen) reject a forced `tool_choice` while
-// thinking mode is on (`Thinking mode does not support this tool_choice`). For
-// those we bind the same single tool but with `tool_choice: "auto"`, which they
-// accept, and parse the tool call exactly like the function-calling path does.
+// The tool is normally forced via `tool_choice`. Some thinking models (DeepSeek,
+// Qwen) reject a forced `tool_choice` while thinking mode is on (`Thinking mode
+// does not support this tool_choice`), so for those we request `tool_choice:
+// "auto"`, which they accept. With `auto` the model may answer in plain text
+// instead of calling the tool once it considers the query resolved, so the
+// routing decision is recovered from either the tool call or the text by
+// `recoverSupervisorRouting`.
 const buildSupervisorRunnable = <T extends z.ZodTypeAny>(
   model: ChatOpenAI,
   schema: T,
-): Runnable<BaseLanguageModelInput, z.infer<T>> => {
-  if (!requiresAutoToolChoice(model.model)) {
-    return model.withStructuredOutput(schema, { method: "functionCalling" });
-  }
-
+  destinations: readonly string[],
+  subAgents: readonly string[],
+): Runnable<BaseLanguageModelInput, SupervisorRouting | undefined> => {
   const asJsonSchema = toJsonSchema(schema);
   const llm = model.bindTools(
     [
@@ -49,14 +47,11 @@ const buildSupervisorRunnable = <T extends z.ZodTypeAny>(
         },
       },
     ],
-    { tool_choice: "auto" },
+    { tool_choice: requiresAutoToolChoice(model.model) ? "auto" : SUPERVISOR_TOOL_NAME },
   );
-  const parser = new JsonOutputKeyToolsParser<z.infer<T>>({
-    returnSingle: true,
-    keyName: SUPERVISOR_TOOL_NAME,
-    zodSchema: schema,
-  });
-  return llm.pipe(parser);
+  return llm.pipe(
+    RunnableLambda.from((message: BaseMessage) => recoverSupervisorRouting(message, destinations, subAgents)),
+  );
 };
 
 export const useAgentSupervisor = () => {
@@ -88,7 +83,7 @@ export const useAgentSupervisor = () => {
       workerResponsibilities: subAgentResponsibilities.join(", "),
       members: subAgents.join(", "),
     });
-    return formattedPrompt.pipe(buildSupervisorRunnable(model, supervisorResponseSchema));
+    return formattedPrompt.pipe(buildSupervisorRunnable(model, supervisorResponseSchema, destinations, subAgents));
   };
 
   return { getAgent };

--- a/src/renderer/business/agent/supervisor-routing.test.ts
+++ b/src/renderer/business/agent/supervisor-routing.test.ts
@@ -1,0 +1,109 @@
+import { AIMessage } from "@langchain/core/messages";
+import { describe, expect, it } from "vitest";
+import {
+  END_DESTINATION,
+  recoverSupervisorRouting,
+  routingFromText,
+  routingFromToolCall,
+  SUPERVISOR_TOOL_NAME,
+} from "./supervisor-routing";
+
+const subAgents = ["agentAnalyzer", "kubernetesOperator", "generalPurposeAgent"];
+const destinations = [END_DESTINATION, ...subAgents];
+
+const toolCallMessage = (args: Record<string, unknown>) =>
+  new AIMessage({
+    content: "",
+    tool_calls: [{ name: SUPERVISOR_TOOL_NAME, args, id: "call_1", type: "tool_call" }],
+  });
+
+describe("routingFromToolCall", () => {
+  it("extracts a valid structured routing decision", () => {
+    const message = toolCallMessage({ reflection: "All done", goto: END_DESTINATION });
+    expect(routingFromToolCall(message, destinations)).toEqual({ reflection: "All done", goto: END_DESTINATION });
+  });
+
+  it("defaults reflection to an empty string when missing", () => {
+    const message = toolCallMessage({ goto: "agentAnalyzer" });
+    expect(routingFromToolCall(message, destinations)).toEqual({ reflection: "", goto: "agentAnalyzer" });
+  });
+
+  it("returns undefined when goto is not a known destination", () => {
+    const message = toolCallMessage({ reflection: "x", goto: "someAgent" });
+    expect(routingFromToolCall(message, destinations)).toBeUndefined();
+  });
+
+  it("returns undefined when there is no extract tool call", () => {
+    expect(routingFromToolCall(new AIMessage({ content: "no tools here" }), destinations)).toBeUndefined();
+  });
+});
+
+describe("routingFromText", () => {
+  it("routes to __end__ when the model answered in plain text with the sentinel", () => {
+    const message = new AIMessage({ content: "The user's query has been resolved. __end__" });
+    expect(routingFromText(message, subAgents)).toEqual({
+      reflection: "The user's query has been resolved. __end__",
+      goto: END_DESTINATION,
+    });
+  });
+
+  it("routes to a sub-agent named in the text", () => {
+    const message = new AIMessage({ content: "We still need cluster state, route to agentAnalyzer next." });
+    expect(routingFromText(message, subAgents)).toEqual({
+      reflection: "We still need cluster state, route to agentAnalyzer next.",
+      goto: "agentAnalyzer",
+    });
+  });
+
+  it("defaults to __end__ when the model produced a final answer with no destination", () => {
+    const message = new AIMessage({ content: "The deployment has 3 healthy replicas." });
+    expect(routingFromText(message, subAgents)).toEqual({
+      reflection: "The deployment has 3 healthy replicas.",
+      goto: END_DESTINATION,
+    });
+  });
+
+  it("returns undefined for leaked tool-call markup so the caller can surface the parser error", () => {
+    const message = new AIMessage({
+      content: '<｜｜DSML｜｜invoke name="listKubernetesResources"></｜｜DSML｜｜invoke>',
+    });
+    expect(routingFromText(message, subAgents)).toBeUndefined();
+  });
+
+  it("returns undefined for empty text", () => {
+    expect(routingFromText(new AIMessage({ content: "" }), subAgents)).toBeUndefined();
+  });
+});
+
+describe("recoverSupervisorRouting", () => {
+  it("prefers the structured tool call over the text fallback", () => {
+    const message = new AIMessage({
+      content: "agentAnalyzer should run",
+      tool_calls: [
+        {
+          name: SUPERVISOR_TOOL_NAME,
+          args: { reflection: "done", goto: END_DESTINATION },
+          id: "c1",
+          type: "tool_call",
+        },
+      ],
+    });
+    expect(recoverSupervisorRouting(message, destinations, subAgents)).toEqual({
+      reflection: "done",
+      goto: END_DESTINATION,
+    });
+  });
+
+  it("falls back to the text routing when no usable tool call is present", () => {
+    const message = new AIMessage({ content: "Everything looks healthy, __end__" });
+    expect(recoverSupervisorRouting(message, destinations, subAgents)).toEqual({
+      reflection: "Everything looks healthy, __end__",
+      goto: END_DESTINATION,
+    });
+  });
+
+  it("returns undefined when markup leaked and no tool call was parsed", () => {
+    const message = new AIMessage({ content: "<｜tool▁calls▁begin｜>" });
+    expect(recoverSupervisorRouting(message, destinations, subAgents)).toBeUndefined();
+  });
+});

--- a/src/renderer/business/agent/supervisor-routing.ts
+++ b/src/renderer/business/agent/supervisor-routing.ts
@@ -1,0 +1,97 @@
+// Recovers the supervisor's routing decision ({ reflection, goto }) from its
+// raw response message.
+//
+// The supervisor binds a single `extract` tool that carries the structured
+// routing decision. For thinking models (DeepSeek/Qwen) the tool is bound with
+// `tool_choice: "auto"` because they reject a forced `tool_choice` while
+// thinking. With `auto`, the model is free to skip the tool call: once it
+// considers the user's query resolved it answers in plain text (typically
+// ending with `__end__`) instead of calling `extract`. The structured parser
+// then yields nothing and the run crashes with "the supervisor did not return a
+// structured routing decision", even though the model clearly said `__end__`.
+//
+// To stay robust we first read the structured tool call, then fall back to the
+// assistant text. Leaked tool-call markup is deliberately NOT recovered here -
+// it means the endpoint lacks a server-side tool-call parser, which the caller
+// surfaces with an actionable message instead of silently ending the run.
+
+import { isAIMessage } from "@langchain/core/messages";
+import { containsLeakedToolCallMarkup, messageContentToText } from "./leaked-tool-calls";
+
+import type { BaseMessage } from "@langchain/core/messages";
+
+// Name of the single structured-output tool bound for the supervisor. Matches
+// the default `withStructuredOutput` function-calling tool name so the parser
+// behaves identically across the forced and "auto" tool_choice paths.
+export const SUPERVISOR_TOOL_NAME = "extract";
+
+// The end-of-run sentinel used by both the supervisor schema and LangGraph.
+export const END_DESTINATION = "__end__";
+
+export interface SupervisorRouting {
+  reflection: string;
+  goto: string;
+}
+
+const escapeRegExp = (value: string): string => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+// Find the sub-agent name mentioned earliest in the text as a standalone token.
+// Sub-agent names are camelCase identifiers, so word boundaries avoid matching
+// substrings inside unrelated words. Returns undefined when none is mentioned.
+const findMentionedSubAgent = (text: string, subAgents: readonly string[]): string | undefined => {
+  let best: string | undefined;
+  let bestIndex = Number.POSITIVE_INFINITY;
+  for (const subAgent of subAgents) {
+    const match = new RegExp(`\\b${escapeRegExp(subAgent)}\\b`).exec(text);
+    if (match && match.index < bestIndex) {
+      bestIndex = match.index;
+      best = subAgent;
+    }
+  }
+  return best;
+};
+
+// Extract routing from the structured `extract` tool call, when present and the
+// `goto` is one of the known destinations. Returns undefined otherwise.
+export const routingFromToolCall = (
+  message: BaseMessage,
+  destinations: readonly string[],
+): SupervisorRouting | undefined => {
+  if (!isAIMessage(message)) {
+    return undefined;
+  }
+  const toolCall = message.tool_calls?.find((call) => call.name === SUPERVISOR_TOOL_NAME);
+  const goto = toolCall?.args?.goto;
+  if (typeof goto !== "string" || !destinations.includes(goto)) {
+    return undefined;
+  }
+  const reflection = typeof toolCall?.args?.reflection === "string" ? toolCall.args.reflection : "";
+  return { reflection, goto };
+};
+
+// Recover routing from a supervisor message that lacked a usable tool call by
+// inspecting its text. A model that answered in prose has finished, so the
+// default is `__end__`; an explicit sentinel or a named sub-agent overrides it.
+// Returns undefined for empty text or leaked tool-call markup (the caller turns
+// that into the actionable "missing server-side tool-call parser" error).
+export const routingFromText = (message: BaseMessage, subAgents: readonly string[]): SupervisorRouting | undefined => {
+  if (containsLeakedToolCallMarkup(message.content)) {
+    return undefined;
+  }
+  const text = messageContentToText(message.content).trim();
+  if (!text) {
+    return undefined;
+  }
+  if (text.includes(END_DESTINATION)) {
+    return { reflection: text, goto: END_DESTINATION };
+  }
+  return { reflection: text, goto: findMentionedSubAgent(text, subAgents) ?? END_DESTINATION };
+};
+
+// Resolve the supervisor's routing decision from its raw response message,
+// preferring the structured tool call and falling back to the assistant text.
+export const recoverSupervisorRouting = (
+  message: BaseMessage,
+  destinations: readonly string[],
+  subAgents: readonly string[],
+): SupervisorRouting | undefined => routingFromToolCall(message, destinations) ?? routingFromText(message, subAgents);


### PR DESCRIPTION
Fixes #223.

For thinking models (DeepSeek/Qwen) the supervisor binds the `extract` routing tool with `tool_choice: "auto"`, so the model may answer in plain text ending with `__end__` instead of calling the tool. The structured parser then returned `undefined` and the run crashed with "The supervisor did not return a structured routing decision".

This adds a pure `supervisor-routing.ts` helper that reads the structured tool call first and falls back to the assistant text (`__end__` for a final answer, or a named sub-agent). Leaked tool-call markup still surfaces the actionable parser-missing error.
