### PR TITLE
Do not forward Content-Encoding from decoded proxied responses

### DIFF
--- a/src/main/ai-proxy-server.test.ts
+++ b/src/main/ai-proxy-server.test.ts
@@ -1,6 +1,12 @@
-import { describe, expect, it } from "vitest";
-import { applyCorsHeaders, applyManagedAuthorization } from "./ai-proxy-server";
-import type { ServerResponse } from "node:http";
+import { request as httpRequest } from "node:http";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import {
+  applyCorsHeaders,
+  applyManagedAuthorization,
+  isForwardableResponseHeader,
+  startAiProxyServer,
+} from "./ai-proxy-server";
+import type { IncomingHttpHeaders, ServerResponse } from "node:http";
 
 // Minimal ServerResponse stand-in that records setHeader calls.
 const createResponseStub = () => {
@@ -52,5 +58,108 @@ describe("applyManagedAuthorization", () => {
     const headers = new Headers({ authorization: "Bearer placeholder" });
     applyManagedAuthorization(headers, undefined);
     expect(headers.get("authorization")).toBe("Bearer placeholder");
+  });
+});
+
+describe("isForwardableResponseHeader", () => {
+  it("drops content-encoding, which no longer describes the decoded body", () => {
+    expect(isForwardableResponseHeader("content-encoding")).toBe(false);
+    expect(isForwardableResponseHeader("Content-Encoding")).toBe(false);
+  });
+
+  it("drops hop-by-hop headers", () => {
+    for (const header of ["connection", "content-length", "keep-alive", "transfer-encoding", "upgrade"]) {
+      expect(isForwardableResponseHeader(header)).toBe(false);
+    }
+  });
+
+  it("forwards ordinary response headers", () => {
+    for (const header of ["content-type", "cache-control", "etag", "x-request-id"]) {
+      expect(isForwardableResponseHeader(header)).toBe(true);
+    }
+  });
+});
+
+const PROXY_TOKEN = "test-proxy-token";
+
+interface ProxiedResponse {
+  statusCode: number | undefined;
+  headers: IncomingHttpHeaders;
+  body: string;
+}
+
+// Real HTTP call against the proxy, so the assertions cover the headers the
+// server actually puts on the wire.
+const requestThroughProxy = (port: number, path: string) =>
+  new Promise<ProxiedResponse>((resolve, reject) => {
+    const clientRequest = httpRequest(
+      {
+        host: "127.0.0.1",
+        port,
+        path,
+        method: "GET",
+        headers: {
+          "x-ai-proxy-token": PROXY_TOKEN,
+          "x-ai-proxy-no-auth": "1",
+        },
+      },
+      (incoming) => {
+        let body = "";
+        incoming.setEncoding("utf8");
+        incoming.on("data", (chunk) => {
+          body += chunk;
+        });
+        incoming.on("end", () => {
+          resolve({ statusCode: incoming.statusCode, headers: incoming.headers, body });
+        });
+      },
+    );
+
+    clientRequest.on("error", reject);
+    clientRequest.end();
+  });
+
+describe("proxied response headers", () => {
+  const upstreamBody = JSON.stringify({ "gpt-5.5": { input_cost_per_token: 0.00000125 } });
+  let proxyPort: number;
+
+  beforeAll(async () => {
+    const port = await startAiProxyServer(PROXY_TOKEN);
+
+    if (port === null) {
+      throw new Error("The AI proxy server did not report a port.");
+    }
+
+    proxyPort = port;
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("serves the decoded body without the upstream content-encoding", async () => {
+    // What undici hands back: the body is already decompressed, but the
+    // content-encoding of the wire format is still on the headers.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(upstreamBody, {
+            status: 200,
+            headers: {
+              "content-encoding": "gzip",
+              "content-type": "application/json",
+            },
+          }),
+      ),
+    );
+
+    const response = await requestThroughProxy(proxyPort, "/litellm/model_prices.json");
+
+    expect(response.statusCode).toBe(200);
+    expect(response.body).toBe(upstreamBody);
+    // Dropped: the renderer would otherwise fail with ERR_CONTENT_DECODING_FAILED.
+    expect(response.headers["content-encoding"]).toBeUndefined();
+    expect(response.headers["content-type"]).toBe("application/json");
   });
 });

--- a/src/main/ai-proxy-server.ts
+++ b/src/main/ai-proxy-server.ts
@@ -60,6 +60,24 @@ const hopByHopHeaders = new Set([
   "upgrade",
 ]);
 
+// Response headers that stop describing the body once it has been read through
+// `fetch`: undici transparently decodes gzip/br/deflate response bodies, so what
+// we pipe back is already plain text. Forwarding the upstream `content-encoding`
+// (like `content-length`, dropped above as hop-by-hop) makes the renderer decode
+// an already decoded body and fail with ERR_CONTENT_DECODING_FAILED, which broke
+// the LiteLLM price list fetch behind the cost estimate.
+const decodedBodyHeaders = new Set(["content-encoding"]);
+
+// Pure predicate telling whether an upstream RESPONSE header can be copied
+// verbatim to the proxied response. Request headers use a different filter (see
+// createUpstreamHeaders): a client-sent `content-encoding` describes a request
+// body we forward untouched and must still reach the upstream.
+export const isForwardableResponseHeader = (name: string): boolean => {
+  const key = name.toLowerCase();
+
+  return !hopByHopHeaders.has(key) && !decodedBodyHeaders.has(key);
+};
+
 // Normalize the possibly-array Origin header to a single value.
 const getRequestOrigin = (request: IncomingMessage): string | undefined => {
   const origin = request.headers.origin;
@@ -171,7 +189,7 @@ const proxyRequest = async (request: IncomingMessage, response: ServerResponse) 
   applyCorsHeaders(response, getRequestOrigin(request));
 
   upstreamResponse.headers.forEach((value, key) => {
-    if (!hopByHopHeaders.has(key)) {
+    if (isForwardableResponseHeader(key)) {
       response.setHeader(key, value);
     }
   });


### PR DESCRIPTION
Fixes #272.

Node's fetch (undici) transparently decompresses gzip upstream responses but keeps `content-encoding` in the response headers. The proxy copied that header onto the already-decoded body it pipes back to the renderer, so Chromium failed with `ERR_CONTENT_DECODING_FAILED` on every compressed upstream response. In the default OpenAI configuration the public LiteLLM price list is the only price source, so the per-session cost estimate never rendered.

The response-header copy now goes through a pure `isForwardableResponseHeader` predicate that excludes `content-encoding` alongside the hop-by-hop set, for the same reason `content-length` was already excluded: after undici's transparent decode, neither header describes the piped body. Request-side header forwarding is unchanged, so a client-sent `content-encoding` describing a request body still reaches the upstream.

Tests: four new cases in `ai-proxy-server.test.ts`, including a server-level regression test that stubs `global.fetch` to return a decoded body still labelled `content-encoding: gzip` and asserts the proxied response drops the header while preserving `content-type` (verified to fail against the previous code).

Validation: biome, type:check, 314 unit tests and build all green.
