### PR TITLE
Document Ollama usage, endpoint switching and fix the build guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ automate complex tasks and enhance productivity.
 **Quick Links:**
 
 - [Install](#install)
-- [How to obtain a Google API Key](./docs/GOOGLE_API_KEY.md)
+- [How to obtain a Google API Key](./docs/GOOGLE_API_KEY.md) (provider
+  temporarily disabled)
 - [Build & Run Guide](./docs/BUILD.md)
 
 ---
@@ -36,6 +37,7 @@ automate complex tasks and enhance productivity.
   - [Available Models](#available-models)
     - [Using other providers through an OpenAI-compatible gateway](#using-other-providers-through-an-openai-compatible-gateway)
     - [DeepSeek and other "thinking" models](#deepseek-and-other-thinking-models)
+    - [Ollama](#ollama)
     - [Connecting a model](#connecting-a-model)
     - [Key Features](#key-features)
     - [Base Agent](#base-agent)
@@ -141,6 +143,30 @@ applies automatically based on the model name:
   structured output. If you hit a `Thinking mode does not support this
   tool_choice` error, enable **Disable thinking mode** in the OpenAI preferences.
 
+### Ollama
+[Ollama](https://ollama.com) exposes a natively OpenAI-compatible endpoint, so
+no gateway is needed to reach a model running on your own machine.
+
+To connect it:
+
+- Set the **Base URL** in the OpenAI section of the preferences to
+  `http://localhost:11434/v1`.
+- Set any non-empty **API key**. Ollama ignores its value, but a key must be set
+  for the models to appear in the chat.
+- Add the exact model name, **including its tag** (for example `llama3.2:3b`, as
+  shown by `ollama list`), to the editable model list.
+
+The model must support **tool calling**: the agent drives every cluster
+operation through tools, so a model without tool support cannot be used. Models
+with a "thinking" mode may need the handling described in [DeepSeek and other
+"thinking" models](#deepseek-and-other-thinking-models).
+
+No pricing data is available for local models, so the cost estimate stays hidden
+and only the token counter is shown.
+
+On networks with TLS inspection, the first `ollama pull` may need the corporate
+root certificate to be trusted by Ollama's environment.
+
 ### Connecting a model
 Open the preferences page and, in the OpenAI section, set your API key and
 (optionally) a custom base URL. You can also provide the key through an
@@ -151,6 +177,12 @@ environment variable instead:
 A model is only offered in the chat dropdown once its provider has a key set; if
 no model is available, the chat shows a button that takes you to the preferences
 page.
+
+The **Base URL** is a single global setting: every configured model is requested
+from that endpoint, so switching between a cloud provider and a local one means
+changing the Base URL. If you alternate between them regularly, put a gateway
+such as [LiteLLM](https://github.com/BerriAI/litellm) in front of the extension
+and keep one fixed URL, with the models routed by name.
 
 ---
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,6 +1,6 @@
 # Build guide
 
-This guide will help you build the project to create the tgz file or run the server localy.
+This guide will help you build the project, create the tgz file, and run the extension in Freelens.
 
 ## Index
 
@@ -9,8 +9,8 @@ This guide will help you build the project to create the tgz file or run the ser
     - [Prerequisites](#prerequisites)
     - [Install dependencies](#install-dependencies)
     - [Build the project](#build-the-project)
-    - [Run the server](#run-the-server)
     - [Create the tgz file](#create-the-tgz-file)
+    - [Run the extension](#run-the-extension)
       - [Additional Resources](#additional-resources)
 
 ---
@@ -49,20 +49,11 @@ pnpm build:production
 
 ---
 
-Now you can choose between the following options:
+Now you can proceed with the following steps:
 
-- [***Run the server***](#run-the-server)
 - [***Create the tgz file***](#create-the-tgz-file)
+- [***Run the extension***](#run-the-extension)
 
----
-
-### Run the server
-
-To run the server, run the following command in your terminal:
-
-```sh
-pnpm start
-```
 ---
 
 ### Create the tgz file
@@ -76,6 +67,15 @@ pnpm pack:dev
 This bumps the prerelease version, builds the project, and creates the tgz file.
 
 After creating the tgz file, you can proceed with the extension setup guide to install the plugin in Freelens.
+
+---
+
+### Run the extension
+
+This project builds a Freelens extension, not a standalone server: the code
+runs inside Freelens once the tgz file is installed, as described in the
+[***setup guide***](./SET_UP_EXTENSION.md). After rebuilding, reinstall the
+extension or restart Freelens to pick up the new build.
 
 ---
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -42,9 +42,9 @@ To build the project, run the following command in your terminal:
 pnpm build
 ```
 
-Or additionally, to build il dev mode:
+Or additionally, to build in production mode:
 ```sh
-pnpm build:dev
+pnpm build:production
 ```
 
 ---
@@ -70,8 +70,10 @@ pnpm start
 To create the tgz file, run the following command in your terminal:
 
 ```sh
-pnpm pack
+pnpm pack:dev
 ```
+
+This bumps the prerelease version, builds the project, and creates the tgz file.
 
 After creating the tgz file, you can proceed with the extension setup guide to install the plugin in Freelens.
 


### PR DESCRIPTION
Documentation polish driven by a real end-to-end test of the extension on Windows (native and WSL2/Docker):

- README: new "Ollama" section — Ollama is natively OpenAI-compatible, so it works directly with `http://localhost:11434/v1` and no gateway; covers the non-empty API key requirement, tagged model names, the tool-calling requirement, the hidden cost estimate for local models, and TLS-inspected networks.
- README: explicit note that the Base URL is a single global setting (switching between a cloud and a local endpoint means changing it, or putting a gateway such as LiteLLM in front), and the Google API key quick link is now annotated as temporarily disabled to match the Available Models section.
- docs/BUILD.md: replaced the nonexistent `pnpm build:dev` and `pnpm pack` with the real `pnpm build:production` and `pnpm pack:dev`, and replaced the leftover "Run the server" section (`pnpm start` does not exist) with a truthful "Run the extension" section: the code runs inside Freelens via the installed tgz.
