### PR TITLE
Add regex filter parameter to the pod logs tool

### DIFF
--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -8,8 +8,11 @@ import {
   capLogOutput,
   capTailLines,
   collectContainerNames,
+  compileLogFilter,
   emptyLogsMessage,
+  filterLogLines,
   type GetPodLogsInput,
+  noMatchingLogsMessage,
   resolveContainer,
 } from "./pod-logs";
 import { stripManagedFields } from "./project-resource";
@@ -699,6 +702,13 @@ export async function getPodLogs(input: GetPodLogsInput): Promise<string> {
     return `Pods are namespaced; please provide a namespace to read logs for "${name}".`;
   }
 
+  // Compile the optional regex filter up front so an invalid expression is
+  // reported before the pod is loaded or its logs are fetched.
+  const filterResolution = compileLogFilter(input.filter);
+  if (filterResolution.kind === "error") {
+    return filterResolution.message;
+  }
+
   const podsApi = Renderer.K8sApi.podsApi;
   const store = Renderer.K8sApi.apiManager.getStore(podsApi);
   if (!store) {
@@ -739,6 +749,13 @@ export async function getPodLogs(input: GetPodLogsInput): Promise<string> {
     );
     if (!logs || logs.trim().length === 0) {
       return emptyLogsMessage(selectedContainer, name, previous);
+    }
+    if (filterResolution.kind === "regex") {
+      const filtered = filterLogLines(logs, filterResolution.regex);
+      if (filtered.trim().length === 0) {
+        return noMatchingLogsMessage(selectedContainer, name, input.filter as string);
+      }
+      return capLogOutput(filtered);
     }
     return capLogOutput(logs);
   } catch (error) {

--- a/src/renderer/business/agent/tools/pod-logs.test.ts
+++ b/src/renderer/business/agent/tools/pod-logs.test.ts
@@ -3,6 +3,8 @@ import {
   capLogOutput,
   capTailLines,
   collectContainerNames,
+  compileLogFilter,
+  filterLogLines,
   MAX_TAIL_LINES,
   resolveContainer,
   TRUNCATION_MARKER,
@@ -113,5 +115,45 @@ describe("capLogOutput", () => {
     const logs = "€".repeat(10);
     const result = capLogOutput(logs, 12);
     expect(result.startsWith(TRUNCATION_MARKER)).toBe(true);
+  });
+});
+
+describe("compileLogFilter", () => {
+  it("disables filtering for an omitted or empty pattern", () => {
+    expect(compileLogFilter(undefined)).toEqual({ kind: "none" });
+    expect(compileLogFilter("")).toEqual({ kind: "none" });
+  });
+
+  it("compiles a valid pattern into a RegExp", () => {
+    const result = compileLogFilter("error|warn");
+    expect(result.kind).toBe("regex");
+    expect(result.kind === "regex" && result.regex.test("an error happened")).toBe(true);
+    expect(result.kind === "regex" && result.regex.test("all good")).toBe(false);
+  });
+
+  it("reports an invalid pattern instead of throwing", () => {
+    const result = compileLogFilter("(unclosed");
+    expect(result.kind).toBe("error");
+    expect(result.kind === "error" && result.message).toContain("(unclosed");
+  });
+});
+
+describe("filterLogLines", () => {
+  it("keeps only matching lines", () => {
+    const logs = "info: started\nerror: boom\ninfo: ok\nwarn: careful\n";
+    expect(filterLogLines(logs, /error|warn/)).toBe("error: boom\nwarn: careful\n");
+  });
+
+  it("preserves the absence of a trailing newline", () => {
+    const logs = "error: a\ninfo: b\nerror: c";
+    expect(filterLogLines(logs, /error/)).toBe("error: a\nerror: c");
+  });
+
+  it("returns an empty string when nothing matches", () => {
+    expect(filterLogLines("info: a\ninfo: b\n", /error/)).toBe("");
+  });
+
+  it("does not emit a blank line for the trailing newline", () => {
+    expect(filterLogLines("match\n", /^/)).toBe("match\n");
   });
 });

--- a/src/renderer/business/agent/tools/pod-logs.ts
+++ b/src/renderer/business/agent/tools/pod-logs.ts
@@ -5,6 +5,7 @@ export interface GetPodLogsInput {
   previous?: boolean;
   tailLines?: number;
   timestamps?: boolean;
+  filter?: string;
 }
 
 // Hard cap on the bytes returned to the model so a chatty pod cannot overflow
@@ -113,4 +114,52 @@ export function emptyLogsMessage(container: string, name: string, previous: bool
   return previous
     ? `No previous logs for container "${container}" in pod "${name}". The container may not have a terminated instance.`
     : `No logs for container "${container}" in pod "${name}". The container may not have started yet; try previous: true to read the last terminated instance.`;
+}
+
+export type LogFilterResolution =
+  | { kind: "none" }
+  | { kind: "regex"; regex: RegExp }
+  | { kind: "error"; message: string };
+
+/**
+ * Compile the optional log-line filter into a RegExp. An empty/omitted pattern
+ * disables filtering; an invalid pattern is reported back to the model instead
+ * of throwing so it can correct the expression.
+ */
+export function compileLogFilter(pattern: string | undefined): LogFilterResolution {
+  if (pattern === undefined || pattern === "") {
+    return { kind: "none" };
+  }
+  try {
+    return { kind: "regex", regex: new RegExp(pattern) };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    return { kind: "error", message: `Invalid filter regular expression "${pattern}": ${reason}` };
+  }
+}
+
+/**
+ * Keep only the log lines matching the regex (grep-style). A trailing newline
+ * on the input is preserved on the output so the result still reads like a log.
+ */
+export function filterLogLines(logs: string, regex: RegExp): string {
+  const hadTrailingNewline = logs.endsWith("\n");
+  const lines = logs.split("\n");
+  if (hadTrailingNewline) {
+    // Drop the empty element produced by the trailing newline so it is not
+    // tested against the filter or re-emitted as a blank line.
+    lines.pop();
+  }
+  const matched = lines.filter((line) => regex.test(line));
+  if (matched.length === 0) {
+    return "";
+  }
+  return matched.join("\n") + (hadTrailingNewline ? "\n" : "");
+}
+
+/**
+ * Build the message returned when a filter was applied but no log line matched.
+ */
+export function noMatchingLogsMessage(container: string, name: string, filter: string): string {
+  return `No log lines for container "${container}" in pod "${name}" matched the filter /${filter}/.`;
 }

--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -204,7 +204,7 @@ export const patchKubernetesResource = tool(patchKubernetesResourceImpl, {
 export const getPodLogs = tool(getPodLogsImpl, {
   name: "getPodLogs",
   description:
-    "Read a one-shot snapshot of container logs from a pod. Namespace is required. If the container is omitted on a multi-container pod, the available containers are returned so one can be chosen. Use previous: true to read the last terminated instance (useful for CrashLoopBackOff).",
+    "Read a one-shot snapshot of container logs from a pod. Namespace is required. If the container is omitted on a multi-container pod, the available containers are returned so one can be chosen. Use previous: true to read the last terminated instance (useful for CrashLoopBackOff). Pass filter with a regular expression to return only matching log lines (grep-style).",
   schema: z.object({
     name: z.string().describe("The name of the pod"),
     namespace: z.string().describe("The namespace of the pod"),
@@ -221,6 +221,14 @@ export const getPodLogs = tool(getPodLogsImpl, {
       .optional()
       .describe("Number of lines from the end of the logs to read (defaults to the preference value)"),
     timestamps: z.boolean().optional().describe("Prefix every log line with an RFC3339 timestamp"),
+    filter: z
+      .string()
+      .optional()
+      .describe(
+        "Optional JavaScript regular expression used to keep only the log lines that match it (grep-style). " +
+          "Applied after tailLines and before any truncation. The match is case-sensitive and unanchored, " +
+          'e.g. "error|warn" keeps lines mentioning error or warn. Omit to return every line.',
+      ),
   }),
 });
 
@@ -352,9 +360,9 @@ export const toolFunctionDescriptions = [
     name: "getPodLogs",
     description: "Read a one-shot snapshot of container logs from a pod",
     arguments:
-      "Requires the pod name (string) and namespace (string), and optionally the container (string; required only for multi-container pods), previous (boolean, for terminated instances), tailLines (number) and timestamps (boolean).",
+      "Requires the pod name (string) and namespace (string), and optionally the container (string; required only for multi-container pods), previous (boolean, for terminated instances), tailLines (number), timestamps (boolean) and filter (string; a regular expression that keeps only matching log lines, grep-style).",
     returnType:
-      "Returns the (possibly truncated) container logs as a string, or the list of containers to choose from for multi-container pods.",
+      "Returns the (possibly truncated and filtered) container logs as a string, or the list of containers to choose from for multi-container pods.",
   },
   {
     name: "createKubernetesResource",


### PR DESCRIPTION
Adds an optional `filter` regular-expression parameter to the `getPodLogs` tool so only matching log lines are returned (grep-style).

Closes #233
