### PR TITLE
Treat "previous terminated container not found" as expected, not a tool error

### DIFF
--- a/src/renderer/business/agent/tools/kubernetes-resource.ts
+++ b/src/renderer/business/agent/tools/kubernetes-resource.ts
@@ -12,6 +12,7 @@ import {
   emptyLogsMessage,
   filterLogLines,
   type GetPodLogsInput,
+  isPreviousContainerNotFoundError,
   noMatchingLogsMessage,
   resolveContainer,
 } from "./pod-logs";
@@ -759,6 +760,13 @@ export async function getPodLogs(input: GetPodLogsInput): Promise<string> {
     }
     return capLogOutput(logs);
   } catch (error) {
+    // A "previous terminated container ... not found" response is expected when
+    // previous: true is requested but the container has never terminated. Treat
+    // it as a normal "no previous logs" result so the model does not report it
+    // as a tool error.
+    if (isPreviousContainerNotFoundError(error)) {
+      return emptyLogsMessage(selectedContainer, name, previous);
+    }
     console.error("[Tool invocation error: getPodLogs] - ", error);
     return JSON.stringify(error);
   }

--- a/src/renderer/business/agent/tools/pod-logs.test.ts
+++ b/src/renderer/business/agent/tools/pod-logs.test.ts
@@ -4,7 +4,9 @@ import {
   capTailLines,
   collectContainerNames,
   compileLogFilter,
+  errorToText,
   filterLogLines,
+  isPreviousContainerNotFoundError,
   MAX_TAIL_LINES,
   resolveContainer,
   TRUNCATION_MARKER,
@@ -155,5 +157,49 @@ describe("filterLogLines", () => {
 
   it("does not emit a blank line for the trailing newline", () => {
     expect(filterLogLines("match\n", /^/)).toBe("match\n");
+  });
+});
+
+describe("errorToText", () => {
+  it("returns a string error unchanged", () => {
+    expect(errorToText("boom")).toBe("boom");
+  });
+
+  it("reads the message from an Error instance", () => {
+    expect(errorToText(new Error("the failure"))).toBe("the failure");
+  });
+
+  it("reads the message from a Kubernetes API error object", () => {
+    expect(errorToText({ code: 400, message: "bad request" })).toBe("bad request");
+  });
+
+  it("JSON-encodes an object without a message", () => {
+    expect(errorToText({ code: 404 })).toBe('{"code":404}');
+  });
+});
+
+describe("isPreviousContainerNotFoundError", () => {
+  it("detects the API message on an Error instance", () => {
+    const error = new Error('previous terminated container "app" in pod "web" not found');
+    expect(isPreviousContainerNotFoundError(error)).toBe(true);
+  });
+
+  it("detects the API message on a Kubernetes error object", () => {
+    const error = { code: 400, message: 'previous terminated container "app" in pod "web" not found' };
+    expect(isPreviousContainerNotFoundError(error)).toBe(true);
+  });
+
+  it("detects the API message on a plain string", () => {
+    expect(isPreviousContainerNotFoundError("previous terminated container not found")).toBe(true);
+  });
+
+  it("is case-insensitive", () => {
+    expect(isPreviousContainerNotFoundError("Previous Terminated Container ... NOT FOUND")).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isPreviousContainerNotFoundError(new Error("container not found"))).toBe(false);
+    expect(isPreviousContainerNotFoundError(new Error("connection refused"))).toBe(false);
+    expect(isPreviousContainerNotFoundError({ code: 500 })).toBe(false);
   });
 });

--- a/src/renderer/business/agent/tools/pod-logs.ts
+++ b/src/renderer/business/agent/tools/pod-logs.ts
@@ -163,3 +163,42 @@ export function filterLogLines(logs: string, regex: RegExp): string {
 export function noMatchingLogsMessage(container: string, name: string, filter: string): string {
   return `No log lines for container "${container}" in pod "${name}" matched the filter /${filter}/.`;
 }
+
+/**
+ * Reduce an unknown thrown value to a searchable string so callers can pattern
+ * match on the underlying server message. Covers Error instances, Kubernetes
+ * API error objects (which carry the server message on `message`), plain
+ * strings, and arbitrary objects (JSON-encoded as a last resort).
+ */
+export function errorToText(error: unknown): string {
+  if (typeof error === "string") {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (error && typeof error === "object") {
+    const message = (error as { message?: unknown }).message;
+    if (typeof message === "string" && message.length > 0) {
+      return message;
+    }
+    try {
+      return JSON.stringify(error);
+    } catch {
+      return String(error);
+    }
+  }
+  return String(error);
+}
+
+/**
+ * Detect the Kubernetes "previous terminated container ... not found" response.
+ * The API returns this when previous: true is requested but the container has
+ * never terminated/restarted. It is an expected, benign situation (there simply
+ * is no prior instance) rather than a tool failure, so the caller surfaces it as
+ * a normal "no previous logs" result instead of a raw error.
+ */
+export function isPreviousContainerNotFoundError(error: unknown): boolean {
+  const text = errorToText(error).toLowerCase();
+  return text.includes("previous terminated container") && text.includes("not found");
+}


### PR DESCRIPTION
Fixes #237.

When `getPodLogs` is called with `previous: true` and the container has never terminated, the Kubernetes API returns a "previous terminated container ... not found" error. This was returned as a raw JSON error and reported by the LLM as a tool failure. It is now detected and surfaced as the normal "no previous logs" result.
