### PR TITLE
Strip managedFields from list and get Kubernetes resource tools

### DIFF
--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -11,6 +11,7 @@ import {
   type GetPodLogsInput,
   resolveContainer,
 } from "./pod-logs";
+import { stripManagedFields } from "./project-resource";
 import {
   DEFAULT_DELETE_MODE,
   type DeleteMode,
@@ -39,6 +40,9 @@ export interface ListResourceInput {
   kind: string;
   apiVersion?: string;
   namespace?: string;
+  // Server-side apply bookkeeping (`metadata.managedFields`) is stripped by
+  // default to keep the output small; set this to opt back in when needed.
+  includeManagedFields?: boolean;
 }
 
 export interface GetResourceInput {
@@ -46,6 +50,8 @@ export interface GetResourceInput {
   apiVersion?: string;
   name: string;
   namespace?: string;
+  // See ListResourceInput.includeManagedFields.
+  includeManagedFields?: boolean;
 }
 
 export interface CreateResourceInput {
@@ -205,13 +211,13 @@ async function captureResourceYaml(
   }
 }
 
-function projectObject(object: KubeObject) {
+function projectObject(object: KubeObject, includeManagedFields = false) {
   return {
     name: object.getName(),
     namespace: object.getNs(),
     spec: object.spec,
     status: object.status,
-    metadata: object.metadata,
+    metadata: stripManagedFields(object.metadata, includeManagedFields),
   };
 }
 
@@ -256,7 +262,12 @@ const STRATEGIC_MERGE_PATCH_CONTENT_TYPE = "application/strategic-merge-patch+js
  * kinds are scoped to `namespace` when provided; otherwise all loaded
  * namespaces are returned.
  */
-export async function listKubernetesResources({ kind, apiVersion, namespace }: ListResourceInput): Promise<string> {
+export async function listKubernetesResources({
+  kind,
+  apiVersion,
+  namespace,
+  includeManagedFields,
+}: ListResourceInput): Promise<string> {
   console.log("[Tool invocation: listKubernetesResources] - kind:", kind, "namespace:", namespace);
   const target = resolveTarget(kind, apiVersion);
   if (typeof target === "string") {
@@ -267,7 +278,7 @@ export async function listKubernetesResources({ kind, apiVersion, namespace }: L
     const scoped = api.isNamespaced && namespace ? [namespace] : undefined;
     const loaded = await store.loadAll(scoped ? { namespaces: scoped } : {});
     const items = loaded ?? (scoped ? store.getAllByNs(namespace as string) : store.items.toJSON());
-    return JSON.stringify(items.map(projectObject));
+    return JSON.stringify(items.map((item) => projectObject(item, includeManagedFields)));
   } catch (error) {
     console.error("[Tool invocation error: listKubernetesResources] - ", error);
     return JSON.stringify(error);
@@ -278,7 +289,13 @@ export async function listKubernetesResources({ kind, apiVersion, namespace }: L
  * Get a single resource by name, loading it from the store on demand. For
  * namespaced kinds a namespace is required.
  */
-export async function getKubernetesResource({ kind, apiVersion, name, namespace }: GetResourceInput): Promise<string> {
+export async function getKubernetesResource({
+  kind,
+  apiVersion,
+  name,
+  namespace,
+  includeManagedFields,
+}: GetResourceInput): Promise<string> {
   console.log("[Tool invocation: getKubernetesResource] - kind:", kind, "name:", name, "namespace:", namespace);
   const target = resolveTarget(kind, apiVersion);
   if (typeof target === "string") {
@@ -293,7 +310,7 @@ export async function getKubernetesResource({ kind, apiVersion, name, namespace 
     if (!object) {
       return `The ${kind} "${name}" was not found.`;
     }
-    return JSON.stringify(projectObject(object));
+    return JSON.stringify(projectObject(object, includeManagedFields));
   } catch (error) {
     console.error("[Tool invocation error: getKubernetesResource] - ", error);
     return JSON.stringify(error);

--- a/src/renderer/business/agent/tools/project-resource.test.ts
+++ b/src/renderer/business/agent/tools/project-resource.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { stripManagedFields } from "./project-resource";
+
+describe("stripManagedFields", () => {
+  it("removes managedFields by default", () => {
+    const metadata = {
+      name: "nginx",
+      namespace: "default",
+      managedFields: [{ manager: "kubectl", operation: "Update" }],
+    };
+    const result = stripManagedFields(metadata);
+    expect(result).toEqual({ name: "nginx", namespace: "default" });
+    expect(result).not.toHaveProperty("managedFields");
+  });
+
+  it("keeps managedFields when includeManagedFields is true", () => {
+    const metadata = {
+      name: "nginx",
+      managedFields: [{ manager: "kubectl" }],
+    };
+    expect(stripManagedFields(metadata, true)).toEqual(metadata);
+  });
+
+  it("does not mutate the original metadata", () => {
+    const metadata = {
+      name: "nginx",
+      managedFields: [{ manager: "kubectl" }],
+    };
+    stripManagedFields(metadata);
+    expect(metadata).toHaveProperty("managedFields");
+  });
+
+  it("returns metadata unchanged when there is no managedFields", () => {
+    const metadata = { name: "nginx", namespace: "default" };
+    expect(stripManagedFields(metadata)).toEqual(metadata);
+  });
+
+  it("returns undefined metadata as-is", () => {
+    expect(stripManagedFields(undefined)).toBeUndefined();
+  });
+});

--- a/src/renderer/business/agent/tools/project-resource.ts
+++ b/src/renderer/business/agent/tools/project-resource.ts
@@ -1,0 +1,20 @@
+// Pure helpers for projecting Kubernetes resources into the compact shape sent
+// to the model. Kept free of host/MobX dependencies so they can be unit-tested
+// directly (see project-resource.test.ts).
+
+/**
+ * Strip the noisy `metadata.managedFields` block from a resource's metadata.
+ * The server-side apply bookkeeping is large and irrelevant for LLM analysis,
+ * so it is removed by default; callers can opt back in via `includeManagedFields`
+ * when the field is actually needed. The original object is never mutated.
+ */
+export function stripManagedFields<T extends object>(
+  metadata: T | undefined,
+  includeManagedFields = false,
+): T | undefined {
+  if (includeManagedFields || !metadata || !("managedFields" in metadata)) {
+    return metadata;
+  }
+  const { managedFields: _managedFields, ...rest } = metadata as T & { managedFields?: unknown };
+  return rest as T;
+}

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -27,6 +27,14 @@ const apiVersionSchema = z
     'The apiVersion (group/version) of the resource, e.g. "v1" or "apps/v1". Required for kinds without a built-in default.',
   );
 const manifestSchema = z.record(z.any()).describe("The Kubernetes resource manifest as a JSON object.");
+const includeManagedFieldsSchema = z
+  .boolean()
+  .optional()
+  .describe(
+    "Whether to include metadata.managedFields in the output. Defaults to false: the server-side apply " +
+      "bookkeeping is large and irrelevant for analysis, so it is stripped to save context. Set to true only " +
+      "when you specifically need to inspect field ownership.",
+  );
 const subresourceSchema = z
   .string()
   .optional()
@@ -107,22 +115,28 @@ export const getWarningEventsByNamespace = tool(
 
 export const listKubernetesResources = tool(listKubernetesResourcesImpl, {
   name: "listKubernetesResources",
-  description: "List Kubernetes resources of a given kind, optionally scoped to a namespace",
+  description:
+    "List Kubernetes resources of a given kind, optionally scoped to a namespace. " +
+    "metadata.managedFields is stripped by default to keep the output small.",
   schema: z.object({
     kind: kindSchema,
     apiVersion: apiVersionSchema,
     namespace: z.string().optional().describe("The namespace to list namespaced resources in"),
+    includeManagedFields: includeManagedFieldsSchema,
   }),
 });
 
 export const getKubernetesResource = tool(getKubernetesResourceImpl, {
   name: "getKubernetesResource",
-  description: "Get a single Kubernetes resource by name (namespace required for namespaced kinds)",
+  description:
+    "Get a single Kubernetes resource by name (namespace required for namespaced kinds). " +
+    "metadata.managedFields is stripped by default to keep the output small.",
   schema: z.object({
     kind: kindSchema,
     apiVersion: apiVersionSchema,
     name: z.string().describe("The name of the resource"),
     namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
+    includeManagedFields: includeManagedFieldsSchema,
   }),
 });
 
@@ -296,17 +310,21 @@ export const toolFunctionDescriptions = [
     name: "listKubernetesResources",
     description: "List Kubernetes resources of a given kind, optionally scoped to a namespace",
     arguments:
-      "Requires the resource kind (string) and optionally the apiVersion (string) and namespace (string). Built-in kinds: " +
+      "Requires the resource kind (string) and optionally the apiVersion (string), namespace (string) and " +
+      "includeManagedFields (boolean; defaults to false). Built-in kinds: " +
       SUPPORTED_KINDS.join(", ") +
       "; any other kind (including CRDs) is accepted.",
-    returnType: "Returns a JSON string containing the matching resources.",
+    returnType:
+      "Returns a JSON string containing the matching resources, with metadata.managedFields stripped unless includeManagedFields is true.",
   },
   {
     name: "getKubernetesResource",
     description: "Get a single Kubernetes resource by name",
     arguments:
-      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string). Namespace (string) is required for namespaced kinds.",
-    returnType: "Returns a JSON string containing the requested resource.",
+      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string) and " +
+      "includeManagedFields (boolean; defaults to false). Namespace (string) is required for namespaced kinds.",
+    returnType:
+      "Returns a JSON string containing the requested resource, with metadata.managedFields stripped unless includeManagedFields is true.",
   },
   {
     name: "getPodLogs",


### PR DESCRIPTION
Strips the noisy `metadata.managedFields` block from `listKubernetesResources` and `getKubernetesResource` output by default, since it is server-side apply bookkeeping that is irrelevant for LLM analysis and wastes context. A new optional `includeManagedFields` flag (default false) opts back in when field ownership matters.

Adds a pure, unit-tested `stripManagedFields` helper and updates the tool schemas and descriptions.

The optional JSONPath idea from the issue is intentionally left for a follow-up.

Closes #229