### PR TITLE
Compact the session before reaching the input token limit

### DIFF
--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -258,8 +258,11 @@ const useChatService = () => {
           continue;
         }
 
-        // Token usage reported for the run is summed into the per-session
-        // counter shown next to the model list.
+        // Token usage deltas are summed into the per-session counter (and the
+        // cost derived from it) shown next to the model list. Emitted live per
+        // completed LLM call, so the counter and cost move during a turn; a
+        // negative delta on a transient-error retry rolls back the failed
+        // attempt's contribution.
         if (isTokenUsageChunk(chunk)) {
           applicationStatusStore.addTokenUsage(chunk.tokenUsage);
           continue;

--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -6,6 +6,7 @@ import {
 } from "../../renderer/business/objects/message-object-provider";
 import { MessageType } from "../../renderer/business/objects/message-type";
 import { DEFAULT_OPENAI_BASE_URL } from "../../renderer/business/provider/ai-models";
+import { approximateTokenCount } from "../../renderer/business/provider/token-estimate";
 import {
   AgentService,
   isReasoningChunk,
@@ -13,6 +14,7 @@ import {
   useAgentService,
 } from "../../renderer/business/service/agent-service";
 import { AiAnalysisService, useAiAnalysisService } from "../../renderer/business/service/ai-analysis-service";
+import { estimateNextPromptTokens, shouldCompactSession } from "../../renderer/business/service/session-compaction";
 import { ActionToApprove } from "../../renderer/components/chat";
 import { useApplicationStatusStore } from "../../renderer/context/application-context";
 import { PreferencesStore } from "../store";
@@ -113,9 +115,13 @@ const useChatService = () => {
           });
         } else {
           _sendMessage(message);
-          runAgent(_buildAgentInput(message.text), { kind: "message", text: message.text }).finally(() =>
-            applicationStatusStore.setLoading(false),
-          );
+          // Compact the session first when the next prompt would approach the
+          // model's input token limit, then send (seeding the summary into the
+          // prompt so the conversation context is not lost).
+          (async () => {
+            const summary = await _maybeCompactBeforeSend(message.text);
+            await runAgent(_buildAgentInput(message.text, summary), { kind: "message", text: message.text });
+          })().finally(() => applicationStatusStore.setLoading(false));
         }
       } else {
         log.error("You cannot call sendMessageToAgent with 'sent: false'");
@@ -125,11 +131,31 @@ const useChatService = () => {
     }
   };
 
-  const _buildAgentInput = (text: string) => ({
+  const _buildAgentInput = (text: string, summary: string | null = null) => ({
     modelName: applicationStatusStore.selectedModel,
     modelApiKey: applicationStatusStore.apiKey,
-    messages: [{ role: "user", content: text }],
+    // When the session was just compacted, prepend the summary so the agent keeps
+    // the earlier context even though the model-side history was wiped.
+    messages: summary
+      ? [
+          { role: "user", content: `Summary of the earlier (compacted) conversation:\n${summary}` },
+          { role: "user", content: text },
+        ]
+      : [{ role: "user", content: text }],
   });
+
+  // Estimate the next prompt's input tokens from the previous response and the
+  // new message, and compact the session first when that reaches the threshold
+  // (90%) of the selected model's max input tokens. Returns the summary to seed
+  // into the next prompt, or null when no compaction was needed or possible.
+  const _maybeCompactBeforeSend = async (text: string): Promise<string | null> => {
+    const estimate = estimateNextPromptTokens(applicationStatusStore.lastInputTokens, approximateTokenCount(text));
+    if (!shouldCompactSession(estimate, applicationStatusStore.getMaxInputTokens())) {
+      return null;
+    }
+    log.debug("Next prompt approaches the input token limit, compacting session first");
+    return applicationStatusStore.compactSession();
+  };
 
   // Re-run the query behind an error message, then drop that message so its
   // "Retry" button disappears from the transcript. The original user prompt is
@@ -235,6 +261,9 @@ const useChatService = () => {
         // counter shown next to the model list.
         if (isTokenUsageChunk(chunk)) {
           applicationStatusStore.addTokenUsage(chunk.tokenUsage);
+          // Record the run's peak prompt size so the next send can decide whether
+          // to compact before reaching the model's input token limit.
+          applicationStatusStore.setLastInputTokens(chunk.peakInputTokens);
           continue;
         }
 

--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -9,6 +9,7 @@ import { DEFAULT_OPENAI_BASE_URL } from "../../renderer/business/provider/ai-mod
 import { approximateTokenCount } from "../../renderer/business/provider/token-estimate";
 import {
   AgentService,
+  isContextSizeChunk,
   isReasoningChunk,
   isTokenUsageChunk,
   useAgentService,
@@ -257,13 +258,20 @@ const useChatService = () => {
           continue;
         }
 
-        // Token usage reported for a model turn is summed into the per-session
+        // Token usage reported for the run is summed into the per-session
         // counter shown next to the model list.
         if (isTokenUsageChunk(chunk)) {
           applicationStatusStore.addTokenUsage(chunk.tokenUsage);
-          // Record the run's peak prompt size so the next send can decide whether
-          // to compact before reaching the model's input token limit.
-          applicationStatusStore.setLastInputTokens(chunk.peakInputTokens);
+          continue;
+        }
+
+        // Persisted-context size: record what the next prompt re-sends so the
+        // next send can decide whether to compact before reaching the model's
+        // input token limit, and update the capacity indicator live. The peak is
+        // kept only for the indicator tooltip.
+        if (isContextSizeChunk(chunk)) {
+          applicationStatusStore.setLastInputTokens(chunk.contextTokens);
+          applicationStatusStore.setLastPeakInputTokens(chunk.peakInputTokens);
           continue;
         }
 

--- a/src/common/store/chat-session-store.ts
+++ b/src/common/store/chat-session-store.ts
@@ -12,6 +12,10 @@ export interface ChatSession {
   // Running token totals for this session, summed across every model turn.
   // Reset when the session is cleared.
   tokenUsage: TokenUsage;
+  // Input tokens of the previous response's largest model turn - the naive proxy
+  // for the current context size, used to decide when to compact before the next
+  // prompt. Reset when the session is cleared or compacted.
+  lastInputTokens: number;
 }
 
 export interface ChatSessionModel {
@@ -22,7 +26,12 @@ export interface ChatSessionModel {
   sessions: Record<string, ChatSession>;
 }
 
-const emptySession = (): ChatSession => ({ messages: [], conversationId: "", tokenUsage: emptyTokenUsage() });
+const emptySession = (): ChatSession => ({
+  messages: [],
+  conversationId: "",
+  tokenUsage: emptyTokenUsage(),
+  lastInputTokens: 0,
+});
 
 /**
  * Durable, host-managed persistence for the rendered chat sessions (the
@@ -90,9 +99,18 @@ export class ChatSessionStore extends Common.Store.ExtensionStore<ChatSessionMod
     this.patch(clusterId, { tokenUsage });
   }
 
+  getLastInputTokens(clusterId: string): number {
+    return this.session(clusterId).lastInputTokens ?? 0;
+  }
+
+  setLastInputTokens(clusterId: string, lastInputTokens: number): void {
+    this.patch(clusterId, { lastInputTokens });
+  }
+
   clear(clusterId: string): void {
-    // Clearing the session also zeroes the token counter.
-    this.patch(clusterId, { messages: [], tokenUsage: emptyTokenUsage() });
+    // Clearing the session also zeroes the token counter and the context-size
+    // estimate that drives compaction.
+    this.patch(clusterId, { messages: [], tokenUsage: emptyTokenUsage(), lastInputTokens: 0 });
   }
 
   fromStore(model: ChatSessionModel): void {
@@ -110,6 +128,7 @@ export class ChatSessionStore extends Common.Store.ExtensionStore<ChatSessionMod
         messages: toJS(session.messages),
         conversationId: session.conversationId,
         tokenUsage: toJS(session.tokenUsage) ?? emptyTokenUsage(),
+        lastInputTokens: session.lastInputTokens ?? 0,
       };
     }
     return { sessions };

--- a/src/common/store/chat-session-store.ts
+++ b/src/common/store/chat-session-store.ts
@@ -12,9 +12,10 @@ export interface ChatSession {
   // Running token totals for this session, summed across every model turn.
   // Reset when the session is cleared.
   tokenUsage: TokenUsage;
-  // Input tokens of the previous response's largest model turn - the naive proxy
-  // for the current context size, used to decide when to compact before the next
-  // prompt. Reset when the session is cleared or compacted.
+  // Approximate size of the persisted conversation that the next prompt re-sends
+  // (parent-thread messages, ~4 chars/token) - what drives the capacity
+  // indicator and the compaction decision. Reset when the session is cleared or
+  // compacted.
   lastInputTokens: number;
 }
 

--- a/src/renderer/business/provider/token-estimate.test.ts
+++ b/src/renderer/business/provider/token-estimate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { approximateTokenCount, messageContentToText } from "./token-estimate";
+import { approximateMessagesTokenCount, approximateTokenCount, messageContentToText } from "./token-estimate";
 
 describe("messageContentToText", () => {
   it("returns a plain string unchanged", () => {
@@ -43,5 +43,25 @@ describe("approximateTokenCount", () => {
       { type: "text" as const, text: "bbbb" },
     ];
     expect(approximateTokenCount(content)).toBe(2);
+  });
+});
+
+describe("approximateMessagesTokenCount", () => {
+  it("sums the per-message estimate", () => {
+    const messages = [{ content: "12345678" }, { content: "123456789" }];
+    expect(approximateMessagesTokenCount(messages)).toBe(5);
+  });
+
+  it("returns zero for an empty list", () => {
+    expect(approximateMessagesTokenCount([])).toBe(0);
+  });
+
+  it("returns zero when the messages are undefined", () => {
+    expect(approximateMessagesTokenCount(undefined)).toBe(0);
+  });
+
+  it("counts content-block messages alongside plain-string messages", () => {
+    const messages = [{ content: "aaaa" }, { content: [{ type: "text" as const, text: "bbbb" }] }];
+    expect(approximateMessagesTokenCount(messages)).toBe(2);
   });
 });

--- a/src/renderer/business/provider/token-estimate.ts
+++ b/src/renderer/business/provider/token-estimate.ts
@@ -33,3 +33,16 @@ export const messageContentToText = (content: MessageContent): string => {
  */
 export const approximateTokenCount = (content: MessageContent): number =>
   Math.ceil(messageContentToText(content).length / 4);
+
+/**
+ * Approximate the token count of the persisted conversation carried into the
+ * next prompt by summing the per-message estimate. This is what sizes the
+ * capacity indicator and the compaction decision: it is the accumulated history
+ * the next prompt re-sends, not the transient tool-loop context of a single
+ * internal sub-agent call (which never persists). Omits the fixed system-prompt
+ * and tool-schema overhead, so it slightly under-counts the real prompt -
+ * consistent with how compaction estimates the post-compaction size, and the
+ * 90% threshold leaves headroom.
+ */
+export const approximateMessagesTokenCount = (messages: { content: MessageContent }[] | undefined): number =>
+  (messages ?? []).reduce((sum, message) => sum + approximateTokenCount(message.content), 0);

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -4,7 +4,14 @@ import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
 import { approximateMessagesTokenCount } from "../provider/token-estimate";
 import { createStreamMergeState, extractReasoningText, mergeAiChunk } from "./stream-merge";
-import { addTokenUsage, emptyTokenUsage, extractTokenUsageFromLLMResult, type TokenUsage } from "./token-usage";
+import {
+  addTokenUsage,
+  emptyTokenUsage,
+  extractTokenUsageFromLLMResult,
+  isEmptyTokenUsage,
+  subtractTokenUsage,
+  type TokenUsage,
+} from "./token-usage";
 
 import type { LLMResult } from "@langchain/core/outputs";
 
@@ -49,10 +56,13 @@ export const isReasoningChunk = (chunk: unknown): chunk is ReasoningChunk =>
   "reasoning" in chunk &&
   typeof (chunk as ReasoningChunk).reasoning === "string";
 
-// A streamed chunk carrying the token usage accumulated across the run. The chat
-// service sums these into the per-session counter shown in the UI. Emitted once
-// at end of turn so a transient-error retry can discard the failed attempt's
-// usage rather than double counting it.
+// A streamed chunk carrying token usage to add onto the per-session counter (and
+// the cost derived from it) shown in the UI. Emitted live as a *delta* per
+// completed internal LLM call, so the counter and cost move during a turn
+// instead of only at the end (a single user turn fans out into several calls).
+// On a transient-error retry the failed attempt's already-counted deltas are
+// rolled back with a negative chunk before the run re-counts them, so retries
+// never double count. The chat service simply sums every chunk.
 export interface TokenUsageChunk {
   tokenUsage: TokenUsage;
 }
@@ -124,6 +134,10 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
     console.log("Starting Agent Service run for message: ", agentInput);
 
     let config = { thread_id: conversationId };
+    // Net token usage this run has already added to the per-session counter via
+    // emitted deltas. Tracked across attempts so a transient-error retry can roll
+    // back the failed attempt's contribution before the re-run re-counts it.
+    let storeContribution = emptyTokenUsage();
     for (let attempt = 1; attempt <= MAX_GEMINI_STREAM_RETRIES + 1; attempt++) {
       let hasYieldedContent = false;
       // Tracks assistant message boundaries so distinct messages emitted within a
@@ -148,6 +162,19 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
           contextTokens: approximateMessagesTokenCount(state?.values?.messages),
           peakInputTokens: tokenUsageCollector.peakInputTokens,
         };
+      };
+
+      // The token usage counted since the last emission, as a delta to add onto
+      // the live per-session counter. `storeContribution` follows the collector's
+      // running total within an attempt, so the next delta is exactly the newly
+      // counted usage. Returns null when nothing new has been counted.
+      const nextUsageDelta = (): TokenUsageChunk | null => {
+        const delta = subtractTokenUsage(tokenUsageCollector.total, storeContribution);
+        if (isEmptyTokenUsage(delta)) {
+          return null;
+        }
+        storeContribution = tokenUsageCollector.total;
+        return { tokenUsage: delta };
       };
 
       try {
@@ -191,12 +218,20 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
             }
           }
 
-          // Refresh the live capacity reading whenever a new internal LLM call
-          // has finished, so the indicator moves during the turn rather than
-          // only at the end (a single user turn fans out into several calls).
+          // Refresh the live capacity reading and the token/cost counter whenever
+          // a new internal LLM call has finished, so both move during the turn
+          // rather than only at the end (a single user turn fans out into several
+          // calls). The usage delta is collected from the `handleLLMEnd` callback,
+          // so the supervisor and analyzer turns - suppressed from the `messages`
+          // stream by the `nostream` tag - are counted too, not just the single
+          // visible turn.
           if (tokenUsageCollector.callCount > lastEmittedCallCount) {
             lastEmittedCallCount = tokenUsageCollector.callCount;
             yield await readContextSize();
+            const usageDelta = nextUsageDelta();
+            if (usageDelta) {
+              yield usageDelta;
+            }
           }
         }
 
@@ -207,16 +242,11 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
         // prompt re-sends and what the pre-send compaction decision acts on.
         yield await readContextSize();
 
-        // Emit the token usage accumulated across every model turn in this run
-        // (collected from the `handleLLMEnd` callback above). Reading it from the
-        // callback rather than the streamed chunks is what lets the supervisor
-        // and analyzer turns - suppressed from the `messages` stream by the
-        // `nostream` tag - be counted, not just the single visible turn. Emitted
-        // once here (not per call) so a transient-error retry discards a failed
-        // attempt's usage rather than double counting it.
-        const tokenUsage = tokenUsageCollector.total;
-        if (tokenUsage.input !== 0 || tokenUsage.cached !== 0 || tokenUsage.output !== 0) {
-          yield { tokenUsage };
+        // Flush any usage from the last call(s) not yet reflected in an emitted
+        // delta (a final `handleLLMEnd` may fire after the stream's last message).
+        const finalUsageDelta = nextUsageDelta();
+        if (finalUsageDelta) {
+          yield finalUsageDelta;
         }
 
         // checks the agent state for any interrupts
@@ -241,6 +271,15 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
 
         if (!canRetry) {
           throw error;
+        }
+
+        // Roll back the usage this failed attempt already added to the live
+        // counter with a negative delta, so the re-run re-counts from scratch
+        // without double counting. The next attempt's fresh collector starts at
+        // zero, so `storeContribution` must too.
+        if (!isEmptyTokenUsage(storeContribution)) {
+          yield { tokenUsage: subtractTokenUsage(emptyTokenUsage(), storeContribution) };
+          storeContribution = emptyTokenUsage();
         }
 
         await wait(getRetryDelay(attempt));

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -13,6 +13,7 @@ import {
   type TokenUsage,
 } from "./token-usage";
 
+import type { BaseMessage } from "@langchain/core/messages";
 import type { LLMResult } from "@langchain/core/outputs";
 
 const MAX_GEMINI_STREAM_RETRIES = 3;
@@ -71,10 +72,13 @@ export const isTokenUsageChunk = (chunk: unknown): chunk is TokenUsageChunk =>
   typeof chunk === "object" && chunk !== null && "tokenUsage" in chunk;
 
 // A streamed chunk carrying the size of the persisted conversation that the next
-// prompt re-sends. `contextTokens` (parent-thread messages, ~4 chars/token)
-// drives the capacity indicator and the compaction decision; unlike a single
-// call's input it excludes the transient tool-loop context of the sub-agents,
-// which never persists. `peakInputTokens` is the largest single LLM call's input
+// prompt re-sends. `contextTokens` is the persisted parent-thread text
+// (~4 chars/token) plus the measured fixed per-request overhead (system prompt +
+// tool schemas + tool-call structure), so it tracks the real next-prompt size
+// rather than the conversation text alone. It drives the capacity indicator and
+// the compaction decision; unlike a single call's input it excludes the
+// transient tool-loop context of the sub-agents, which never persists.
+// `peakInputTokens` is the largest single LLM call's input
 // in the run - surfaced only in the indicator tooltip, never used to size the
 // gauge or trigger compaction. Emitted live, once per completed LLM call, so the
 // indicator moves during a turn instead of only at the end.
@@ -105,14 +109,38 @@ class TokenUsageCollector extends BaseCallbackHandler {
   // Incremented on every completed LLM call so the streaming loop can detect when
   // a new internal call finished and refresh the live persisted-context reading.
   callCount = 0;
+  // Largest fixed per-request overhead observed: the part of a real prompt that
+  // the ~4-chars/token text estimate cannot see - the node's system prompt, the
+  // tool-schema JSON, and tool-call arguments/structure that live outside message
+  // `content`. Measured per call as (real prompt_tokens) - (estimated tokens of
+  // the messages actually sent), so it is content-independent. Added to the
+  // persisted-context estimate so the gauge reflects the real next-prompt size
+  // rather than the conversation text alone (which under-counts badly on short
+  // sessions, where the fixed overhead dominates). Bounded by the largest tool
+  // set, so unlike the transient content spike it stays small and stable.
+  requestOverhead = 0;
+  // Estimated tokens of the messages handed to each in-flight call, keyed by the
+  // callback `runId`, so `handleLLMEnd` can pair the real input against the
+  // estimate to recover that call's fixed overhead.
+  private approxInputByRun = new Map<string, number>();
 
-  handleLLMEnd(output: LLMResult): void {
+  handleChatModelStart(_llm: unknown, messages: BaseMessage[][], runId: string): void {
+    this.approxInputByRun.set(runId, approximateMessagesTokenCount(messages.flat()));
+  }
+
+  handleLLMEnd(output: LLMResult, runId: string): void {
     const usage = extractTokenUsageFromLLMResult(output);
     if (usage) {
       this.total = addTokenUsage(this.total, usage);
       this.peakInputTokens = Math.max(this.peakInputTokens, usage.input);
       this.callCount += 1;
+
+      const approxInput = this.approxInputByRun.get(runId);
+      if (approxInput !== undefined) {
+        this.requestOverhead = Math.max(this.requestOverhead, usage.input - approxInput);
+      }
     }
+    this.approxInputByRun.delete(runId);
   }
 }
 
@@ -158,8 +186,13 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
       // turn instead of only at the end.
       const readContextSize = async (): Promise<ContextSizeChunk> => {
         const state = await agent.getState({ configurable: config });
+        // Size the gauge as the persisted conversation text plus the measured
+        // fixed per-request overhead (system prompt + tool schemas + tool-call
+        // structure). The text estimate alone omits that overhead, which on a
+        // short session dominates the real prompt - so it would otherwise read
+        // far too low (e.g. 41 tokens for a real 244-token request).
         return {
-          contextTokens: approximateMessagesTokenCount(state?.values?.messages),
+          contextTokens: approximateMessagesTokenCount(state?.values?.messages) + tokenUsageCollector.requestOverhead,
           peakInputTokens: tokenUsageCollector.peakInputTokens,
         };
       };

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -2,6 +2,7 @@ import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import { Command, Interrupt } from "@langchain/langgraph";
 import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
+import { approximateMessagesTokenCount } from "../provider/token-estimate";
 import { createStreamMergeState, extractReasoningText, mergeAiChunk } from "./stream-merge";
 import { addTokenUsage, emptyTokenUsage, extractTokenUsageFromLLMResult, type TokenUsage } from "./token-usage";
 
@@ -48,18 +49,32 @@ export const isReasoningChunk = (chunk: unknown): chunk is ReasoningChunk =>
   "reasoning" in chunk &&
   typeof (chunk as ReasoningChunk).reasoning === "string";
 
-// A streamed chunk carrying the token usage reported for a single model turn.
-// The chat service sums these into the per-session counter shown in the UI.
-// `peakInputTokens` is the largest single LLM call's input within the run - the
-// best naive proxy for the current context size, used to decide when the session
-// must be compacted before the next prompt.
+// A streamed chunk carrying the token usage accumulated across the run. The chat
+// service sums these into the per-session counter shown in the UI. Emitted once
+// at end of turn so a transient-error retry can discard the failed attempt's
+// usage rather than double counting it.
 export interface TokenUsageChunk {
   tokenUsage: TokenUsage;
-  peakInputTokens: number;
 }
 
 export const isTokenUsageChunk = (chunk: unknown): chunk is TokenUsageChunk =>
   typeof chunk === "object" && chunk !== null && "tokenUsage" in chunk;
+
+// A streamed chunk carrying the size of the persisted conversation that the next
+// prompt re-sends. `contextTokens` (parent-thread messages, ~4 chars/token)
+// drives the capacity indicator and the compaction decision; unlike a single
+// call's input it excludes the transient tool-loop context of the sub-agents,
+// which never persists. `peakInputTokens` is the largest single LLM call's input
+// in the run - surfaced only in the indicator tooltip, never used to size the
+// gauge or trigger compaction. Emitted live, once per completed LLM call, so the
+// indicator moves during a turn instead of only at the end.
+export interface ContextSizeChunk {
+  contextTokens: number;
+  peakInputTokens: number;
+}
+
+export const isContextSizeChunk = (chunk: unknown): chunk is ContextSizeChunk =>
+  typeof chunk === "object" && chunk !== null && "contextTokens" in chunk;
 
 /**
  * Accumulates the token usage reported by every model turn in a run via the
@@ -72,16 +87,21 @@ export const isTokenUsageChunk = (chunk: unknown): chunk is TokenUsageChunk =>
 class TokenUsageCollector extends BaseCallbackHandler {
   name = "freelens-token-usage-collector";
   total: TokenUsage = emptyTokenUsage();
-  // Largest single call's input tokens seen in the run. The per-call inputs are
-  // not summed: each call re-sends roughly the same accumulated context, so the
-  // peak (not the sum) approximates how close the conversation is to the limit.
+  // Largest single call's input tokens seen in the run. This is a transient
+  // intra-turn spike (e.g. a sub-agent re-sending a big tool result) that does
+  // not persist, so it never sizes the gauge or the compaction decision - it is
+  // surfaced only in the indicator tooltip as "largest single request this turn".
   peakInputTokens = 0;
+  // Incremented on every completed LLM call so the streaming loop can detect when
+  // a new internal call finished and refresh the live persisted-context reading.
+  callCount = 0;
 
   handleLLMEnd(output: LLMResult): void {
     const usage = extractTokenUsageFromLLMResult(output);
     if (usage) {
       this.total = addTokenUsage(this.total, usage);
       this.peakInputTokens = Math.max(this.peakInputTokens, usage.input);
+      this.callCount += 1;
     }
   }
 }
@@ -90,7 +110,7 @@ export interface AgentService {
   run(
     agentInput: object | Command,
     conversationId: string,
-  ): AsyncGenerator<string | ReasoningChunk | TokenUsageChunk | Interrupt, void, unknown>;
+  ): AsyncGenerator<string | ReasoningChunk | TokenUsageChunk | ContextSizeChunk | Interrupt, void, unknown>;
 }
 
 /**
@@ -112,6 +132,23 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
       // Fresh per attempt so a transient-error retry discards the usage counted
       // for the failed attempt rather than double counting it.
       const tokenUsageCollector = new TokenUsageCollector();
+      // Number of completed LLM calls already reflected in an emitted context
+      // chunk, so the live reading is refreshed only when a new internal call
+      // finishes rather than on every streamed token.
+      let lastEmittedCallCount = 0;
+
+      // Read the persisted parent-thread context size (what the next prompt
+      // re-sends) and pair it with the run's peak single-call input for the
+      // tooltip. The persisted thread grows as the graph's nodes check point, so
+      // reading it after each completed call lets the indicator move during the
+      // turn instead of only at the end.
+      const readContextSize = async (): Promise<ContextSizeChunk> => {
+        const state = await agent.getState({ configurable: config });
+        return {
+          contextTokens: approximateMessagesTokenCount(state?.values?.messages),
+          peakInputTokens: tokenUsageCollector.peakInputTokens,
+        };
+      };
 
       try {
         const streamResponse = await agent.stream(agentInput, {
@@ -153,18 +190,33 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
               yield text;
             }
           }
+
+          // Refresh the live capacity reading whenever a new internal LLM call
+          // has finished, so the indicator moves during the turn rather than
+          // only at the end (a single user turn fans out into several calls).
+          if (tokenUsageCollector.callCount > lastEmittedCallCount) {
+            lastEmittedCallCount = tokenUsageCollector.callCount;
+            yield await readContextSize();
+          }
         }
 
         yield "\n";
+
+        // Final, authoritative capacity reading once the run has settled: the
+        // persisted thread is now complete, so this is exactly what the next
+        // prompt re-sends and what the pre-send compaction decision acts on.
+        yield await readContextSize();
 
         // Emit the token usage accumulated across every model turn in this run
         // (collected from the `handleLLMEnd` callback above). Reading it from the
         // callback rather than the streamed chunks is what lets the supervisor
         // and analyzer turns - suppressed from the `messages` stream by the
-        // `nostream` tag - be counted, not just the single visible turn.
+        // `nostream` tag - be counted, not just the single visible turn. Emitted
+        // once here (not per call) so a transient-error retry discards a failed
+        // attempt's usage rather than double counting it.
         const tokenUsage = tokenUsageCollector.total;
         if (tokenUsage.input !== 0 || tokenUsage.cached !== 0 || tokenUsage.output !== 0) {
-          yield { tokenUsage, peakInputTokens: tokenUsageCollector.peakInputTokens };
+          yield { tokenUsage };
         }
 
         // checks the agent state for any interrupts

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -50,8 +50,12 @@ export const isReasoningChunk = (chunk: unknown): chunk is ReasoningChunk =>
 
 // A streamed chunk carrying the token usage reported for a single model turn.
 // The chat service sums these into the per-session counter shown in the UI.
+// `peakInputTokens` is the largest single LLM call's input within the run - the
+// best naive proxy for the current context size, used to decide when the session
+// must be compacted before the next prompt.
 export interface TokenUsageChunk {
   tokenUsage: TokenUsage;
+  peakInputTokens: number;
 }
 
 export const isTokenUsageChunk = (chunk: unknown): chunk is TokenUsageChunk =>
@@ -68,11 +72,16 @@ export const isTokenUsageChunk = (chunk: unknown): chunk is TokenUsageChunk =>
 class TokenUsageCollector extends BaseCallbackHandler {
   name = "freelens-token-usage-collector";
   total: TokenUsage = emptyTokenUsage();
+  // Largest single call's input tokens seen in the run. The per-call inputs are
+  // not summed: each call re-sends roughly the same accumulated context, so the
+  // peak (not the sum) approximates how close the conversation is to the limit.
+  peakInputTokens = 0;
 
   handleLLMEnd(output: LLMResult): void {
     const usage = extractTokenUsageFromLLMResult(output);
     if (usage) {
       this.total = addTokenUsage(this.total, usage);
+      this.peakInputTokens = Math.max(this.peakInputTokens, usage.input);
     }
   }
 }
@@ -155,7 +164,7 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
         // `nostream` tag - be counted, not just the single visible turn.
         const tokenUsage = tokenUsageCollector.total;
         if (tokenUsage.input !== 0 || tokenUsage.cached !== 0 || tokenUsage.output !== 0) {
-          yield { tokenUsage };
+          yield { tokenUsage, peakInputTokens: tokenUsageCollector.peakInputTokens };
         }
 
         // checks the agent state for any interrupts

--- a/src/renderer/business/service/session-compaction-service.ts
+++ b/src/renderer/business/service/session-compaction-service.ts
@@ -1,0 +1,30 @@
+// Summarizes a session's model-side history into a single compact summary used
+// to replace that history when the conversation approaches the model's input
+// token limit. The decision math and prompt assembly are the pure helpers in
+// session-compaction.ts; this module owns the impure model invocation.
+
+import { useModelProvider } from "../provider/model-provider";
+import { messageContentToText } from "../provider/token-estimate";
+import { buildSummaryPrompt, type HistoryMessageLike, toSummarizableMessages } from "./session-compaction";
+
+export interface SessionCompactionService {
+  // Summarize the given model-side history into a single compact summary string.
+  // Returns an empty string when there is nothing to summarize.
+  summarize(messages: HistoryMessageLike[]): Promise<string>;
+}
+
+export const useSessionCompactionService = (): SessionCompactionService => {
+  const { getModel } = useModelProvider();
+
+  const summarize = async (messages: HistoryMessageLike[]): Promise<string> => {
+    const summarizable = toSummarizableMessages(messages);
+    if (summarizable.every((message) => message.content.trim().length === 0)) {
+      return "";
+    }
+
+    const response = await getModel().invoke(buildSummaryPrompt(summarizable));
+    return messageContentToText(response.content).trim();
+  };
+
+  return { summarize };
+};

--- a/src/renderer/business/service/session-compaction.test.ts
+++ b/src/renderer/business/service/session-compaction.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSummaryPrompt,
+  COMPACTION_SUMMARY_INSTRUCTION,
+  COMPACTION_THRESHOLD,
+  DEFAULT_MAX_INPUT_TOKENS,
+  estimateNextPromptTokens,
+  renderConversationForSummary,
+  resolveMaxInputTokens,
+  shouldCompactSession,
+  toSummarizableMessages,
+} from "./session-compaction";
+
+describe("resolveMaxInputTokens", () => {
+  it("uses the model's advertised max input tokens", () => {
+    expect(resolveMaxInputTokens({ maxInputTokens: 200_000 })).toBe(200_000);
+  });
+
+  it("falls back to 128000 for an unknown model", () => {
+    expect(resolveMaxInputTokens(undefined)).toBe(DEFAULT_MAX_INPUT_TOKENS);
+    expect(DEFAULT_MAX_INPUT_TOKENS).toBe(128_000);
+  });
+
+  it("falls back when the limit is missing, zero, or not finite", () => {
+    expect(resolveMaxInputTokens({ maxInputTokens: undefined })).toBe(DEFAULT_MAX_INPUT_TOKENS);
+    expect(resolveMaxInputTokens({ maxInputTokens: 0 })).toBe(DEFAULT_MAX_INPUT_TOKENS);
+    expect(resolveMaxInputTokens({ maxInputTokens: Number.POSITIVE_INFINITY })).toBe(DEFAULT_MAX_INPUT_TOKENS);
+  });
+
+  it("honours a custom fallback", () => {
+    expect(resolveMaxInputTokens(undefined, 64_000)).toBe(64_000);
+  });
+});
+
+describe("estimateNextPromptTokens", () => {
+  it("adds the carried-over context to the next message estimate", () => {
+    expect(estimateNextPromptTokens(1000, 250)).toBe(1250);
+  });
+
+  it("clamps negative inputs to zero", () => {
+    expect(estimateNextPromptTokens(-5, -10)).toBe(0);
+    expect(estimateNextPromptTokens(-5, 30)).toBe(30);
+  });
+});
+
+describe("shouldCompactSession", () => {
+  const max = 100_000;
+
+  it("compacts once the estimate reaches the threshold", () => {
+    expect(shouldCompactSession(max * COMPACTION_THRESHOLD, max)).toBe(true);
+    expect(shouldCompactSession(max, max)).toBe(true);
+  });
+
+  it("does not compact below the threshold", () => {
+    expect(shouldCompactSession(max * COMPACTION_THRESHOLD - 1, max)).toBe(false);
+  });
+
+  it("never compacts a fresh session with no prior response", () => {
+    expect(shouldCompactSession(0, max)).toBe(false);
+  });
+
+  it("never compacts when the max is unknown (non-positive)", () => {
+    expect(shouldCompactSession(95_000, 0)).toBe(false);
+  });
+
+  it("respects a custom threshold", () => {
+    expect(shouldCompactSession(50_000, 100_000, 0.5)).toBe(true);
+    expect(shouldCompactSession(49_999, 100_000, 0.5)).toBe(false);
+  });
+});
+
+describe("renderConversationForSummary", () => {
+  it("joins role-tagged turns and drops empty ones", () => {
+    const rendered = renderConversationForSummary([
+      { role: "user", content: "list pods" },
+      { role: "assistant", content: "   " },
+      { role: "assistant", content: "3 pods running" },
+    ]);
+    expect(rendered).toBe("user: list pods\n\nassistant: 3 pods running");
+  });
+
+  it("returns an empty string when there is nothing to summarize", () => {
+    expect(renderConversationForSummary([])).toBe("");
+  });
+});
+
+describe("buildSummaryPrompt", () => {
+  it("prepends the instruction and wraps the conversation", () => {
+    const prompt = buildSummaryPrompt([{ role: "user", content: "scale web to 3" }]);
+    expect(prompt.startsWith(COMPACTION_SUMMARY_INSTRUCTION)).toBe(true);
+    expect(prompt).toContain("<conversation>\nuser: scale web to 3\n</conversation>");
+  });
+});
+
+describe("toSummarizableMessages", () => {
+  it("maps the message type and flattens string content", () => {
+    const result = toSummarizableMessages([
+      { getType: () => "human", content: "list pods" },
+      { getType: () => "ai", content: "3 pods running" },
+    ]);
+    expect(result).toEqual([
+      { role: "human", content: "list pods" },
+      { role: "ai", content: "3 pods running" },
+    ]);
+  });
+
+  it("flattens array content blocks to their text", () => {
+    const result = toSummarizableMessages([
+      {
+        getType: () => "human",
+        content: [
+          { type: "text", text: "hello" },
+          { type: "text", text: " world" },
+        ],
+      },
+    ]);
+    expect(result).toEqual([{ role: "human", content: "hello world" }]);
+  });
+
+  it("defaults the role to 'message' when the type is unavailable", () => {
+    const result = toSummarizableMessages([{ content: "no type" }]);
+    expect(result).toEqual([{ role: "message", content: "no type" }]);
+  });
+});

--- a/src/renderer/business/service/session-compaction.ts
+++ b/src/renderer/business/service/session-compaction.ts
@@ -1,0 +1,111 @@
+// Pure helpers for deciding when a chat session must be compacted and for
+// building the summarization prompt used to compact it.
+//
+// Kept free of host/MobX/network/LangChain-runtime dependencies so the decision
+// math and prompt assembly can be unit-tested in isolation (see
+// session-compaction.test.ts). The impure parts - reading the model-side
+// history, invoking the model to summarize, and wiping the LangGraph thread -
+// live in session-compaction-service.ts and application-context.tsx.
+
+import { messageContentToText } from "../provider/token-estimate";
+
+import type { MessageContent } from "@langchain/core/messages";
+
+import type { ModelPricing } from "../provider/model-pricing";
+
+// Fallback context window used when the selected model's max input tokens are
+// unknown (an undetected model, or pricing data that did not load). A
+// conservative 128k matches the smallest common large-context window, so the
+// estimate stays pessimistic rather than letting an unknown model run until the
+// endpoint rejects the request.
+export const DEFAULT_MAX_INPUT_TOKENS = 128_000;
+
+// Compact once the estimated next prompt reaches this fraction of the model's
+// max input tokens, leaving headroom for the model's own response and for the
+// imprecision of the naive token estimate.
+export const COMPACTION_THRESHOLD = 0.9;
+
+/**
+ * Resolve the model's max input tokens from the pricing data already fetched for
+ * the cost estimate (LiteLLM `/model/info` or the public price list). Falls back
+ * to {@link DEFAULT_MAX_INPUT_TOKENS} when the model is unknown or advertises no
+ * positive limit.
+ */
+export const resolveMaxInputTokens = (
+  pricing: Pick<ModelPricing, "maxInputTokens"> | undefined,
+  fallback: number = DEFAULT_MAX_INPUT_TOKENS,
+): number => {
+  const limit = pricing?.maxInputTokens;
+  return typeof limit === "number" && Number.isFinite(limit) && limit > 0 ? limit : fallback;
+};
+
+/**
+ * Naively (pessimistically) estimate the next prompt's input token count from
+ * the previous response's input tokens and the new message's estimated tokens.
+ * The previous prompt's tokens are reused as the carried-over context size
+ * because the model re-sends the accumulated conversation each turn.
+ */
+export const estimateNextPromptTokens = (lastInputTokens: number, nextMessageTokens: number): number =>
+  Math.max(0, lastInputTokens) + Math.max(0, nextMessageTokens);
+
+/**
+ * Decide whether the session should be compacted before the next prompt: true
+ * when the estimated prompt reaches {@link COMPACTION_THRESHOLD} of the model's
+ * max input tokens. A zero/negative estimate never triggers compaction so a
+ * fresh session (no prior response yet) is left alone.
+ */
+export const shouldCompactSession = (
+  estimatedPromptTokens: number,
+  maxInputTokens: number,
+  threshold: number = COMPACTION_THRESHOLD,
+): boolean => estimatedPromptTokens > 0 && maxInputTokens > 0 && estimatedPromptTokens >= maxInputTokens * threshold;
+
+// One turn of the conversation, flattened to plain text for summarization.
+export interface SummarizableMessage {
+  role: string;
+  content: string;
+}
+
+// Minimal shape of the LangChain messages held in the agent's LangGraph state.
+// Only the fields read to render the conversation are described.
+export interface HistoryMessageLike {
+  getType?: () => string;
+  content: MessageContent;
+}
+
+/**
+ * Flatten the agent's stored history into role-tagged plain-text turns. Unknown
+ * or missing types degrade to "message" so nothing is dropped.
+ */
+export const toSummarizableMessages = (messages: HistoryMessageLike[]): SummarizableMessage[] =>
+  messages.map((message) => ({
+    role: typeof message.getType === "function" ? message.getType() : "message",
+    content: messageContentToText(message.content),
+  }));
+
+// Instruction prepended to the conversation when asking the model to compact it.
+// The summary replaces the model-side history, so it must preserve the facts a
+// follow-up turn needs (resources touched, findings, decisions, open actions).
+export const COMPACTION_SUMMARY_INSTRUCTION = [
+  "You are compacting a long Kubernetes assistant conversation so it fits within the model's context window.",
+  "Write a concise summary that preserves every fact a follow-up turn may need:",
+  "the user's goals, the cluster resources and namespaces discussed, findings and",
+  "diagnoses, actions already taken or approved, and any still-open questions or",
+  "next steps. Omit pleasantries and redundant detail. Respond with the summary only.",
+].join(" ");
+
+/**
+ * Render the model-side history as the plain text fed to the summarizer. Empty
+ * messages are dropped so they do not pad the prompt.
+ */
+export const renderConversationForSummary = (messages: SummarizableMessage[]): string =>
+  messages
+    .filter((message) => message.content.trim().length > 0)
+    .map((message) => `${message.role}: ${message.content}`)
+    .join("\n\n");
+
+/**
+ * Build the full summarization prompt (instruction + rendered conversation).
+ */
+export const buildSummaryPrompt = (messages: SummarizableMessage[]): string =>
+  `${COMPACTION_SUMMARY_INSTRUCTION}\n\n<conversation>\n${renderConversationForSummary(messages)}\n</conversation>`;

--- a/src/renderer/business/service/token-usage.test.ts
+++ b/src/renderer/business/service/token-usage.test.ts
@@ -5,6 +5,8 @@ import {
   extractTokenUsage,
   extractTokenUsageFromLLMResult,
   formatTokenUsage,
+  isEmptyTokenUsage,
+  subtractTokenUsage,
 } from "./token-usage";
 
 describe("extractTokenUsage", () => {
@@ -120,6 +122,38 @@ describe("addTokenUsage", () => {
       cached: 0,
       output: 2,
     });
+  });
+});
+
+describe("subtractTokenUsage", () => {
+  it("returns the field-wise difference", () => {
+    expect(subtractTokenUsage({ input: 105, cached: 22, output: 38 }, { input: 100, cached: 20, output: 30 })).toEqual({
+      input: 5,
+      cached: 2,
+      output: 8,
+    });
+  });
+
+  it("can produce a negative delta to roll back a counted total", () => {
+    expect(subtractTokenUsage(emptyTokenUsage(), { input: 5, cached: 2, output: 8 })).toEqual({
+      input: -5,
+      cached: -2,
+      output: -8,
+    });
+  });
+
+  it("round-trips with addTokenUsage", () => {
+    const total = { input: 100, cached: 20, output: 30 };
+    const delta = { input: 5, cached: 2, output: 8 };
+    expect(subtractTokenUsage(addTokenUsage(total, delta), total)).toEqual(delta);
+  });
+});
+
+describe("isEmptyTokenUsage", () => {
+  it("is true only when every field is zero", () => {
+    expect(isEmptyTokenUsage(emptyTokenUsage())).toBe(true);
+    expect(isEmptyTokenUsage({ input: 0, cached: 0, output: 1 })).toBe(false);
+    expect(isEmptyTokenUsage({ input: 1, cached: 0, output: 0 })).toBe(false);
   });
 });
 

--- a/src/renderer/business/service/token-usage.ts
+++ b/src/renderer/business/service/token-usage.ts
@@ -124,6 +124,19 @@ export const addTokenUsage = (total: TokenUsage, delta: TokenUsage): TokenUsage 
   output: total.output + delta.output,
 });
 
+// Field-wise difference of two totals. Used to turn a collector's running total
+// into the per-call delta the live counter adds, and to roll back a failed
+// attempt's already-counted usage before a transient-error retry re-runs it.
+export const subtractTokenUsage = (total: TokenUsage, delta: TokenUsage): TokenUsage => ({
+  input: total.input - delta.input,
+  cached: total.cached - delta.cached,
+  output: total.output - delta.output,
+});
+
+// True when every field is zero, so callers can skip emitting an empty delta.
+export const isEmptyTokenUsage = (usage: TokenUsage): boolean =>
+  usage.input === 0 && usage.cached === 0 && usage.output === 0;
+
 /**
  * Render the session totals as the compact counter requested in the issue:
  * `in:xxx (cached:zzz) + out:yyy`. Counts use locale grouping so large totals

--- a/src/renderer/components/text-input/text-input.scss
+++ b/src/renderer/components/text-input/text-input.scss
@@ -150,7 +150,9 @@
   color: var(--textColorPrimary);
   font-size: 0.8em;
   line-height: 1.3;
-  white-space: normal;
+  // `pre-line` keeps explicit newlines in `data-tooltip` (the capacity indicator
+  // puts the peak on its own line) while still wrapping long single-line text.
+  white-space: pre-line;
   text-align: left;
   pointer-events: none;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);

--- a/src/renderer/components/text-input/text-input.scss
+++ b/src/renderer/components/text-input/text-input.scss
@@ -42,6 +42,17 @@
   transition: color 0.2s ease;
 }
 
+// Circular token-capacity indicator shown next to the send button. The contour
+// inherits the send button's colour via `currentColor`; the progress arc is
+// drawn in the standard text colour inside the component.
+.text-input-token-capacity {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.5rem;
+  color: var(--layoutTabsActiveColor);
+  user-select: none;
+}
+
 .text-input-send-button:disabled {
   opacity: 0.3;
   cursor: default;

--- a/src/renderer/components/text-input/text-input.scss
+++ b/src/renderer/components/text-input/text-input.scss
@@ -42,15 +42,33 @@
   transition: color 0.2s ease;
 }
 
-// Circular token-capacity indicator shown next to the send button. The contour
-// is a neutral grey (#acacac); the progress arc is drawn in the standard text
-// colour inside the component. Kept tight against the send button.
+// Circular token-capacity indicator shown next to the send button. Kept tight
+// against the send button.
 .text-input-token-capacity {
   display: inline-flex;
   align-items: center;
   margin-left: 0.5rem;
   margin-right: 0;
   user-select: none;
+}
+
+// Capacity-indicator stroke colours. A CSS `stroke` rule overrides the SVG
+// presentation attribute, so this drives the colours per theme. Dark theme is
+// the default (no body class); `body.theme-light` is set by the host for light.
+.text-input-token-capacity-track {
+  stroke: #616466; // unused capacity (dark theme)
+}
+
+.text-input-token-capacity-arc {
+  stroke: #a0a0a0; // used tokens (dark theme)
+}
+
+body.theme-light .text-input-token-capacity-track {
+  stroke: #acacac; // unused capacity (light theme)
+}
+
+body.theme-light .text-input-token-capacity-arc {
+  stroke: var(--textColorPrimary); // used tokens (light theme)
 }
 
 .text-input-send-button:disabled {

--- a/src/renderer/components/text-input/text-input.scss
+++ b/src/renderer/components/text-input/text-input.scss
@@ -57,6 +57,21 @@
   user-select: none;
 }
 
+// Transient compaction status shown next to the token counter. While compacting
+// it stays dimmed like the counter; once compacted it switches to the normal
+// (primary) text colour to confirm the conversation was compacted.
+.text-input-compaction-status {
+  margin-right: 0.5rem;
+  color: var(--textColorPrimary);
+  font-size: 0.9em;
+  white-space: nowrap;
+  user-select: none;
+}
+
+.text-input-compaction-status.compacting {
+  color: var(--textColorDimmed);
+}
+
 .text-input-select-box {
   min-width: 70px !important;
 }

--- a/src/renderer/components/text-input/text-input.scss
+++ b/src/renderer/components/text-input/text-input.scss
@@ -34,7 +34,7 @@
 }
 
 .text-input-send-button {
-  margin-left: 0.5rem;
+  margin-left: 0;
   background: none;
   border: none;
   cursor: pointer;
@@ -43,13 +43,13 @@
 }
 
 // Circular token-capacity indicator shown next to the send button. The contour
-// inherits the send button's colour via `currentColor`; the progress arc is
-// drawn in the standard text colour inside the component.
+// is a neutral grey (#acacac); the progress arc is drawn in the standard text
+// colour inside the component. Kept tight against the send button.
 .text-input-token-capacity {
   display: inline-flex;
   align-items: center;
   margin-left: 0.5rem;
-  color: var(--layoutTabsActiveColor);
+  margin-right: 0;
   user-select: none;
 }
 
@@ -125,4 +125,33 @@
   background: var(--inputControlHoverBorder);
   color: var(--textColorPrimary);
   border-color: var(--inputControlHoverBorder);
+}
+
+// Lightweight hover tooltip used for the token counter and capacity indicator.
+// The native `title` attribute is slow to appear and hard to trigger, so the
+// text is supplied via `data-tooltip` and shown instantly on hover, anchored to
+// the element's right edge so it stays inside the input area.
+.text-input-tooltip {
+  position: relative;
+}
+
+.text-input-tooltip[data-tooltip]:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 6px);
+  right: 0;
+  z-index: 100;
+  width: max-content;
+  max-width: 280px;
+  padding: 6px 8px;
+  border: 1px solid var(--borderColor);
+  border-radius: 4px;
+  background-color: var(--menuBackground);
+  color: var(--textColorPrimary);
+  font-size: 0.8em;
+  line-height: 1.3;
+  white-space: normal;
+  text-align: left;
+  pointer-events: none;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.25);
 }

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -110,6 +110,18 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
               </button>
             </div>
             <div style={{ display: "flex", alignItems: "center" }}>
+              {applicationStatusStore.compactionStatus && (
+                <span
+                  className={`text-input-compaction-status${
+                    applicationStatusStore.compactionStatus === "compacting" ? " compacting" : ""
+                  }`}
+                  title="The conversation was getting close to the model's input token limit, so it was summarized to free up context."
+                >
+                  {applicationStatusStore.compactionStatus === "compacting"
+                    ? "Compacting conversation..."
+                    : "Compacted conversation."}
+                </span>
+              )}
               {textInputHook.agentConfigured && (
                 <span
                   className="text-input-token-counter"

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -153,6 +153,7 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
                 <TokenCapacityIndicator
                   usedTokens={applicationStatusStore.lastInputTokens}
                   maxTokens={applicationStatusStore.getMaxInputTokens()}
+                  peakTokens={applicationStatusStore.lastPeakInputTokens}
                 />
               )}
               <button

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -8,6 +8,7 @@ import { useApplicationStatusStore } from "../../context/application-context";
 import { AvailableTools } from "../available-tools/available-tools";
 import styleInline from "./text-input.scss?inline";
 import { useTextInput } from "./text-input-hook";
+import { TokenCapacityIndicator } from "./token-capacity-indicator";
 
 const { observer } = MobxReact;
 
@@ -146,6 +147,12 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
                   label="Configure agent"
                   onClick={textInputHook.goToPreferences}
                   title="Set an API key and add a model in Freelens AI settings."
+                />
+              )}
+              {textInputHook.agentConfigured && (
+                <TokenCapacityIndicator
+                  usedTokens={applicationStatusStore.lastInputTokens}
+                  maxTokens={applicationStatusStore.getMaxInputTokens()}
                 />
               )}
               <button

--- a/src/renderer/components/text-input/text-input.tsx
+++ b/src/renderer/components/text-input/text-input.tsx
@@ -125,8 +125,8 @@ export const TextInput = observer(({ onSend }: TextInputProps) => {
               )}
               {textInputHook.agentConfigured && (
                 <span
-                  className="text-input-token-counter"
-                  title="Tokens used this session (input, cached input, output), with estimated cost when known. Resets when the chat is cleared."
+                  className="text-input-token-counter text-input-tooltip"
+                  data-tooltip="Tokens used this session (input, cached input, output), with estimated cost when known. Resets when the chat is cleared."
                 >
                   {formatTokenUsage(applicationStatusStore.tokenUsage)}
                   {applicationStatusStore.sessionCost > 0 ? ` = ${formatCost(applicationStatusStore.sessionCost)}` : ""}

--- a/src/renderer/components/text-input/token-capacity-indicator.tsx
+++ b/src/renderer/components/text-input/token-capacity-indicator.tsx
@@ -1,18 +1,28 @@
 import * as React from "react";
 
 type TokenCapacityIndicatorProps = {
-  // Input tokens of the last request to the LLM. 0 at the start of a session.
+  // Approximate size of the persisted conversation carried into the next prompt.
+  // 0 at the start of a session. This is what the next prompt re-sends and what
+  // the compaction decision acts on, so the gauge fills as the history grows and
+  // nears 100% just before a compaction is triggered.
   usedTokens: number;
   // Max input tokens of the currently selected model.
   maxTokens: number;
+  // Largest single LLM call's input tokens in the last run. A transient
+  // intra-turn spike surfaced only in the tooltip, not used to size the gauge.
+  peakTokens: number;
 };
 
 // Minimal circular progress indicator shown next to the send button. Renders a
 // thin circle contour (matching the send button's size and colour) with the
 // progress arc drawn in the standard text colour, leaving the inside unfilled.
-// 0% means no tokens were used in the last request (or a fresh session); 100%
-// means the last request reached the model's max input tokens.
-export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({ usedTokens, maxTokens }) => {
+// 0% means the persisted conversation is empty (a fresh session); 100% means it
+// reached the model's max input tokens and the next send will compact it.
+export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({
+  usedTokens,
+  maxTokens,
+  peakTokens,
+}) => {
   const size = 22;
   const strokeWidth = 2;
   const center = size / 2;
@@ -23,10 +33,17 @@ export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({ 
   const dashOffset = circumference * (1 - fraction);
   const percent = Math.round(fraction * 100);
 
-  const title =
+  const contextLine =
     maxTokens > 0
-      ? `Input tokens in last request: ${usedTokens.toLocaleString("en-US")} / ${maxTokens.toLocaleString("en-US")} (${percent}%)`
-      : `Input tokens in last request: ${usedTokens.toLocaleString("en-US")}`;
+      ? `Conversation context: ${usedTokens.toLocaleString("en-US")} / ${maxTokens.toLocaleString("en-US")} tokens (${percent}%)`
+      : `Conversation context: ${usedTokens.toLocaleString("en-US")} tokens`;
+  // Surface the transient peak separately so it is visible without driving the
+  // gauge, which answers "max or last?": the gauge tracks the persisted context,
+  // the tooltip reports the largest single request of the last turn.
+  const title =
+    peakTokens > 0
+      ? `${contextLine}\nLargest single request last turn: ${peakTokens.toLocaleString("en-US")} tokens`
+      : contextLine;
 
   return (
     <span className="text-input-token-capacity text-input-tooltip" data-tooltip={title}>

--- a/src/renderer/components/text-input/token-capacity-indicator.tsx
+++ b/src/renderer/components/text-input/token-capacity-indicator.tsx
@@ -14,8 +14,9 @@ type TokenCapacityIndicatorProps = {
 };
 
 // Minimal circular progress indicator shown next to the send button. Renders a
-// thin circle contour (matching the send button's size and colour) with the
-// progress arc drawn in the standard text colour, leaving the inside unfilled.
+// thin circle contour (a neutral dark grey for the unused capacity) with the
+// progress arc drawn in a lighter grey for the used tokens, leaving the inside
+// unfilled.
 // 0% means the persisted conversation is empty (a fresh session); 100% means it
 // reached the model's max input tokens and the next send will compact it.
 export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({
@@ -48,15 +49,15 @@ export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({
   return (
     <span className="text-input-token-capacity text-input-tooltip" data-tooltip={title}>
       <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label={title}>
-        {/* Contour, drawn in a neutral grey */}
-        <circle cx={center} cy={center} r={radius} fill="none" stroke="#acacac" strokeWidth={strokeWidth} />
-        {/* Progress arc, drawn in the standard text colour */}
+        {/* Contour for the unused capacity, drawn in a neutral dark grey */}
+        <circle cx={center} cy={center} r={radius} fill="none" stroke="#616466" strokeWidth={strokeWidth} />
+        {/* Progress arc for the used tokens, drawn in a lighter grey */}
         <circle
           cx={center}
           cy={center}
           r={radius}
           fill="none"
-          stroke="var(--textColorPrimary)"
+          stroke="#a0a0a0"
           strokeWidth={strokeWidth}
           strokeLinecap="round"
           strokeDasharray={circumference}

--- a/src/renderer/components/text-input/token-capacity-indicator.tsx
+++ b/src/renderer/components/text-input/token-capacity-indicator.tsx
@@ -14,9 +14,9 @@ type TokenCapacityIndicatorProps = {
 };
 
 // Minimal circular progress indicator shown next to the send button. Renders a
-// thin circle contour (a neutral dark grey for the unused capacity) with the
-// progress arc drawn in a lighter grey for the used tokens, leaving the inside
-// unfilled.
+// thin circle contour for the unused capacity with the progress arc drawn for
+// the used tokens, leaving the inside unfilled. The stroke colours are
+// theme-aware and driven from SCSS (see `text-input.scss`).
 // 0% means the persisted conversation is empty (a fresh session); 100% means it
 // reached the model's max input tokens and the next send will compact it.
 export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({
@@ -49,15 +49,22 @@ export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({
   return (
     <span className="text-input-token-capacity text-input-tooltip" data-tooltip={title}>
       <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label={title}>
-        {/* Contour for the unused capacity, drawn in a neutral dark grey */}
-        <circle cx={center} cy={center} r={radius} fill="none" stroke="#616466" strokeWidth={strokeWidth} />
-        {/* Progress arc for the used tokens, drawn in a lighter grey */}
+        {/* Contour for the unused capacity; colour is theme-aware (see SCSS) */}
         <circle
+          className="text-input-token-capacity-track"
           cx={center}
           cy={center}
           r={radius}
           fill="none"
-          stroke="#a0a0a0"
+          strokeWidth={strokeWidth}
+        />
+        {/* Progress arc for the used tokens; colour is theme-aware (see SCSS) */}
+        <circle
+          className="text-input-token-capacity-arc"
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
           strokeWidth={strokeWidth}
           strokeLinecap="round"
           strokeDasharray={circumference}

--- a/src/renderer/components/text-input/token-capacity-indicator.tsx
+++ b/src/renderer/components/text-input/token-capacity-indicator.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+
+type TokenCapacityIndicatorProps = {
+  // Input tokens of the last request to the LLM. 0 at the start of a session.
+  usedTokens: number;
+  // Max input tokens of the currently selected model.
+  maxTokens: number;
+};
+
+// Minimal circular progress indicator shown next to the send button. Renders a
+// thin circle contour (matching the send button's size and colour) with the
+// progress arc drawn in the standard text colour, leaving the inside unfilled.
+// 0% means no tokens were used in the last request (or a fresh session); 100%
+// means the last request reached the model's max input tokens.
+export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({ usedTokens, maxTokens }) => {
+  const size = 22;
+  const strokeWidth = 2;
+  const center = size / 2;
+  const radius = (size - strokeWidth) / 2;
+  const circumference = 2 * Math.PI * radius;
+
+  const fraction = maxTokens > 0 ? Math.min(1, Math.max(0, usedTokens / maxTokens)) : 0;
+  const dashOffset = circumference * (1 - fraction);
+  const percent = Math.round(fraction * 100);
+
+  const title =
+    maxTokens > 0
+      ? `Input tokens in last request: ${usedTokens.toLocaleString("en-US")} / ${maxTokens.toLocaleString("en-US")} (${percent}%)`
+      : `Input tokens in last request: ${usedTokens.toLocaleString("en-US")}`;
+
+  return (
+    <span className="text-input-token-capacity" title={title}>
+      <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label={title}>
+        {/* Contour, matching the send button's colour */}
+        <circle cx={center} cy={center} r={radius} fill="none" stroke="currentColor" strokeWidth={strokeWidth} />
+        {/* Progress arc, drawn in the standard text colour */}
+        <circle
+          cx={center}
+          cy={center}
+          r={radius}
+          fill="none"
+          stroke="var(--textColorPrimary)"
+          strokeWidth={strokeWidth}
+          strokeLinecap="round"
+          strokeDasharray={circumference}
+          strokeDashoffset={dashOffset}
+          transform={`rotate(-90 ${center} ${center})`}
+        />
+      </svg>
+    </span>
+  );
+};

--- a/src/renderer/components/text-input/token-capacity-indicator.tsx
+++ b/src/renderer/components/text-input/token-capacity-indicator.tsx
@@ -29,10 +29,10 @@ export const TokenCapacityIndicator: React.FC<TokenCapacityIndicatorProps> = ({ 
       : `Input tokens in last request: ${usedTokens.toLocaleString("en-US")}`;
 
   return (
-    <span className="text-input-token-capacity" title={title}>
+    <span className="text-input-token-capacity text-input-tooltip" data-tooltip={title}>
       <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`} role="img" aria-label={title}>
-        {/* Contour, matching the send button's colour */}
-        <circle cx={center} cy={center} r={radius} fill="none" stroke="currentColor" strokeWidth={strokeWidth} />
+        {/* Contour, drawn in a neutral grey */}
+        <circle cx={center} cy={center} r={radius} fill="none" stroke="#acacac" strokeWidth={strokeWidth} />
         {/* Progress arc, drawn in the standard text colour */}
         <circle
           cx={center}

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -19,10 +19,18 @@ import { MessageType } from "../business/objects/message-type";
 import { AIProviders, DEFAULT_OPENAI_BASE_URL } from "../business/provider/ai-models";
 import { computeSessionCost, type ModelPricingMap } from "../business/provider/model-pricing";
 import { fetchModelPricing } from "../business/provider/model-pricing-provider";
+import { approximateTokenCount } from "../business/provider/token-estimate";
+import { resolveMaxInputTokens } from "../business/service/session-compaction";
+import { useSessionCompactionService } from "../business/service/session-compaction-service";
 import { emptyTokenUsage, addTokenUsage as sumTokenUsage, type TokenUsage } from "../business/service/token-usage";
 import { IS_CONVERSATION_INTERRUPTED_KEY, IS_LOADING_KEY } from "./chat-session-storage";
 
 import type { MessageObject } from "../business/objects/message-object";
+
+// Transient status shown while the session is compacted: dimmed "Compacting
+// conversation..." during, then normal "Compacted conversation." after. Null
+// hides the indicator.
+export type CompactionStatus = "compacting" | "compacted" | null;
 
 export interface AppContextType {
   apiKey: string;
@@ -39,10 +47,22 @@ export interface AppContextType {
   // Estimated USD cost of this session for the selected model, or 0 when no
   // price is known. Resets with the token counter when the chat is cleared.
   sessionCost: number;
+  // Input tokens of the previous response's largest model turn - the naive proxy
+  // for the current context size that drives compaction.
+  lastInputTokens: number;
+  // Transient compaction status shown in the input bar, or null when idle.
+  compactionStatus: CompactionStatus;
   freeLensAgent: FreeLensAgent | null;
   mcpAgent: MPCAgent | null;
   setSelectedModel: (selectedModel: string) => void;
   addTokenUsage: (usage: TokenUsage) => void;
+  setLastInputTokens: (lastInputTokens: number) => void;
+  // Max input tokens for the selected model from the fetched pricing data,
+  // falling back to a conservative default for unknown models.
+  getMaxInputTokens: () => number;
+  // Summarize and reset the model-side history before the next prompt. Returns
+  // the summary to seed into that prompt, or null when nothing was compacted.
+  compactSession: () => Promise<string | null>;
   setExplainEvent: (messageObject: MessageObject) => void;
   setBypassApprovals: (bypassApprovals: boolean) => void;
   setLoading: (isLoading: boolean) => void;
@@ -78,6 +98,10 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const [isConversationInterrupted, _setConversationInterrupted] = useState(false);
   const [chatMessages, _setChatMessages] = useState<MessageObject[] | null>(null);
   const [tokenUsage, _setTokenUsage] = useState<TokenUsage>(emptyTokenUsage());
+  // Previous response's peak input tokens (context-size proxy) and the transient
+  // compaction status shown while the session is being compacted.
+  const [lastInputTokens, _setLastInputTokens] = useState<number>(0);
+  const [compactionStatus, _setCompactionStatus] = useState<CompactionStatus>(null);
   // Model name => pricing, fetched on start and whenever the model list or
   // endpoint changes. Used to estimate the per-session cost shown by the UI.
   const [modelPricing, _setModelPricing] = useState<ModelPricingMap>({});
@@ -85,9 +109,13 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const [mcpAgent, _setMcpAgent] = useState<MPCAgent | null>(agentsStore.mcpAgent);
 
   const prevMcpConfiguration = useRef(preferencesStore.mcpConfiguration);
+  // Holds the pending timer that hides the "Compacted conversation." status after
+  // a short delay, so a new compaction can cancel and restart it.
+  const compactionStatusTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const mcpAgentSystem = useMcpAgent(preferencesStore.mcpConfiguration);
   const freeLensAgentSystem = useFreeLensAgentSystem();
+  const sessionCompactionService = useSessionCompactionService();
 
   // Init variables
   useEffect(() => {
@@ -96,6 +124,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     _getConversationId();
     _loadChatMessages();
     _setTokenUsage(chatSessionStore.getTokenUsage(clusterId));
+    _setLastInputTokens(chatSessionStore.getLastInputTokens(clusterId));
     _initFreeLensAgent();
   }, []);
 
@@ -267,9 +296,77 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     });
   };
 
+  const setLastInputTokens = (value: number) => {
+    _setLastInputTokens(value);
+    // Durable: persisted so the compaction decision survives an app restart.
+    chatSessionStore.setLastInputTokens(clusterId, value);
+  };
+
+  // Max input tokens for the selected model, from the pricing data already
+  // fetched for the cost estimate. Falls back to a conservative default for
+  // models with no known limit.
+  const getMaxInputTokens = (): number => resolveMaxInputTokens(modelPricing[preferencesStore.selectedModel]);
+
+  // Summarize the model-side history into a short summary, wipe that history, and
+  // reset the context-size estimate so the next prompt starts small. The summary
+  // is returned so the caller can seed it into the next prompt. On any failure
+  // the history is still wiped (best effort) so the next prompt cannot exceed the
+  // limit; only the summary context is lost.
+  const compactSession = async (): Promise<string | null> => {
+    _showCompacting();
+    const agent = await getActiveAgent();
+    const config = { configurable: { thread_id: conversationId } };
+
+    try {
+      const messages = (await agent.getState(config)).values.messages ?? [];
+      const summary = await sessionCompactionService.summarize(messages);
+      await cleanAgentMessageHistory(agent);
+      // The new context is just the summary, so reset the estimate to its size.
+      setLastInputTokens(approximateTokenCount(summary));
+      _showCompacted();
+      return summary.length > 0 ? summary : null;
+    } catch (error) {
+      log.error("Failed to compact session: ", error);
+      // Best effort: drop the model-side history anyway so the next prompt is
+      // small, even though we could not summarize it.
+      try {
+        await cleanAgentMessageHistory(agent);
+      } catch (cleanError) {
+        log.error("Failed to clean history during compaction fallback: ", cleanError);
+      }
+      setLastInputTokens(0);
+      _showCompacted();
+      return null;
+    }
+  };
+
+  const _showCompacting = () => {
+    if (compactionStatusTimer.current) {
+      clearTimeout(compactionStatusTimer.current);
+      compactionStatusTimer.current = null;
+    }
+    _setCompactionStatus("compacting");
+  };
+
+  // Show the "Compacted conversation." status, then hide it after a short delay
+  // so the transient notification does not linger on the input bar.
+  const _showCompacted = () => {
+    _setCompactionStatus("compacted");
+    if (compactionStatusTimer.current) {
+      clearTimeout(compactionStatusTimer.current);
+    }
+    compactionStatusTimer.current = setTimeout(() => {
+      _setCompactionStatus(null);
+      compactionStatusTimer.current = null;
+    }, 5000);
+  };
+
   const clearChat = async () => {
-    // Zero the per-session token counter alongside the transcript.
+    // Zero the per-session token counter and context-size estimate alongside the
+    // transcript, and drop any lingering compaction status.
     _setTokenUsage(emptyTokenUsage());
+    setLastInputTokens(0);
+    _setCompactionStatus(null);
     if (freeLensAgent) {
       cleanAgentMessageHistory(freeLensAgent).finally(() => {
         _setChatMessages([]);
@@ -425,10 +522,15 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         chatMessages,
         tokenUsage,
         sessionCost,
+        lastInputTokens,
+        compactionStatus,
         mcpAgent,
         freeLensAgent,
         setSelectedModel,
         addTokenUsage,
+        setLastInputTokens,
+        getMaxInputTokens,
+        compactSession,
         setExplainEvent,
         setBypassApprovals,
         setLoading,

--- a/src/renderer/context/application-context.tsx
+++ b/src/renderer/context/application-context.tsx
@@ -47,9 +47,14 @@ export interface AppContextType {
   // Estimated USD cost of this session for the selected model, or 0 when no
   // price is known. Resets with the token counter when the chat is cleared.
   sessionCost: number;
-  // Input tokens of the previous response's largest model turn - the naive proxy
-  // for the current context size that drives compaction.
+  // Approximate size of the persisted conversation that the next prompt re-sends
+  // (parent-thread messages, ~4 chars/token). Drives the capacity indicator and
+  // the compaction decision; updated live as the run progresses.
   lastInputTokens: number;
+  // Largest single LLM call's input tokens in the last run - a transient
+  // intra-turn spike shown only in the indicator tooltip, never used to size the
+  // gauge or trigger compaction.
+  lastPeakInputTokens: number;
   // Transient compaction status shown in the input bar, or null when idle.
   compactionStatus: CompactionStatus;
   freeLensAgent: FreeLensAgent | null;
@@ -57,6 +62,7 @@ export interface AppContextType {
   setSelectedModel: (selectedModel: string) => void;
   addTokenUsage: (usage: TokenUsage) => void;
   setLastInputTokens: (lastInputTokens: number) => void;
+  setLastPeakInputTokens: (lastPeakInputTokens: number) => void;
   // Max input tokens for the selected model from the fetched pricing data,
   // falling back to a conservative default for unknown models.
   getMaxInputTokens: () => number;
@@ -98,9 +104,11 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
   const [isConversationInterrupted, _setConversationInterrupted] = useState(false);
   const [chatMessages, _setChatMessages] = useState<MessageObject[] | null>(null);
   const [tokenUsage, _setTokenUsage] = useState<TokenUsage>(emptyTokenUsage());
-  // Previous response's peak input tokens (context-size proxy) and the transient
-  // compaction status shown while the session is being compacted.
+  // Persisted-context size that drives compaction (durable), the last run's peak
+  // single-call input shown only in the tooltip (transient, not persisted), and
+  // the compaction status shown while the session is being compacted.
   const [lastInputTokens, _setLastInputTokens] = useState<number>(0);
+  const [lastPeakInputTokens, _setLastPeakInputTokens] = useState<number>(0);
   const [compactionStatus, _setCompactionStatus] = useState<CompactionStatus>(null);
   // Model name => pricing, fetched on start and whenever the model list or
   // endpoint changes. Used to estimate the per-session cost shown by the UI.
@@ -302,6 +310,12 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     chatSessionStore.setLastInputTokens(clusterId, value);
   };
 
+  // Transient: the peak is a within-turn diagnostic for the tooltip only, so it
+  // is kept in memory and not persisted alongside the durable session state.
+  const setLastPeakInputTokens = (value: number) => {
+    _setLastPeakInputTokens(value);
+  };
+
   // Max input tokens for the selected model, from the pricing data already
   // fetched for the cost estimate. Falls back to a conservative default for
   // models with no known limit.
@@ -321,8 +335,10 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
       const messages = (await agent.getState(config)).values.messages ?? [];
       const summary = await sessionCompactionService.summarize(messages);
       await cleanAgentMessageHistory(agent);
-      // The new context is just the summary, so reset the estimate to its size.
+      // The new context is just the summary, so reset the estimate to its size
+      // and clear the last run's peak (a stale within-turn diagnostic).
       setLastInputTokens(approximateTokenCount(summary));
+      setLastPeakInputTokens(0);
       _showCompacted();
       return summary.length > 0 ? summary : null;
     } catch (error) {
@@ -335,6 +351,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         log.error("Failed to clean history during compaction fallback: ", cleanError);
       }
       setLastInputTokens(0);
+      setLastPeakInputTokens(0);
       _showCompacted();
       return null;
     }
@@ -366,6 +383,7 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
     // transcript, and drop any lingering compaction status.
     _setTokenUsage(emptyTokenUsage());
     setLastInputTokens(0);
+    setLastPeakInputTokens(0);
     _setCompactionStatus(null);
     if (freeLensAgent) {
       cleanAgentMessageHistory(freeLensAgent).finally(() => {
@@ -523,12 +541,14 @@ export const ApplicationContextProvider = observer(({ children }: { children: Re
         tokenUsage,
         sessionCost,
         lastInputTokens,
+        lastPeakInputTokens,
         compactionStatus,
         mcpAgent,
         freeLensAgent,
         setSelectedModel,
         addTokenUsage,
         setLastInputTokens,
+        setLastPeakInputTokens,
         getMaxInputTokens,
         compactSession,
         setExplainEvent,


### PR DESCRIPTION
Implements #227: automatically compacts the chat session before the next prompt when it would approach the model's max input tokens (90% threshold, fallback 128000). Summarizes the model-side history, wipes the LangGraph thread, and seeds the summary into the next prompt. Shows a dimmed "Compacting conversation..." status that becomes "Compacted conversation.".