### PR TITLE
Add JSONPath field filtering to list and get Kubernetes resource tools

### DIFF
--- a/src/renderer/business/agent/tools/field-filter.test.ts
+++ b/src/renderer/business/agent/tools/field-filter.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { buildFieldSelector, parseFieldPath } from "./field-filter";
+
+const pod = {
+  name: "nginx",
+  namespace: "default",
+  metadata: {
+    name: "nginx",
+    namespace: "default",
+    labels: { app: "nginx", "app.kubernetes.io/name": "nginx" },
+  },
+  spec: {
+    containers: [
+      { name: "nginx", image: "nginx:1.25" },
+      { name: "sidecar", image: "envoy:1.30" },
+    ],
+  },
+  status: { phase: "Running", podIP: "10.0.0.1" },
+};
+
+describe("buildFieldSelector", () => {
+  it("returns null when no fields are provided", () => {
+    expect(buildFieldSelector(undefined)).toBeNull();
+    expect(buildFieldSelector([])).toBeNull();
+  });
+
+  it("selects a single dot-notation field, preserving nesting", () => {
+    const select = buildFieldSelector([".metadata.name"]);
+    expect(select?.(pod)).toEqual({ metadata: { name: "nginx" } });
+  });
+
+  it("selects multiple fields into one merged object", () => {
+    const select = buildFieldSelector([".metadata.name", ".status.phase"]);
+    expect(select?.(pod)).toEqual({
+      metadata: { name: "nginx" },
+      status: { phase: "Running" },
+    });
+  });
+
+  it("supports top-level convenience fields", () => {
+    const select = buildFieldSelector([".name", ".namespace"]);
+    expect(select?.(pod)).toEqual({ name: "nginx", namespace: "default" });
+  });
+
+  it("expands a wildcard over array elements", () => {
+    const select = buildFieldSelector([".spec.containers[*].image"]);
+    expect(select?.(pod)).toEqual({
+      spec: { containers: [{ image: "nginx:1.25" }, { image: "envoy:1.30" }] },
+    });
+  });
+
+  it("selects an explicit array index", () => {
+    const select = buildFieldSelector([".spec.containers[0].name"]);
+    expect(select?.(pod)).toEqual({ spec: { containers: [{ name: "nginx" }] } });
+  });
+
+  it("supports a negative array index", () => {
+    const select = buildFieldSelector([".spec.containers[-1].name"]);
+    // Serialize to normalize the sparse array (the unmatched index 0 becomes null).
+    expect(JSON.parse(JSON.stringify(select?.(pod)))).toEqual({
+      spec: { containers: [null, { name: "sidecar" }] },
+    });
+  });
+
+  it("reads a bracketed quoted key with dots", () => {
+    const select = buildFieldSelector([".metadata.labels['app.kubernetes.io/name']"]);
+    expect(select?.(pod)).toEqual({
+      metadata: { labels: { "app.kubernetes.io/name": "nginx" } },
+    });
+  });
+
+  it("expands a wildcard over object keys", () => {
+    const select = buildFieldSelector([".status.*"]);
+    expect(select?.(pod)).toEqual({ status: { phase: "Running", podIP: "10.0.0.1" } });
+  });
+
+  it("tolerates kubectl-style wrapping braces and a leading $", () => {
+    const select = buildFieldSelector(["{.metadata.name}", "$.status.phase"]);
+    expect(select?.(pod)).toEqual({
+      metadata: { name: "nginx" },
+      status: { phase: "Running" },
+    });
+  });
+
+  it("tolerates a bare leading key without a dot", () => {
+    const select = buildFieldSelector(["metadata.name"]);
+    expect(select?.(pod)).toEqual({ metadata: { name: "nginx" } });
+  });
+
+  it("skips selectors that do not match anything", () => {
+    const select = buildFieldSelector([".metadata.name", ".spec.nonexistent.field"]);
+    expect(select?.(pod)).toEqual({ metadata: { name: "nginx" } });
+  });
+
+  it("does not mutate the source object", () => {
+    const select = buildFieldSelector([".metadata.name"]);
+    select?.(pod);
+    expect(pod.metadata.labels).toHaveProperty("app", "nginx");
+  });
+});
+
+describe("parseFieldPath", () => {
+  it("throws on an empty selector", () => {
+    expect(() => parseFieldPath("   ")).toThrow(/does not reference any field/);
+  });
+
+  it("throws on an unterminated bracket", () => {
+    expect(() => parseFieldPath(".spec.containers[0")).toThrow(/unterminated/);
+  });
+
+  it("throws on empty brackets", () => {
+    expect(() => parseFieldPath(".spec.containers[]")).toThrow(/empty/);
+  });
+
+  it("validates eagerly through buildFieldSelector", () => {
+    expect(() => buildFieldSelector([".metadata.name", "[bad"])).toThrow(/unterminated/);
+  });
+});

--- a/src/renderer/business/agent/tools/field-filter.ts
+++ b/src/renderer/business/agent/tools/field-filter.ts
@@ -1,0 +1,190 @@
+// Pure helpers to project a subset of fields out of a Kubernetes resource using
+// a JSONPath-style field selector (the kubectl `-o jsonpath` subset). Kept free
+// of host/MobX dependencies so they can be unit-tested directly (see
+// field-filter.test.ts).
+//
+// Supported selector syntax (relative to a single resource object):
+//   .metadata.name                         dot notation
+//   .spec.containers[*].image              wildcard over array elements
+//   .spec.containers[0].name               explicit array index
+//   .metadata.labels['app.kubernetes.io/name']  bracketed quoted key (dots in key)
+//   .status.*                              wildcard over object keys
+// Optional kubectl-style wrapping braces ({ ... }) and a leading `$` are
+// tolerated. The matched values are copied into a fresh object that preserves
+// the nested structure of the source, so the model can tell which field is which.
+
+type Segment = { type: "key"; key: string } | { type: "index"; index: number } | { type: "wildcard" };
+
+interface Match {
+  path: (string | number)[];
+  value: unknown;
+}
+
+/**
+ * Parse a single JSONPath-style selector into a flat list of segments. Throws an
+ * Error with a readable message when the selector is malformed so the caller can
+ * surface it to the model.
+ */
+export function parseFieldPath(raw: string): Segment[] {
+  let source = raw.trim();
+  if (source.startsWith("{") && source.endsWith("}")) {
+    source = source.slice(1, -1).trim();
+  }
+  if (source.startsWith("$")) {
+    source = source.slice(1);
+  }
+
+  const segments: Segment[] = [];
+  let i = 0;
+  while (i < source.length) {
+    const char = source[i];
+    if (char === ".") {
+      i++;
+      i = readDotSegment(source, i, segments);
+    } else if (char === "[") {
+      i = readBracketSegment(source, i, segments, raw);
+    } else {
+      // A bare leading key without a leading dot (e.g. "metadata.name").
+      i = readDotSegment(source, i, segments);
+    }
+  }
+
+  if (segments.length === 0) {
+    throw new Error(`Invalid field selector "${raw}": it does not reference any field.`);
+  }
+  return segments;
+}
+
+/**
+ * Read a dot-style key (or `*` wildcard) starting at `i`, pushing the resulting
+ * segment, and return the new cursor position.
+ */
+function readDotSegment(source: string, i: number, segments: Segment[]): number {
+  if (source[i] === "*") {
+    segments.push({ type: "wildcard" });
+    return i + 1;
+  }
+  let key = "";
+  while (i < source.length && source[i] !== "." && source[i] !== "[") {
+    key += source[i];
+    i++;
+  }
+  if (key === "*") {
+    segments.push({ type: "wildcard" });
+  } else if (key.length > 0) {
+    segments.push({ type: "key", key });
+  }
+  return i;
+}
+
+/**
+ * Read a bracket-style segment (`[*]`, `[0]`, `['key']`, `["key"]` or `[key]`)
+ * starting at the opening `[`, pushing the resulting segment, and return the new
+ * cursor position.
+ */
+function readBracketSegment(source: string, i: number, segments: Segment[], raw: string): number {
+  const end = source.indexOf("]", i);
+  if (end === -1) {
+    throw new Error(`Invalid field selector "${raw}": unterminated "[".`);
+  }
+  const inner = source.slice(i + 1, end).trim();
+  if (inner === "*") {
+    segments.push({ type: "wildcard" });
+  } else if ((inner.startsWith("'") && inner.endsWith("'")) || (inner.startsWith('"') && inner.endsWith('"'))) {
+    segments.push({ type: "key", key: inner.slice(1, -1) });
+  } else if (/^-?\d+$/.test(inner)) {
+    segments.push({ type: "index", index: Number(inner) });
+  } else if (inner.length > 0) {
+    segments.push({ type: "key", key: inner });
+  } else {
+    throw new Error(`Invalid field selector "${raw}": empty "[]".`);
+  }
+  return end + 1;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Resolve the concrete matches (path + value) of a parsed selector against a
+ * source object, expanding wildcards against the actual data.
+ */
+function resolveMatches(source: unknown, segments: Segment[]): Match[] {
+  let frontier: Match[] = [{ path: [], value: source }];
+  for (const segment of segments) {
+    const next: Match[] = [];
+    for (const node of frontier) {
+      const value = node.value;
+      if (value == null) {
+        continue;
+      }
+      if (segment.type === "key") {
+        if (isPlainObject(value) && Object.hasOwn(value, segment.key)) {
+          next.push({ path: [...node.path, segment.key], value: value[segment.key] });
+        }
+      } else if (segment.type === "index") {
+        if (Array.isArray(value)) {
+          const index = segment.index < 0 ? value.length + segment.index : segment.index;
+          if (index >= 0 && index < value.length) {
+            next.push({ path: [...node.path, index], value: value[index] });
+          }
+        }
+      } else {
+        if (Array.isArray(value)) {
+          value.forEach((element, index) => next.push({ path: [...node.path, index], value: element }));
+        } else if (isPlainObject(value)) {
+          for (const key of Object.keys(value)) {
+            next.push({ path: [...node.path, key], value: value[key] });
+          }
+        }
+      }
+    }
+    frontier = next;
+  }
+  return frontier;
+}
+
+/**
+ * Set `value` at `path` inside `target`, creating intermediate objects/arrays as
+ * needed. A numeric path segment creates an array, a string segment an object.
+ */
+function setPath(target: Record<string, unknown>, path: (string | number)[], value: unknown): void {
+  let cursor: Record<string, unknown> | unknown[] = target;
+  for (let i = 0; i < path.length - 1; i++) {
+    const key = path[i];
+    const nextKey = path[i + 1];
+    const container = cursor as Record<string | number, unknown>;
+    if (container[key] == null) {
+      container[key] = typeof nextKey === "number" ? [] : {};
+    }
+    cursor = container[key] as Record<string, unknown> | unknown[];
+  }
+  (cursor as Record<string | number, unknown>)[path[path.length - 1]] = value;
+}
+
+export type FieldSelector = (object: Record<string, unknown>) => Record<string, unknown>;
+
+/**
+ * Compile a list of JSONPath-style selectors into a reusable function that
+ * projects an object down to only the matched fields, preserving their nested
+ * structure. Returns `null` when no selectors are provided (meaning: keep the
+ * full object). Throws on a malformed selector so the caller can report it.
+ */
+export function buildFieldSelector(fields?: string[]): FieldSelector | null {
+  if (!fields || fields.length === 0) {
+    return null;
+  }
+  const parsed = fields.map((field) => parseFieldPath(field));
+  return (object) => {
+    const result: Record<string, unknown> = {};
+    for (const segments of parsed) {
+      for (const match of resolveMatches(object, segments)) {
+        if (match.path.length > 0) {
+          setPath(result, match.path, match.value);
+        }
+      }
+    }
+    return result;
+  };
+}

--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -3,6 +3,7 @@ import { interrupt } from "@langchain/langgraph";
 import { stringify as stringifyYaml } from "yaml";
 import { PreferencesStore } from "../../../../common/store";
 import { type KubernetesVersionInfo, summarizeClusterVersion } from "./cluster-version";
+import { buildFieldSelector } from "./field-filter";
 import {
   capLogOutput,
   capTailLines,
@@ -43,6 +44,9 @@ export interface ListResourceInput {
   // Server-side apply bookkeeping (`metadata.managedFields`) is stripped by
   // default to keep the output small; set this to opt back in when needed.
   includeManagedFields?: boolean;
+  // Optional JSONPath-style field selectors (the kubectl `-o jsonpath` subset)
+  // applied to each resource to trim the output to just the requested fields.
+  fields?: string[];
 }
 
 export interface GetResourceInput {
@@ -52,6 +56,8 @@ export interface GetResourceInput {
   namespace?: string;
   // See ListResourceInput.includeManagedFields.
   includeManagedFields?: boolean;
+  // See ListResourceInput.fields.
+  fields?: string[];
 }
 
 export interface CreateResourceInput {
@@ -267,18 +273,26 @@ export async function listKubernetesResources({
   apiVersion,
   namespace,
   includeManagedFields,
+  fields,
 }: ListResourceInput): Promise<string> {
   console.log("[Tool invocation: listKubernetesResources] - kind:", kind, "namespace:", namespace);
   const target = resolveTarget(kind, apiVersion);
   if (typeof target === "string") {
     return target;
   }
+  let select: ReturnType<typeof buildFieldSelector>;
+  try {
+    select = buildFieldSelector(fields);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
   const { api, store } = target;
   try {
     const scoped = api.isNamespaced && namespace ? [namespace] : undefined;
     const loaded = await store.loadAll(scoped ? { namespaces: scoped } : {});
     const items = loaded ?? (scoped ? store.getAllByNs(namespace as string) : store.items.toJSON());
-    return JSON.stringify(items.map((item) => projectObject(item, includeManagedFields)));
+    const projected = items.map((item) => projectObject(item, includeManagedFields));
+    return JSON.stringify(select ? projected.map(select) : projected);
   } catch (error) {
     console.error("[Tool invocation error: listKubernetesResources] - ", error);
     return JSON.stringify(error);
@@ -295,6 +309,7 @@ export async function getKubernetesResource({
   name,
   namespace,
   includeManagedFields,
+  fields,
 }: GetResourceInput): Promise<string> {
   console.log("[Tool invocation: getKubernetesResource] - kind:", kind, "name:", name, "namespace:", namespace);
   const target = resolveTarget(kind, apiVersion);
@@ -305,12 +320,19 @@ export async function getKubernetesResource({
   if (api.isNamespaced && !namespace) {
     return `Kind "${kind}" is namespaced; please provide a namespace to get "${name}".`;
   }
+  let select: ReturnType<typeof buildFieldSelector>;
+  try {
+    select = buildFieldSelector(fields);
+  } catch (error) {
+    return error instanceof Error ? error.message : String(error);
+  }
   try {
     const object = await store.load({ name, namespace: api.isNamespaced ? namespace : undefined });
     if (!object) {
       return `The ${kind} "${name}" was not found.`;
     }
-    return JSON.stringify(projectObject(object, includeManagedFields));
+    const projected = projectObject(object, includeManagedFields);
+    return JSON.stringify(select ? select(projected) : projected);
   } catch (error) {
     console.error("[Tool invocation error: getKubernetesResource] - ", error);
     return JSON.stringify(error);

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -35,6 +35,17 @@ const includeManagedFieldsSchema = z
       "bookkeeping is large and irrelevant for analysis, so it is stripped to save context. Set to true only " +
       "when you specifically need to inspect field ownership.",
   );
+const fieldsSchema = z
+  .array(z.string())
+  .optional()
+  .describe(
+    "Optional list of JSONPath-style field selectors (the kubectl `-o jsonpath` subset) applied to each " +
+      "returned resource to trim the output to only the fields you need, instead of the full and often verbose " +
+      "object. Each selector is relative to a single resource and the result keeps the nested structure of the " +
+      'matched fields. Examples: ".metadata.name", ".status.phase", ".spec.containers[*].image", ' +
+      '".metadata.labels[\'app.kubernetes.io/name\']", ".spec.containers[0].name". ' +
+      "Omit to return the full resource.",
+  );
 const subresourceSchema = z
   .string()
   .optional()
@@ -117,12 +128,15 @@ export const listKubernetesResources = tool(listKubernetesResourcesImpl, {
   name: "listKubernetesResources",
   description:
     "List Kubernetes resources of a given kind, optionally scoped to a namespace. " +
-    "metadata.managedFields is stripped by default to keep the output small.",
+    "metadata.managedFields is stripped by default to keep the output small. " +
+    'Pass "fields" with JSONPath-style selectors (e.g. [".metadata.name", ".status.phase"]) to return only ' +
+    "a subset of each resource instead of the full, verbose object.",
   schema: z.object({
     kind: kindSchema,
     apiVersion: apiVersionSchema,
     namespace: z.string().optional().describe("The namespace to list namespaced resources in"),
     includeManagedFields: includeManagedFieldsSchema,
+    fields: fieldsSchema,
   }),
 });
 
@@ -130,13 +144,16 @@ export const getKubernetesResource = tool(getKubernetesResourceImpl, {
   name: "getKubernetesResource",
   description:
     "Get a single Kubernetes resource by name (namespace required for namespaced kinds). " +
-    "metadata.managedFields is stripped by default to keep the output small.",
+    "metadata.managedFields is stripped by default to keep the output small. " +
+    'Pass "fields" with JSONPath-style selectors (e.g. [".status.phase", ".spec.containers[*].image"]) to ' +
+    "return only a subset of the resource instead of the full, verbose object.",
   schema: z.object({
     kind: kindSchema,
     apiVersion: apiVersionSchema,
     name: z.string().describe("The name of the resource"),
     namespace: z.string().optional().describe("The namespace of the resource (required for namespaced kinds)"),
     includeManagedFields: includeManagedFieldsSchema,
+    fields: fieldsSchema,
   }),
 });
 
@@ -310,21 +327,26 @@ export const toolFunctionDescriptions = [
     name: "listKubernetesResources",
     description: "List Kubernetes resources of a given kind, optionally scoped to a namespace",
     arguments:
-      "Requires the resource kind (string) and optionally the apiVersion (string), namespace (string) and " +
-      "includeManagedFields (boolean; defaults to false). Built-in kinds: " +
+      "Requires the resource kind (string) and optionally the apiVersion (string), namespace (string), " +
+      "includeManagedFields (boolean; defaults to false) and fields (array of JSONPath-style selectors to " +
+      "trim each resource to a subset, the kubectl `-o jsonpath` subset). Built-in kinds: " +
       SUPPORTED_KINDS.join(", ") +
       "; any other kind (including CRDs) is accepted.",
     returnType:
-      "Returns a JSON string containing the matching resources, with metadata.managedFields stripped unless includeManagedFields is true.",
+      "Returns a JSON string containing the matching resources, with metadata.managedFields stripped unless " +
+      "includeManagedFields is true, and limited to the selected fields when fields is provided.",
   },
   {
     name: "getKubernetesResource",
     description: "Get a single Kubernetes resource by name",
     arguments:
-      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string) and " +
-      "includeManagedFields (boolean; defaults to false). Namespace (string) is required for namespaced kinds.",
+      "Requires the resource kind (string) and name (string), and optionally the apiVersion (string), " +
+      "includeManagedFields (boolean; defaults to false) and fields (array of JSONPath-style selectors to " +
+      "trim the resource to a subset, the kubectl `-o jsonpath` subset). Namespace (string) is required for " +
+      "namespaced kinds.",
     returnType:
-      "Returns a JSON string containing the requested resource, with metadata.managedFields stripped unless includeManagedFields is true.",
+      "Returns a JSON string containing the requested resource, with metadata.managedFields stripped unless " +
+      "includeManagedFields is true, and limited to the selected fields when fields is provided.",
   },
   {
     name: "getPodLogs",


### PR DESCRIPTION
Adds an optional `fields` parameter (JSONPath-style selectors, the kubectl `-o jsonpath` subset) to `listKubernetesResources` and `getKubernetesResource` so the model can request only a subset of each resource instead of the full, verbose object.

Closes #231