### PR TITLE
Encourage regexp log filtering before a full log scan

### DIFF
--- a/src/renderer/business/agent/tools/tools.ts
+++ b/src/renderer/business/agent/tools/tools.ts
@@ -204,7 +204,7 @@ export const patchKubernetesResource = tool(patchKubernetesResourceImpl, {
 export const getPodLogs = tool(getPodLogsImpl, {
   name: "getPodLogs",
   description:
-    "Read a one-shot snapshot of container logs from a pod. Namespace is required. If the container is omitted on a multi-container pod, the available containers are returned so one can be chosen. Use previous: true to read the last terminated instance (useful for CrashLoopBackOff). Pass filter with a regular expression to return only matching log lines (grep-style).",
+    "Read a one-shot snapshot of container logs from a pod. Namespace is required. If the container is omitted on a multi-container pod, the available containers are returned so one can be chosen. Use previous: true to read the last terminated instance (useful for CrashLoopBackOff). When you are looking for specific log content (errors, warnings, a keyword or pattern) PREFER passing filter with a regular expression to return only the matching lines (grep-style) instead of fetching the whole log and scanning it; read the full, unfiltered log only when the user asks for everything or a filtered read finds nothing.",
   schema: z.object({
     name: z.string().describe("The name of the pod"),
     namespace: z.string().describe("The namespace of the pod"),
@@ -226,8 +226,11 @@ export const getPodLogs = tool(getPodLogsImpl, {
       .optional()
       .describe(
         "Optional JavaScript regular expression used to keep only the log lines that match it (grep-style). " +
+          "Prefer setting this whenever the goal is to find specific content (errors, warnings, a keyword or " +
+          "pattern) so chatty logs are narrowed before they reach the model, instead of fetching every line. " +
           "Applied after tailLines and before any truncation. The match is case-sensitive and unanchored, " +
-          'e.g. "error|warn" keeps lines mentioning error or warn. Omit to return every line.',
+          'e.g. "error|err|fatal|panic" keeps lines mentioning those terms; add casing variants when case may ' +
+          "differ. Omit to return every line.",
       ),
   }),
 });
@@ -360,7 +363,7 @@ export const toolFunctionDescriptions = [
     name: "getPodLogs",
     description: "Read a one-shot snapshot of container logs from a pod",
     arguments:
-      "Requires the pod name (string) and namespace (string), and optionally the container (string; required only for multi-container pods), previous (boolean, for terminated instances), tailLines (number), timestamps (boolean) and filter (string; a regular expression that keeps only matching log lines, grep-style).",
+      "Requires the pod name (string) and namespace (string), and optionally the container (string; required only for multi-container pods), previous (boolean, for terminated instances), tailLines (number), timestamps (boolean) and filter (string; a regular expression that keeps only matching log lines, grep-style - prefer it when searching for specific content such as errors or warnings instead of reading the whole log).",
     returnType:
       "Returns the (possibly truncated and filtered) container logs as a string, or the list of containers to choose from for multi-container pods.",
   },

--- a/src/renderer/business/provider/prompt-template-provider.ts
+++ b/src/renderer/business/provider/prompt-template-provider.ts
@@ -35,6 +35,14 @@ You should assist with:
 - Diagnosing issues and providing solutions
 - Suggesting best practices and improvements
 
+<log_reading>
+When a request targets specific log content rather than the whole log - for example "check errors in the pod log", "find timeouts", "is there an OOM", or anything mentioning a keyword, level, or pattern - prefer narrowing the logs with getPodLogs's "filter" parameter (a regular expression applied grep-style) instead of pulling every line and scanning it yourself. This keeps chatty logs out of the context and focuses the analysis on the relevant lines.
+- Build the filter from the user's intent, e.g. "error|err|fatal|panic|exception" for errors, "warn|warning" for warnings, or the exact term the user named.
+- The regex is case-sensitive and unanchored, so add explicit alternatives or "(?i)"-style casing variants when case may differ (e.g. "Error|ERROR|error").
+- Only fall back to reading the full, unfiltered log when the user explicitly asks for everything, when a filtered read returns no matching lines and you need broader context, or when the relevant pattern is genuinely unknown.
+- Mention to the user that you filtered the logs and with which expression, so they can broaden it if needed.
+</log_reading>
+
 <tool_calling>
 You have tools at your disposal to solve the coding task. Follow these rules regarding tool calls:
 1. ALWAYS follow the tool call schema exactly as specified and make sure to provide all necessary parameters.


### PR DESCRIPTION
Targeted prompts like "check errors in the pod log" should narrow the logs with the `getPodLogs` `filter` parameter (grep-style regexp) instead of fetching every line and scanning it.

Adds a `<log_reading>` guidance block to the analyzer agent system prompt and strengthens the `getPodLogs` tool and `filter` parameter descriptions to prefer filtering for content searches, falling back to the full log only when needed.

Closes #233