### PR TITLE
Add per-session cost estimate next to the token counter

### DIFF
--- a/src/main/ai-proxy-server.ts
+++ b/src/main/ai-proxy-server.ts
@@ -15,8 +15,17 @@ const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
 // whose token does not match the one generated for this launch.
 const PROXY_TOKEN_HEADER = "x-ai-proxy-token";
 
+// Header set by the renderer to fetch a public resource through the proxy
+// without attaching the managed API key. Used for the LiteLLM price list
+// (see model-pricing-provider.ts): it routes through the proxy only to avoid
+// browser CORS, so the user's credentials must never travel with it.
+const NO_AUTH_HEADER = "x-ai-proxy-no-auth";
+
 const UPSTREAM_BY_PREFIX: Record<string, string> = {
   openai: "https://api.openai.com/v1",
+  // Public LiteLLM model price + context-window list. Fetched with the no-auth
+  // header so the user's API key is never sent to GitHub.
+  litellm: "https://raw.githubusercontent.com/BerriAI/litellm/main",
 };
 
 let proxyServerStarted = false;
@@ -36,7 +45,7 @@ let proxyAuthToken: string | null = null;
 // proxy never advertises itself as open to every origin.
 const CORS_ALLOW_METHODS = "GET,POST,OPTIONS";
 const CORS_ALLOW_HEADERS =
-  "authorization,content-type,x-stainless-os,x-stainless-runtime-version,x-stainless-package-version,x-stainless-runtime,x-stainless-arch,x-stainless-retry-count,x-stainless-lang,accept,user-agent,x-upstream-base-url,x-ai-proxy-token";
+  "authorization,content-type,x-stainless-os,x-stainless-runtime-version,x-stainless-package-version,x-stainless-runtime,x-stainless-arch,x-stainless-retry-count,x-stainless-lang,accept,user-agent,x-upstream-base-url,x-ai-proxy-token,x-ai-proxy-no-auth";
 
 const hopByHopHeaders = new Set([
   "connection",
@@ -92,7 +101,7 @@ export const applyManagedAuthorization = (headers: Headers, apiKey: string | und
   return headers;
 };
 
-const createUpstreamHeaders = (request: IncomingMessage) => {
+const createUpstreamHeaders = (request: IncomingMessage, applyAuth: boolean) => {
   const headers = new Headers();
 
   for (const [key, value] of Object.entries(request.headers)) {
@@ -100,6 +109,10 @@ const createUpstreamHeaders = (request: IncomingMessage) => {
       hopByHopHeaders.has(key) ||
       key === UPSTREAM_BASE_URL_HEADER ||
       key === PROXY_TOKEN_HEADER ||
+      key === NO_AUTH_HEADER ||
+      // Drop the caller's Authorization on no-auth routes so neither the managed
+      // key nor the renderer's placeholder is forwarded to the public resource.
+      (!applyAuth && key === "authorization") ||
       value === undefined
     ) {
       continue;
@@ -112,7 +125,7 @@ const createUpstreamHeaders = (request: IncomingMessage) => {
     }
   }
 
-  return applyManagedAuthorization(headers, resolveApiKey());
+  return applyAuth ? applyManagedAuthorization(headers, resolveApiKey()) : headers;
 };
 
 const proxyRequest = async (request: IncomingMessage, response: ServerResponse) => {
@@ -143,9 +156,13 @@ const proxyRequest = async (request: IncomingMessage, response: ServerResponse) 
   const method = request.method ?? "GET";
   const body = method === "GET" || method === "HEAD" ? undefined : await readRequestBody(request);
 
+  // Public resources (the LiteLLM price list) are fetched without the managed
+  // API key so the user's credentials never leak to a third party.
+  const applyAuth = request.headers[NO_AUTH_HEADER] === undefined;
+
   const upstreamResponse = await fetch(upstreamUrl, {
     method,
-    headers: createUpstreamHeaders(request),
+    headers: createUpstreamHeaders(request, applyAuth),
     body,
   });
 

--- a/src/renderer/business/provider/model-pricing-provider.ts
+++ b/src/renderer/business/provider/model-pricing-provider.ts
@@ -1,0 +1,104 @@
+// Fetches model pricing through the local AI proxy and builds the map consumed
+// by the per-session cost estimate. The pure parsing/cost math lives in
+// model-pricing.ts; this module owns only the (impure) network access.
+//
+// Two sources, in order of preference per model:
+//   1. The endpoint's own `/model/info` (LiteLLM proxies expose prices there).
+//      Fetched with a short timeout so a slow/absent endpoint never blocks the
+//      UI.
+//   2. The public LiteLLM `model_prices_and_context_window.json`, routed through
+//      the proxy with the no-auth header so the user's API key is never sent to
+//      GitHub.
+
+import { DEFAULT_OPENAI_BASE_URL } from "./ai-models";
+import { buildModelPricingMap, type ModelPricingMap, parseModelInfoResponse, parsePriceMap } from "./model-pricing";
+import { PROXY_NO_AUTH_HEADER, PROXY_TOKEN_HEADER, UPSTREAM_BASE_URL_HEADER } from "./openai-fields";
+
+// Short cap on the `/model/info` probe: a missing or slow endpoint must not hold
+// up the cost display. The public price list has no explicit timeout beyond the
+// platform default.
+const MODEL_INFO_TIMEOUT_MS = 2000;
+
+export interface FetchModelPricingOptions {
+  modelNames: string[];
+  openAIBaseUrl: string;
+  proxyPort: number | null;
+  proxyToken: string | null;
+}
+
+const proxyOrigin = (proxyPort: number): string => `http://127.0.0.1:${proxyPort}`;
+
+// Resolve the JSON body of a proxied request, or null on any failure (timeout,
+// non-2xx, unparseable body). The cost display is best-effort, so every error
+// degrades to "no price" rather than surfacing to the user.
+const fetchJson = async (url: string, headers: Record<string, string>, timeoutMs?: number): Promise<unknown> => {
+  try {
+    const response = await fetch(url, {
+      headers,
+      signal: typeof timeoutMs === "number" ? AbortSignal.timeout(timeoutMs) : undefined,
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return await response.json();
+  } catch {
+    return null;
+  }
+};
+
+// Query the endpoint's own `/model/info` (LiteLLM). Returns an empty map when
+// the endpoint is the public OpenAI API (no such route), is slow, or errors.
+const fetchEndpointPricing = async (
+  origin: string,
+  openAIBaseUrl: string,
+  proxyToken: string,
+): Promise<ModelPricingMap> => {
+  // Skip the probe for the stock OpenAI endpoint, which has no `/model/info`.
+  if (!openAIBaseUrl || openAIBaseUrl === DEFAULT_OPENAI_BASE_URL) {
+    return {};
+  }
+
+  const json = await fetchJson(
+    `${origin}/openai/model/info`,
+    {
+      [UPSTREAM_BASE_URL_HEADER]: openAIBaseUrl,
+      [PROXY_TOKEN_HEADER]: proxyToken,
+    },
+    MODEL_INFO_TIMEOUT_MS,
+  );
+  return parseModelInfoResponse(json);
+};
+
+// Fetch the public LiteLLM price list through the proxy without credentials.
+const fetchPublicPricing = async (origin: string, proxyToken: string): Promise<ModelPricingMap> => {
+  const json = await fetchJson(`${origin}/litellm/model_prices_and_context_window.json`, {
+    [PROXY_TOKEN_HEADER]: proxyToken,
+    [PROXY_NO_AUTH_HEADER]: "1",
+  });
+  return parsePriceMap(json);
+};
+
+/**
+ * Build the pricing map for the configured models. Returns an empty map when the
+ * proxy is not ready yet so callers can simply hide the cost until it is.
+ */
+export const fetchModelPricing = async ({
+  modelNames,
+  openAIBaseUrl,
+  proxyPort,
+  proxyToken,
+}: FetchModelPricingOptions): Promise<ModelPricingMap> => {
+  if (proxyPort === null || !proxyToken || modelNames.length === 0) {
+    return {};
+  }
+
+  const origin = proxyOrigin(proxyPort);
+  const primary = await fetchEndpointPricing(origin, openAIBaseUrl, proxyToken);
+
+  // Only fetch the (large) public list when a configured model is still
+  // unpriced after the endpoint probe.
+  const needsFallback = modelNames.some((name) => !primary[name]);
+  const fallback = needsFallback ? await fetchPublicPricing(origin, proxyToken) : {};
+
+  return buildModelPricingMap(modelNames, primary, fallback);
+};

--- a/src/renderer/business/provider/model-pricing.test.ts
+++ b/src/renderer/business/provider/model-pricing.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildModelPricingMap,
+  computeSessionCost,
+  formatCost,
+  parseModelInfo,
+  parseModelInfoResponse,
+  parsePriceMap,
+} from "./model-pricing";
+
+describe("parseModelInfo", () => {
+  it("reads costs and limits from a LiteLLM model-info record", () => {
+    expect(
+      parseModelInfo({
+        input_cost_per_token: 2.5e-6,
+        output_cost_per_token: 1e-5,
+        cache_read_input_token_cost: 1.25e-6,
+        max_input_tokens: 128000,
+        max_output_tokens: 16384,
+      }),
+    ).toEqual({
+      inputCostPerToken: 2.5e-6,
+      outputCostPerToken: 1e-5,
+      cachedInputCostPerToken: 1.25e-6,
+      maxInputTokens: 128000,
+      maxOutputTokens: 16384,
+    });
+  });
+
+  it("defaults a missing input or output price to 0 but keeps the other", () => {
+    expect(parseModelInfo({ output_cost_per_token: 1e-5 })).toMatchObject({
+      inputCostPerToken: 0,
+      outputCostPerToken: 1e-5,
+    });
+  });
+
+  it("returns null when neither input nor output price is present", () => {
+    expect(parseModelInfo({ max_input_tokens: 1000 })).toBeNull();
+    expect(parseModelInfo({})).toBeNull();
+    expect(parseModelInfo(null)).toBeNull();
+    expect(parseModelInfo("nope")).toBeNull();
+  });
+
+  it("ignores invalid (negative / non-finite) numbers", () => {
+    expect(parseModelInfo({ input_cost_per_token: -1, output_cost_per_token: 1e-5, max_input_tokens: 0 })).toEqual({
+      inputCostPerToken: 0,
+      outputCostPerToken: 1e-5,
+      cachedInputCostPerToken: undefined,
+      maxInputTokens: undefined,
+      maxOutputTokens: undefined,
+    });
+  });
+});
+
+describe("parsePriceMap", () => {
+  it("keys entries by model name and skips sample_spec and price-less entries", () => {
+    const map = parsePriceMap({
+      sample_spec: { input_cost_per_token: 1, output_cost_per_token: 1 },
+      "gpt-4o": { input_cost_per_token: 2.5e-6, output_cost_per_token: 1e-5 },
+      "embed-only": { max_input_tokens: 1000 },
+    });
+    expect(Object.keys(map)).toEqual(["gpt-4o"]);
+    expect(map["gpt-4o"].inputCostPerToken).toBe(2.5e-6);
+  });
+
+  it("returns an empty map for non-objects", () => {
+    expect(parsePriceMap(null)).toEqual({});
+    expect(parsePriceMap("nope")).toEqual({});
+  });
+});
+
+describe("parseModelInfoResponse", () => {
+  it("reads the LiteLLM /model/info data array keyed by model_name", () => {
+    const map = parseModelInfoResponse({
+      data: [
+        { model_name: "gpt-4o", model_info: { input_cost_per_token: 2.5e-6, output_cost_per_token: 1e-5 } },
+        { model_name: "no-price", model_info: { max_input_tokens: 1000 } },
+        { model_info: { input_cost_per_token: 1, output_cost_per_token: 1 } },
+      ],
+    });
+    expect(Object.keys(map)).toEqual(["gpt-4o"]);
+  });
+
+  it("returns an empty map when data is missing or not an array", () => {
+    expect(parseModelInfoResponse({})).toEqual({});
+    expect(parseModelInfoResponse({ data: "nope" })).toEqual({});
+    expect(parseModelInfoResponse(null)).toEqual({});
+  });
+});
+
+describe("buildModelPricingMap", () => {
+  const primary = { "gpt-4o": { inputCostPerToken: 1, outputCostPerToken: 2 } };
+  const fallback = {
+    "gpt-4o": { inputCostPerToken: 9, outputCostPerToken: 9 },
+    "gpt-3.5": { inputCostPerToken: 0.5, outputCostPerToken: 1 },
+  };
+
+  it("prefers the primary source over the fallback per model", () => {
+    const map = buildModelPricingMap(["gpt-4o", "gpt-3.5"], primary, fallback);
+    expect(map["gpt-4o"].inputCostPerToken).toBe(1);
+    expect(map["gpt-3.5"].inputCostPerToken).toBe(0.5);
+  });
+
+  it("omits models with no price in either source", () => {
+    const map = buildModelPricingMap(["gpt-4o", "unknown-model"], primary, fallback);
+    expect(Object.keys(map)).toEqual(["gpt-4o"]);
+  });
+});
+
+describe("computeSessionCost", () => {
+  it("bills cached input at the discounted price and excludes it from full input", () => {
+    const cost = computeSessionCost(
+      { input: 1000, cached: 400, output: 200 },
+      { inputCostPerToken: 1e-3, cachedInputCostPerToken: 1e-4, outputCostPerToken: 2e-3 },
+    );
+    // 600 * 1e-3 + 400 * 1e-4 + 200 * 2e-3 = 0.6 + 0.04 + 0.4 = 1.04
+    expect(cost).toBeCloseTo(1.04, 10);
+  });
+
+  it("falls back to the full input price for cached tokens when no cache price is set", () => {
+    const cost = computeSessionCost(
+      { input: 1000, cached: 400, output: 0 },
+      { inputCostPerToken: 1e-3, outputCostPerToken: 2e-3 },
+    );
+    // 600 * 1e-3 + 400 * 1e-3 = 1.0
+    expect(cost).toBeCloseTo(1.0, 10);
+  });
+
+  it("clamps cached tokens to the input total", () => {
+    const cost = computeSessionCost(
+      { input: 100, cached: 500, output: 0 },
+      { inputCostPerToken: 1e-3, cachedInputCostPerToken: 1e-4, outputCostPerToken: 0 },
+    );
+    // cached clamped to 100: 0 * 1e-3 + 100 * 1e-4 = 0.01
+    expect(cost).toBeCloseTo(0.01, 10);
+  });
+
+  it("is zero for empty usage", () => {
+    expect(
+      computeSessionCost({ input: 0, cached: 0, output: 0 }, { inputCostPerToken: 1, outputCostPerToken: 1 }),
+    ).toBe(0);
+  });
+});
+
+describe("formatCost", () => {
+  it("uses two decimals for amounts of a cent or more", () => {
+    expect(formatCost(1.2)).toBe("$1.20");
+    expect(formatCost(0.01)).toBe("$0.01");
+    expect(formatCost(0)).toBe("$0.00");
+  });
+
+  it("uses four decimals for sub-cent non-zero amounts", () => {
+    expect(formatCost(0.0042)).toBe("$0.0042");
+  });
+});

--- a/src/renderer/business/provider/model-pricing.ts
+++ b/src/renderer/business/provider/model-pricing.ts
@@ -1,0 +1,170 @@
+// Pure helpers for the per-session cost estimate shown next to the token
+// counter. Kept free of host/MobX/fetch dependencies so the parsing and cost
+// math can be unit-tested in isolation (see model-pricing.test.ts). The impure
+// fetching (through the local AI proxy) lives in model-pricing-provider.ts.
+
+import type { TokenUsage } from "../service/token-usage";
+
+// Per-token costs (in USD) and context limits for a single model. All costs are
+// per single token, matching the LiteLLM data shape. `cachedInputCostPerToken`
+// is the discounted price charged for prompt-cache reads; when a model does not
+// advertise one, callers fall back to the full input price.
+export interface ModelPricing {
+  inputCostPerToken: number;
+  cachedInputCostPerToken?: number;
+  outputCostPerToken: number;
+  maxInputTokens?: number;
+  maxOutputTokens?: number;
+}
+
+// Map of model name => pricing. Only models we found prices for are present.
+export type ModelPricingMap = Record<string, ModelPricing>;
+
+const toCost = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+
+const toLimit = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) && value > 0 ? value : undefined;
+
+// The fields we read from a single LiteLLM model entry (both the
+// `model_prices_and_context_window.json` values and a `/model/info` entry's
+// `model_info` use the same field names). Everything else is ignored.
+interface LiteLLMModelInfoLike {
+  input_cost_per_token?: unknown;
+  output_cost_per_token?: unknown;
+  cache_read_input_token_cost?: unknown;
+  max_input_tokens?: unknown;
+  max_output_tokens?: unknown;
+}
+
+/**
+ * Turn one raw LiteLLM model-info record into a {@link ModelPricing}. Returns
+ * `null` when neither an input nor an output price is present, so callers can
+ * skip non-chat or price-less entries (e.g. the file's `sample_spec` key).
+ */
+export const parseModelInfo = (info: unknown): ModelPricing | null => {
+  if (!info || typeof info !== "object") {
+    return null;
+  }
+
+  const record = info as LiteLLMModelInfoLike;
+  const inputCostPerToken = toCost(record.input_cost_per_token);
+  const outputCostPerToken = toCost(record.output_cost_per_token);
+
+  if (inputCostPerToken === undefined && outputCostPerToken === undefined) {
+    return null;
+  }
+
+  return {
+    inputCostPerToken: inputCostPerToken ?? 0,
+    outputCostPerToken: outputCostPerToken ?? 0,
+    cachedInputCostPerToken: toCost(record.cache_read_input_token_cost),
+    maxInputTokens: toLimit(record.max_input_tokens),
+    maxOutputTokens: toLimit(record.max_output_tokens),
+  };
+};
+
+/**
+ * Parse the LiteLLM `model_prices_and_context_window.json` document (an object
+ * keyed by model name) into a {@link ModelPricingMap}. The synthetic
+ * `sample_spec` entry and any price-less entries are skipped.
+ */
+export const parsePriceMap = (json: unknown): ModelPricingMap => {
+  if (!json || typeof json !== "object") {
+    return {};
+  }
+
+  const map: ModelPricingMap = {};
+  for (const [name, info] of Object.entries(json as Record<string, unknown>)) {
+    if (name === "sample_spec") {
+      continue;
+    }
+    const pricing = parseModelInfo(info);
+    if (pricing) {
+      map[name] = pricing;
+    }
+  }
+  return map;
+};
+
+// The `/model/info` response shape returned by a LiteLLM proxy: a `data` array
+// of `{ model_name, model_info }` entries.
+interface ModelInfoResponseLike {
+  data?: Array<{ model_name?: unknown; model_info?: unknown }>;
+}
+
+/**
+ * Parse a LiteLLM `/model/info` response into a {@link ModelPricingMap}, keyed
+ * by each entry's `model_name`.
+ */
+export const parseModelInfoResponse = (json: unknown): ModelPricingMap => {
+  if (!json || typeof json !== "object") {
+    return {};
+  }
+
+  const { data } = json as ModelInfoResponseLike;
+  if (!Array.isArray(data)) {
+    return {};
+  }
+
+  const map: ModelPricingMap = {};
+  for (const entry of data) {
+    const name = entry?.model_name;
+    if (typeof name !== "string" || !name) {
+      continue;
+    }
+    const pricing = parseModelInfo(entry?.model_info);
+    if (pricing) {
+      map[name] = pricing;
+    }
+  }
+  return map;
+};
+
+/**
+ * Build the pricing map for exactly the configured model names, preferring the
+ * primary source (the endpoint's `/model/info`) over the fallback (the public
+ * LiteLLM price list) for each name. Only names we found a price for end up in
+ * the result, so an absent model simply has no cost shown.
+ */
+export const buildModelPricingMap = (
+  modelNames: string[],
+  primary: ModelPricingMap,
+  fallback: ModelPricingMap,
+): ModelPricingMap => {
+  const map: ModelPricingMap = {};
+  for (const name of modelNames) {
+    const pricing = primary[name] ?? fallback[name];
+    if (pricing) {
+      map[name] = pricing;
+    }
+  }
+  return map;
+};
+
+/**
+ * Compute the session cost (USD) for a model's pricing and the running token
+ * totals. Cached input tokens are billed at the discounted cache-read price and
+ * are excluded from the full-priced input tokens, matching:
+ *   input_price * (input - cached) + cached_input_price * cached + output_price * output
+ * When the model advertises no cache-read price, cached tokens fall back to the
+ * full input price.
+ */
+export const computeSessionCost = (usage: TokenUsage, pricing: ModelPricing): number => {
+  const cached = Math.min(usage.cached, usage.input);
+  const uncachedInput = Math.max(0, usage.input - cached);
+  const cachedPrice = pricing.cachedInputCostPerToken ?? pricing.inputCostPerToken;
+
+  return uncachedInput * pricing.inputCostPerToken + cached * cachedPrice + usage.output * pricing.outputCostPerToken;
+};
+
+/**
+ * Format a USD cost as `$x.xx`. Sub-cent amounts use more decimals so a small
+ * but non-zero cost is not rendered as a misleading `$0.00`.
+ */
+export const formatCost = (cost: number): string => {
+  if (cost > 0 && cost < 0.01) {
+    return `$${cost.toFixed(4)}`;
+  }
+  return `$${cost.toFixed(2)}`;
+};

--- a/src/renderer/business/provider/openai-fields.ts
+++ b/src/renderer/business/provider/openai-fields.ts
@@ -15,6 +15,10 @@ export const UPSTREAM_BASE_URL_HEADER = "x-upstream-base-url";
 // request.
 export const PROXY_TOKEN_HEADER = "x-ai-proxy-token";
 
+// Header that tells the proxy to fetch a public resource without attaching the
+// managed API key (see model-pricing-provider.ts).
+export const PROXY_NO_AUTH_HEADER = "x-ai-proxy-no-auth";
+
 export interface OpenAIChatFieldsOptions {
   // Model id sent to the OpenAI API (e.g. "gpt-5.5").
   modelName: string;

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -2,6 +2,7 @@ import { Renderer } from "@freelensapp/extensions";
 import { Eraser, SendHorizonal, ShieldOff } from "lucide-react";
 import * as MobxReact from "mobx-react";
 import * as React from "react";
+import { formatCost } from "../../business/provider/model-pricing";
 import { formatTokenUsage } from "../../business/service/token-usage";
 import { useApplicationStatusStore } from "../../context/application-context";
 import { AvailableTools } from "../available-tools/available-tools";
@@ -112,9 +113,10 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
               {textInputHook.agentConfigured && (
                 <span
                   className="text-input-token-counter"
-                  title="Tokens used this session (input, cached input, output). Resets when the chat is cleared."
+                  title="Tokens used this session (input, cached input, output), with estimated cost when known. Resets when the chat is cleared."
                 >
                   {formatTokenUsage(applicationStatusStore.tokenUsage)}
+                  {applicationStatusStore.sessionCost > 0 ? ` = ${formatCost(applicationStatusStore.sessionCost)}` : ""}
                 </span>
               )}
               {textInputHook.agentConfigured ? (

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -16,7 +16,9 @@ import { MPCAgent, useMcpAgent } from "../business/agent/mcp-agent";
 import { getActiveClusterId } from "../business/cluster/active-cluster";
 import { getTextMessage } from "../business/objects/message-object-provider";
 import { MessageType } from "../business/objects/message-type";
-import { AIProviders } from "../business/provider/ai-models";
+import { AIProviders, DEFAULT_OPENAI_BASE_URL } from "../business/provider/ai-models";
+import { computeSessionCost, type ModelPricingMap } from "../business/provider/model-pricing";
+import { fetchModelPricing } from "../business/provider/model-pricing-provider";
 import { emptyTokenUsage, addTokenUsage as sumTokenUsage, type TokenUsage } from "../business/service/token-usage";
 import { IS_CONVERSATION_INTERRUPTED_KEY, IS_LOADING_KEY } from "./chat-session-storage";
 
@@ -34,6 +36,9 @@ export interface AppContextType {
   isConversationInterrupted: boolean;
   chatMessages: MessageObject[] | null;
   tokenUsage: TokenUsage;
+  // Estimated USD cost of this session for the selected model, or 0 when no
+  // price is known. Resets with the token counter when the chat is cleared.
+  sessionCost: number;
   freeLensAgent: FreeLensAgent | null;
   mcpAgent: MPCAgent | null;
   setSelectedModel: (selectedModel: string) => void;
@@ -73,6 +78,9 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const [isConversationInterrupted, _setConversationInterrupted] = useState(false);
   const [chatMessages, _setChatMessages] = useState<MessageObject[] | null>(null);
   const [tokenUsage, _setTokenUsage] = useState<TokenUsage>(emptyTokenUsage());
+  // Model name => pricing, fetched on start and whenever the model list or
+  // endpoint changes. Used to estimate the per-session cost shown by the UI.
+  const [modelPricing, _setModelPricing] = useState<ModelPricingMap>({});
   const [freeLensAgent, _setFreeLensAgent] = useState<FreeLensAgent | null>(agentsStore.freeLensAgent);
   const [mcpAgent, _setMcpAgent] = useState<MPCAgent | null>(agentsStore.mcpAgent);
 
@@ -90,6 +98,29 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     _setTokenUsage(chatSessionStore.getTokenUsage(clusterId));
     _initFreeLensAgent();
   }, []);
+
+  // Fetch model pricing on start and whenever the model list, endpoint, or proxy
+  // changes. Best-effort: failures leave the map empty and the cost is hidden.
+  const modelNames = preferencesStore.models.map((model) => model.name);
+  const modelNamesKey = modelNames.join(",");
+  useEffect(() => {
+    let cancelled = false;
+    fetchModelPricing({
+      modelNames,
+      openAIBaseUrl: preferencesStore.openAIBaseUrl || DEFAULT_OPENAI_BASE_URL,
+      proxyPort: preferencesStore.aiProxyPort,
+      proxyToken: preferencesStore.aiProxyToken,
+    })
+      .then((pricing) => {
+        if (!cancelled) {
+          _setModelPricing(pricing);
+        }
+      })
+      .catch((error) => log.debug("Failed to fetch model pricing: ", error));
+    return () => {
+      cancelled = true;
+    };
+  }, [modelNamesKey, preferencesStore.openAIBaseUrl, preferencesStore.aiProxyPort, preferencesStore.aiProxyToken]);
 
   // Recreate MCP server when MCP configuration change
   useEffect(() => {
@@ -366,6 +397,11 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     preferencesStore.bypassApprovals = bypassApprovals;
   };
 
+  // Estimate the session cost for the currently selected model. Zero when the
+  // model has no known price, so the UI can hide it.
+  const selectedPricing = modelPricing[preferencesStore.selectedModel];
+  const sessionCost = selectedPricing ? computeSessionCost(tokenUsage, selectedPricing) : 0;
+
   const changeInterruptStatus = (id: string, status: boolean) => {
     _setChatMessages((prevMessages) => {
       const updated = prevMessages!.map((msg) => (msg.messageId === id ? { ...msg, approved: status } : msg));
@@ -388,6 +424,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         isConversationInterrupted,
         chatMessages,
         tokenUsage,
+        sessionCost,
         mcpAgent,
         freeLensAgent,
         setSelectedModel,


### PR DESCRIPTION
Implements basic cost control (#225): fetches model pricing via the local AI proxy (LiteLLM /model/info with a 2s timeout, then the public LiteLLM price list as fallback with credentials stripped), estimates the session cost for the selected model from tracked input/cached/output tokens, and shows it as `= $x.xx` next to the token counter when non-zero. Cost zeroes with the token counter on clear.
