### PR TITLE
Fix streaming rendering, upstream headers and API key logging for local endpoints

### DIFF
--- a/src/common/utils/logger/logger-service.ts
+++ b/src/common/utils/logger/logger-service.ts
@@ -1,5 +1,6 @@
 import log from "loglevel";
 import * as React from "react";
+import { redactSecrets } from "../redact";
 
 const { useMemo } = React;
 
@@ -19,6 +20,8 @@ export interface Logger {
   error: (message: string, ...meta: any[]) => void;
 }
 
+const redact = (meta: any[]) => meta.map((entry) => redactSecrets(entry));
+
 const useLog = (scope = "default") => {
   const _logger = useMemo(() => {
     const _logger = log.getLogger("base");
@@ -26,12 +29,15 @@ const useLog = (scope = "default") => {
     return _logger;
   }, []);
 
+  // Redact here rather than at each call site: the objects most often logged
+  // (the agent input, the graph state) carry the user's API key, and a new log
+  // line must not be able to reintroduce the leak.
   const logger: Logger = useMemo(
     () => ({
-      debug: (msg: string, ...meta: any[]) => _logger.debug(`[${scope}] ${msg}`, ...meta),
-      info: (msg: string, ...meta: any[]) => _logger.info(`[${scope}] ${msg}`, ...meta),
-      warn: (msg: string, ...meta: any[]) => _logger.warn(`[${scope}] ${msg}`, ...meta),
-      error: (msg: string, ...meta: any[]) => _logger.error(`[${scope}] ${msg}`, ...meta),
+      debug: (msg: string, ...meta: any[]) => _logger.debug(`[${scope}] ${msg}`, ...redact(meta)),
+      info: (msg: string, ...meta: any[]) => _logger.info(`[${scope}] ${msg}`, ...redact(meta)),
+      warn: (msg: string, ...meta: any[]) => _logger.warn(`[${scope}] ${msg}`, ...redact(meta)),
+      error: (msg: string, ...meta: any[]) => _logger.error(`[${scope}] ${msg}`, ...redact(meta)),
     }),
     [scope],
   );

--- a/src/common/utils/redact.test.ts
+++ b/src/common/utils/redact.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { REDACTED, redactSecrets } from "./redact";
+
+describe("redactSecrets", () => {
+  it("replaces the API key of an agent input", () => {
+    const agentInput = {
+      modelName: "gpt-5.5",
+      modelApiKey: "sk-super-secret",
+      messages: [{ role: "user", content: "hello" }],
+    };
+
+    expect(redactSecrets(agentInput)).toEqual({
+      modelName: "gpt-5.5",
+      modelApiKey: REDACTED,
+      messages: [{ role: "user", content: "hello" }],
+    });
+  });
+
+  it("does not mutate the input", () => {
+    const agentInput = { modelApiKey: "sk-super-secret" };
+    redactSecrets(agentInput);
+    expect(agentInput.modelApiKey).toBe("sk-super-secret");
+  });
+
+  it("replaces the key nested in a graph state snapshot", () => {
+    const snapshot = { values: { modelApiKey: "sk-super-secret" }, next: ["conclusionsAgent"] };
+    expect(redactSecrets(snapshot)).toEqual({ values: { modelApiKey: REDACTED }, next: ["conclusionsAgent"] });
+  });
+
+  it("replaces keys inside arrays", () => {
+    expect(redactSecrets([{ apiKey: "one" }, { api_key: "two" }])).toEqual([
+      { apiKey: REDACTED },
+      { api_key: REDACTED },
+    ]);
+  });
+
+  it("returns the original reference when there is nothing to redact", () => {
+    const state = { modelName: "gpt-5.5", messages: [] };
+    expect(redactSecrets(state)).toBe(state);
+  });
+
+  it("leaves an unset key visible for troubleshooting", () => {
+    expect(redactSecrets({ modelApiKey: "" })).toEqual({ modelApiKey: "" });
+    expect(redactSecrets({ modelApiKey: undefined })).toEqual({ modelApiKey: undefined });
+  });
+
+  it("leaves class instances untouched", () => {
+    class Message {
+      constructor(readonly content: string) {}
+    }
+    const error = new Error("boom");
+    const message = new Message("hi");
+
+    expect(redactSecrets(error)).toBe(error);
+    expect(redactSecrets({ modelApiKey: "sk-x", message }).message).toBe(message);
+  });
+
+  it("passes through primitives and nullish values", () => {
+    expect(redactSecrets("plain")).toBe("plain");
+    expect(redactSecrets(42)).toBe(42);
+    expect(redactSecrets(null)).toBeNull();
+    expect(redactSecrets(undefined)).toBeUndefined();
+  });
+
+  it("stops at the depth limit instead of walking a cyclic object forever", () => {
+    const cyclic: Record<string, unknown> = { modelApiKey: "sk-super-secret" };
+    cyclic.self = cyclic;
+
+    const redacted = redactSecrets(cyclic) as Record<string, unknown>;
+
+    expect(redacted.modelApiKey).toBe(REDACTED);
+  });
+});

--- a/src/common/utils/redact.ts
+++ b/src/common/utils/redact.ts
@@ -1,0 +1,80 @@
+/**
+ * Redaction of credentials carried by the objects the extension logs.
+ *
+ * The user's API key travels inside two objects that are logged verbatim for
+ * troubleshooting: the agent input built by the chat service, and the LangGraph
+ * state (`modelApiKey` is a graph channel, see
+ * `renderer/business/agent/state/graph-state.ts`), which also appears one level
+ * down as `values` on a state snapshot. Logging them printed the key in
+ * cleartext into the DevTools console, so every logged value is passed through
+ * here first rather than dropping the logs.
+ */
+
+export const REDACTED = "<redacted>";
+
+// Keys whose value is a credential wherever it appears.
+const SECRET_KEYS = new Set(["apiKey", "api_key", "modelApiKey"]);
+
+// Deep enough for the shapes actually logged (channel values sit one level below
+// a state snapshot's `values`), shallow enough to bound the walk on a large or
+// self-referencing object.
+const MAX_DEPTH = 6;
+
+// Only plain objects and arrays are walked: a class instance (a LangChain
+// message, an Error) is left untouched so the log keeps showing it as-is.
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+
+  return prototype === Object.prototype || prototype === null;
+};
+
+const redactValue = (value: unknown, depth: number): unknown => {
+  if (depth >= MAX_DEPTH) {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    let changed = false;
+    const items = value.map((item) => {
+      const redacted = redactValue(item, depth + 1);
+      changed = changed || redacted !== item;
+      return redacted;
+    });
+
+    return changed ? items : value;
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  let changed = false;
+  const result: Record<string, unknown> = {};
+
+  for (const [key, item] of Object.entries(value)) {
+    // An unset key is left visible: "no key configured" is exactly what one
+    // needs to see when troubleshooting a failing request.
+    if (SECRET_KEYS.has(key) && item !== undefined && item !== null && item !== "") {
+      result[key] = REDACTED;
+      changed = true;
+      continue;
+    }
+
+    const redacted = redactValue(item, depth + 1);
+    changed = changed || redacted !== item;
+    result[key] = redacted;
+  }
+
+  return changed ? result : value;
+};
+
+/**
+ * Return `value` with every credential replaced by {@link REDACTED}. The input
+ * is never mutated, and the original reference is returned unchanged when it
+ * carries no credential, so a log line without secrets stays exactly as it was.
+ */
+export const redactSecrets = <T>(value: T): T => redactValue(value, 0) as T;

--- a/src/main/ai-proxy-server.test.ts
+++ b/src/main/ai-proxy-server.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   applyCorsHeaders,
   applyManagedAuthorization,
+  isForwardableRequestHeader,
   isForwardableResponseHeader,
   startAiProxyServer,
 } from "./ai-proxy-server";
@@ -80,6 +81,57 @@ describe("isForwardableResponseHeader", () => {
   });
 });
 
+describe("isForwardableRequestHeader", () => {
+  const authenticated = { applyAuth: true };
+
+  it("drops the browser context the renderer attaches to every request", () => {
+    // Ollama rejects the renderer's Origin (http://<cluster-id>.localhost:<port>)
+    // with a bodyless 403 when it is forwarded.
+    for (const header of [
+      "origin",
+      "Origin",
+      "referer",
+      "cookie",
+      "sec-fetch-mode",
+      "sec-fetch-site",
+      "sec-fetch-dest",
+      "sec-ch-ua",
+      "sec-ch-ua-platform",
+    ]) {
+      expect(isForwardableRequestHeader(header, authenticated)).toBe(false);
+    }
+  });
+
+  it("drops hop-by-hop headers and the proxy's own headers", () => {
+    for (const header of [
+      "connection",
+      "content-length",
+      "host",
+      "transfer-encoding",
+      "x-upstream-base-url",
+      "x-ai-proxy-token",
+      "x-ai-proxy-no-auth",
+    ]) {
+      expect(isForwardableRequestHeader(header, authenticated)).toBe(false);
+    }
+  });
+
+  it("forwards the headers the LLM SDKs rely on", () => {
+    for (const header of ["content-type", "accept", "user-agent", "x-stainless-lang", "x-stainless-package-version"]) {
+      expect(isForwardableRequestHeader(header, authenticated)).toBe(true);
+    }
+  });
+
+  it("keeps Authorization only on authenticated routes", () => {
+    expect(isForwardableRequestHeader("authorization", authenticated)).toBe(true);
+    // No-auth route (the public LiteLLM price list): neither the managed key nor
+    // the renderer's placeholder may travel to a third party.
+    expect(isForwardableRequestHeader("authorization", { applyAuth: false })).toBe(false);
+    expect(isForwardableRequestHeader("Authorization", { applyAuth: false })).toBe(false);
+    expect(isForwardableRequestHeader("content-type", { applyAuth: false })).toBe(true);
+  });
+});
+
 const PROXY_TOKEN = "test-proxy-token";
 
 interface ProxiedResponse {
@@ -90,7 +142,7 @@ interface ProxiedResponse {
 
 // Real HTTP call against the proxy, so the assertions cover the headers the
 // server actually puts on the wire.
-const requestThroughProxy = (port: number, path: string) =>
+const requestThroughProxy = (port: number, path: string, extraHeaders: Record<string, string> = {}) =>
   new Promise<ProxiedResponse>((resolve, reject) => {
     const clientRequest = httpRequest(
       {
@@ -101,6 +153,7 @@ const requestThroughProxy = (port: number, path: string) =>
         headers: {
           "x-ai-proxy-token": PROXY_TOKEN,
           "x-ai-proxy-no-auth": "1",
+          ...extraHeaders,
         },
       },
       (incoming) => {
@@ -161,5 +214,31 @@ describe("proxied response headers", () => {
     // Dropped: the renderer would otherwise fail with ERR_CONTENT_DECODING_FAILED.
     expect(response.headers["content-encoding"]).toBeUndefined();
     expect(response.headers["content-type"]).toBe("application/json");
+  });
+
+  it("strips the renderer's browser context from the upstream request", async () => {
+    // Ollama answers a forwarded Freelens renderer Origin with a bodyless 403.
+    const fetchMock = vi.fn(
+      async (_url: unknown, _init?: RequestInit) =>
+        new Response(upstreamBody, { status: 200, headers: { "content-type": "application/json" } }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await requestThroughProxy(proxyPort, "/litellm/model_prices.json", {
+      origin: "http://c56ec0d3ac1f4e0a9d2b.localhost:52341",
+      referer: "http://c56ec0d3ac1f4e0a9d2b.localhost:52341/",
+      cookie: "session=secret",
+      "sec-fetch-mode": "cors",
+      "sec-ch-ua-platform": '"macOS"',
+      "content-type": "application/json",
+    });
+
+    const upstreamHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(upstreamHeaders.get("origin")).toBeNull();
+    expect(upstreamHeaders.get("referer")).toBeNull();
+    expect(upstreamHeaders.get("cookie")).toBeNull();
+    expect(upstreamHeaders.get("sec-fetch-mode")).toBeNull();
+    expect(upstreamHeaders.get("sec-ch-ua-platform")).toBeNull();
+    expect(upstreamHeaders.get("content-type")).toBe("application/json");
   });
 });

--- a/src/main/ai-proxy-server.ts
+++ b/src/main/ai-proxy-server.ts
@@ -60,6 +60,19 @@ const hopByHopHeaders = new Set([
   "upgrade",
 ]);
 
+// The proxy's own headers: consumed here, never meaningful upstream.
+const internalProxyHeaders = new Set([UPSTREAM_BASE_URL_HEADER, PROXY_TOKEN_HEADER, NO_AUTH_HEADER]);
+
+// Headers Chromium attaches to every renderer request. They describe the calling
+// page rather than the request itself, and an upstream that enforces an origin
+// allowlist rejects them: Ollama answers the Freelens renderer's Origin
+// (http://<cluster-id>.localhost:<port>) with a bodyless 403, so a Base URL
+// pointing straight at Ollama could not work. `cookie` is dropped for the same
+// reason plus a stricter one - the proxy authenticates with the managed API key
+// alone, so no browser cookie ever needs to travel to a third-party endpoint.
+const browserContextHeaders = new Set(["cookie", "origin", "referer"]);
+const browserContextHeaderPrefixes = ["sec-ch-", "sec-fetch-"];
+
 // Response headers that stop describing the body once it has been read through
 // `fetch`: undici transparently decodes gzip/br/deflate response bodies, so what
 // we pipe back is already plain text. Forwarding the upstream `content-encoding`
@@ -76,6 +89,28 @@ export const isForwardableResponseHeader = (name: string): boolean => {
   const key = name.toLowerCase();
 
   return !hopByHopHeaders.has(key) && !decodedBodyHeaders.has(key);
+};
+
+/**
+ * Pure predicate telling whether a client REQUEST header can be forwarded to the
+ * upstream. Drops hop-by-hop headers, the proxy's own headers, and the browser
+ * context the renderer cannot suppress; `applyAuth: false` (the no-auth routes)
+ * additionally drops Authorization so neither the managed key nor the renderer's
+ * placeholder reaches a public resource. Everything else - `content-type`,
+ * `accept`, the OpenAI SDK's `x-stainless-*` - passes through untouched.
+ */
+export const isForwardableRequestHeader = (name: string, { applyAuth }: { applyAuth: boolean }): boolean => {
+  const key = name.toLowerCase();
+
+  if (hopByHopHeaders.has(key) || internalProxyHeaders.has(key) || browserContextHeaders.has(key)) {
+    return false;
+  }
+
+  if (browserContextHeaderPrefixes.some((prefix) => key.startsWith(prefix))) {
+    return false;
+  }
+
+  return applyAuth || key !== "authorization";
 };
 
 // Normalize the possibly-array Origin header to a single value.
@@ -123,16 +158,7 @@ const createUpstreamHeaders = (request: IncomingMessage, applyAuth: boolean) => 
   const headers = new Headers();
 
   for (const [key, value] of Object.entries(request.headers)) {
-    if (
-      hopByHopHeaders.has(key) ||
-      key === UPSTREAM_BASE_URL_HEADER ||
-      key === PROXY_TOKEN_HEADER ||
-      key === NO_AUTH_HEADER ||
-      // Drop the caller's Authorization on no-auth routes so neither the managed
-      // key nor the renderer's placeholder is forwarded to the public resource.
-      (!applyAuth && key === "authorization") ||
-      value === undefined
-    ) {
+    if (value === undefined || !isForwardableRequestHeader(key, { applyAuth })) {
       continue;
     }
 

--- a/src/renderer/business/agent/nodes/teardown.ts
+++ b/src/renderer/business/agent/nodes/teardown.ts
@@ -1,4 +1,5 @@
 import { RemoveMessage } from "@langchain/core/messages";
+import { redactSecrets } from "../../../../common/utils/redact";
 import { GraphState } from "../state/graph-state";
 
 /* this is the size of the history to keep in the state.
@@ -11,7 +12,7 @@ import { GraphState } from "../state/graph-state";
 const HISTORY_SIZE = 5;
 
 export function teardownNode(state: typeof GraphState.State) {
-  console.log("Teardown Node - called with input: ", state);
+  console.log("Teardown Node - called with input: ", redactSecrets(state));
   const messages = state.messages;
   if (messages.length > HISTORY_SIZE) {
     return {

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -218,7 +218,7 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
         });
 
         // streams LLM token by token to the UI
-        for await (const [message, _metadata] of streamResponse) {
+        for await (const [message, metadata] of streamResponse) {
           // Always emit the assistant's text content, even when the same chunk
           // also carries tool calls. Some providers (e.g. DeepSeek via
           // DsmlAwareChatOpenAI) deliver the preamble text and the tool call in
@@ -244,7 +244,10 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
               yield { reasoning };
             }
 
-            const text = mergeAiChunk(mergeState, message.id, message.content);
+            // The stream metadata identifies the graph node execution behind the
+            // chunk, which is what separates two assistant messages; the chunk id
+            // is not reliable (some gateways mint one per token).
+            const text = mergeAiChunk(mergeState, message, metadata);
             if (text.length > 0) {
               hasYieldedContent = true;
               yield text;

--- a/src/renderer/business/service/agent-service.ts
+++ b/src/renderer/business/service/agent-service.ts
@@ -1,5 +1,6 @@
 import { BaseCallbackHandler } from "@langchain/core/callbacks/base";
 import { Command, Interrupt } from "@langchain/langgraph";
+import { redactSecrets } from "../../../common/utils/redact";
 import { FreeLensAgent } from "../agent/freelens-agent-system";
 import { MPCAgent } from "../agent/mcp-agent";
 import { approximateMessagesTokenCount } from "../provider/token-estimate";
@@ -159,7 +160,7 @@ export interface AgentService {
  */
 export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService => {
   const run = async function* (agentInput: object | Command, conversationId: string) {
-    console.log("Starting Agent Service run for message: ", agentInput);
+    console.log("Starting Agent Service run for message: ", redactSecrets(agentInput));
 
     let config = { thread_id: conversationId };
     // Net token usage this run has already added to the per-session counter via
@@ -287,7 +288,8 @@ export const useAgentService = (agent: FreeLensAgent | MPCAgent): AgentService =
 
         // checks the agent state for any interrupts
         const agentState = await agent.getState({ configurable: config });
-        console.log("Agent state: ", agentState);
+        // The snapshot's `values` are the graph channels, which include the key.
+        console.log("Agent state: ", redactSecrets(agentState));
         if (agentState.next) {
           console.log("Agent state next: ", agentState.next);
           for (const task of agentState.tasks) {

--- a/src/renderer/business/service/stream-merge.test.ts
+++ b/src/renderer/business/service/stream-merge.test.ts
@@ -1,59 +1,145 @@
 import { describe, expect, it } from "vitest";
-import { createStreamMergeState, extractReasoningText, flattenContentText, mergeAiChunk } from "./stream-merge";
+import {
+  type AiMessageChunk,
+  createStreamMergeState,
+  extractReasoningText,
+  flattenContentText,
+  hasFinishSignal,
+  mergeAiChunk,
+  streamBoundaryKey,
+} from "./stream-merge";
+
+import type { MessageContent } from "@langchain/core/messages";
+
+const chunk = (id: string | undefined, content: MessageContent, extra: Partial<AiMessageChunk> = {}): AiMessageChunk =>
+  ({ id, content, ...extra }) satisfies AiMessageChunk;
+
+// LangGraph tags every streamed chunk with the checkpoint namespace of the node
+// execution that produced it.
+const nodeMetadata = (checkpointNamespace: string) => ({ langgraph_checkpoint_ns: checkpointNamespace });
+
+const finished = { response_metadata: { finish_reason: "stop" } };
 
 describe("mergeAiChunk", () => {
   it("concatenates chunks of the same message without a separator", () => {
     const state = createStreamMergeState();
-    expect(mergeAiChunk(state, "msg-1", "Everything is ")).toBe("Everything is ");
-    expect(mergeAiChunk(state, "msg-1", "working fine.")).toBe("working fine.");
+    const node = nodeMetadata("conclusionsAgent:1");
+    expect(mergeAiChunk(state, chunk("msg-1", "Everything is "), node)).toBe("Everything is ");
+    expect(mergeAiChunk(state, chunk("msg-1", "working fine."), node)).toBe("working fine.");
   });
 
-  it("inserts a blank line when a new message begins", () => {
+  it("concatenates a gateway stream that mints a fresh id for every chunk", () => {
+    // LiteLLM proxying ollama_chat: each SSE chunk carries a different id and no
+    // finish signal until the end. Treating the id change as a boundary rendered
+    // one word per Markdown paragraph.
     const state = createStreamMergeState();
-    mergeAiChunk(state, "msg-1", "Everything is working fine.");
-    expect(mergeAiChunk(state, "msg-2", "### Summary")).toBe("\n\n### Summary");
+    const node = nodeMetadata("generalPurposeAgent:1");
+    expect(mergeAiChunk(state, chunk("chatcmpl-1", "Everything "), node)).toBe("Everything ");
+    expect(mergeAiChunk(state, chunk("chatcmpl-2", "is "), node)).toBe("is ");
+    expect(mergeAiChunk(state, chunk("chatcmpl-3", "working "), node)).toBe("working ");
+    expect(mergeAiChunk(state, chunk("chatcmpl-4", "fine.", finished), node)).toBe("fine.");
+  });
+
+  it("inserts a blank line when the next node execution emits a new message", () => {
+    const state = createStreamMergeState();
+    mergeAiChunk(state, chunk("msg-1", "Everything is working fine."), nodeMetadata("kubernetesOperator:1|agent:7"));
+    expect(mergeAiChunk(state, chunk("msg-2", "### Summary"), nodeMetadata("kubernetesOperator:1|agent:9"))).toBe(
+      "\n\n### Summary",
+    );
+  });
+
+  it("separates on the node boundary even when the gateway reuses the id", () => {
+    const state = createStreamMergeState();
+    mergeAiChunk(state, chunk("same-id", "Checked the pods."), nodeMetadata("agentAnalyzer:1"));
+    expect(mergeAiChunk(state, chunk("same-id", "### Summary"), nodeMetadata("conclusionsAgent:4"))).toBe(
+      "\n\n### Summary",
+    );
+  });
+
+  it("separates on the node and step pair when no checkpoint namespace is sent", () => {
+    const state = createStreamMergeState();
+    mergeAiChunk(state, chunk("msg-1", "Working."), { langgraph_node: "agent", langgraph_step: 1 });
+    expect(mergeAiChunk(state, chunk("msg-2", "### Summary"), { langgraph_node: "agent", langgraph_step: 3 })).toBe(
+      "\n\n### Summary",
+    );
+  });
+
+  it("separates a new id once the previous message reported a finish reason", () => {
+    // OpenAI-style stream without LangGraph metadata: one id per completion, and
+    // a final chunk carrying finish_reason.
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, chunk("msg-1", "Everything is "))).toBe("Everything is ");
+    expect(mergeAiChunk(state, chunk("msg-1", "working fine.", finished))).toBe("working fine.");
+    expect(mergeAiChunk(state, chunk("msg-2", "### Summary"))).toBe("\n\n### Summary");
+  });
+
+  it("records the finish signal carried by an empty final chunk", () => {
+    // OpenAI sends finish_reason on a chunk whose content delta is empty; the
+    // signal must survive the empty-chunk shortcut.
+    const state = createStreamMergeState();
+    mergeAiChunk(state, chunk("msg-1", "Everything is working fine."));
+    expect(mergeAiChunk(state, chunk("msg-1", "", finished))).toBe("");
+    expect(mergeAiChunk(state, chunk("msg-2", "### Summary"))).toBe("\n\n### Summary");
+  });
+
+  it("does not separate on an id change while no boundary signal is available", () => {
+    // Provider sends neither LangGraph metadata nor a finish reason: degrade to
+    // concatenation rather than to a paragraph per token.
+    const state = createStreamMergeState();
+    expect(mergeAiChunk(state, chunk("chatcmpl-1", "Everything "))).toBe("Everything ");
+    expect(mergeAiChunk(state, chunk("chatcmpl-2", "is "))).toBe("is ");
+    expect(mergeAiChunk(state, chunk("chatcmpl-3", "working fine."))).toBe("working fine.");
+  });
+
+  it("ignores an explicit null finish_reason sent on every intermediate chunk", () => {
+    const state = createStreamMergeState();
+    mergeAiChunk(state, chunk("chatcmpl-1", "Everything ", { response_metadata: { finish_reason: null } }));
+    expect(mergeAiChunk(state, chunk("chatcmpl-2", "is working fine."))).toBe("is working fine.");
+  });
+
+  it("reads the finish signal from additional_kwargs", () => {
+    const state = createStreamMergeState();
+    mergeAiChunk(state, chunk("msg-1", "Done.", { additional_kwargs: { finish_reason: "stop" } }));
+    expect(mergeAiChunk(state, chunk("msg-2", "### Summary"))).toBe("\n\n### Summary");
   });
 
   it("does not prepend a separator before the very first chunk", () => {
     const state = createStreamMergeState();
-    expect(mergeAiChunk(state, "msg-1", "### Summary")).toBe("### Summary");
+    expect(mergeAiChunk(state, chunk("msg-1", "### Summary"), nodeMetadata("conclusionsAgent:1"))).toBe("### Summary");
   });
 
   it("ignores empty chunks and leaves the boundary state untouched", () => {
     const state = createStreamMergeState();
-    mergeAiChunk(state, "msg-1", "Hello");
-    expect(mergeAiChunk(state, "msg-2", "")).toBe("");
+    mergeAiChunk(state, chunk("msg-1", "Hello"), nodeMetadata("agent:1"));
+    expect(mergeAiChunk(state, chunk("msg-2", ""), nodeMetadata("agent:2"))).toBe("");
     // The empty chunk must not consume the boundary: the next real chunk from a
     // new message still gets its separator.
-    expect(mergeAiChunk(state, "msg-2", "World")).toBe("\n\nWorld");
+    expect(mergeAiChunk(state, chunk("msg-2", "World"), nodeMetadata("agent:2"))).toBe("\n\nWorld");
   });
 
   it("does not separate when ids are missing (preserves token streaming)", () => {
     const state = createStreamMergeState();
-    expect(mergeAiChunk(state, undefined, "Hello ")).toBe("Hello ");
-    expect(mergeAiChunk(state, undefined, "world")).toBe("world");
+    expect(mergeAiChunk(state, chunk(undefined, "Hello "))).toBe("Hello ");
+    expect(mergeAiChunk(state, chunk(undefined, "world"))).toBe("world");
   });
 
-  it("separates when the first message has no id but the next one does", () => {
+  it("handles three distinct node executions in a row", () => {
     const state = createStreamMergeState();
-    expect(mergeAiChunk(state, undefined, "Everything is working fine.")).toBe("Everything is working fine.");
-    expect(mergeAiChunk(state, "msg-2", "### Summary")).toBe("\n\n### Summary");
-  });
-
-  it("handles three distinct messages in a row", () => {
-    const state = createStreamMergeState();
-    expect(mergeAiChunk(state, "a", "First.")).toBe("First.");
-    expect(mergeAiChunk(state, "b", "Second.")).toBe("\n\nSecond.");
-    expect(mergeAiChunk(state, "c", "Third.")).toBe("\n\nThird.");
+    expect(mergeAiChunk(state, chunk("a", "First."), nodeMetadata("agent:1"))).toBe("First.");
+    expect(mergeAiChunk(state, chunk("b", "Second."), nodeMetadata("agent:2"))).toBe("\n\nSecond.");
+    expect(mergeAiChunk(state, chunk("c", "Third."), nodeMetadata("agent:3"))).toBe("\n\nThird.");
   });
 
   it("flattens structured content arrays to their text", () => {
     const state = createStreamMergeState();
     expect(
-      mergeAiChunk(state, "msg-1", [
-        { type: "text", text: "I'll investigate " },
-        { type: "text", text: "now." },
-      ]),
+      mergeAiChunk(
+        state,
+        chunk("msg-1", [
+          { type: "text", text: "I'll investigate " },
+          { type: "text", text: "now." },
+        ]),
+      ),
     ).toBe("I'll investigate now.");
   });
 
@@ -62,16 +148,60 @@ describe("mergeAiChunk", () => {
     // A chunk where the assistant wrote a preamble and then invoked a tool: the
     // tool-call lives outside `content`, so only the preamble text is emitted.
     expect(
-      mergeAiChunk(state, "msg-1", [
-        { type: "text", text: "Good morning! I'll search the cluster." },
-        { type: "tool_use", id: "call_1", name: "read_logs", input: { pod: "foo" } },
-      ]),
+      mergeAiChunk(
+        state,
+        chunk("msg-1", [
+          { type: "text", text: "Good morning! I'll search the cluster." },
+          { type: "tool_use", id: "call_1", name: "read_logs", input: { pod: "foo" } },
+        ]),
+      ),
     ).toBe("Good morning! I'll search the cluster.");
   });
 
   it("yields nothing for a tool-only chunk with no text", () => {
     const state = createStreamMergeState();
-    expect(mergeAiChunk(state, "msg-1", [{ type: "tool_use", id: "call_1", name: "read_logs", input: {} }])).toBe("");
+    expect(
+      mergeAiChunk(state, chunk("msg-1", [{ type: "tool_use", id: "call_1", name: "read_logs", input: {} }])),
+    ).toBe("");
+  });
+});
+
+describe("streamBoundaryKey", () => {
+  it("prefers the checkpoint namespace of the node execution", () => {
+    expect(
+      streamBoundaryKey({
+        langgraph_checkpoint_ns: "conclusionsAgent:abc",
+        checkpoint_ns: "other",
+        langgraph_node: "conclusionsAgent",
+        langgraph_step: 4,
+      }),
+    ).toBe("conclusionsAgent:abc");
+  });
+
+  it("falls back to checkpoint_ns, then to the node and step pair", () => {
+    expect(streamBoundaryKey({ checkpoint_ns: "agent:xyz" })).toBe("agent:xyz");
+    expect(streamBoundaryKey({ langgraph_node: "agent", langgraph_step: 2 })).toBe("agent:2");
+    expect(streamBoundaryKey({ langgraph_node: "agent" })).toBe("agent");
+  });
+
+  it("returns undefined without usable metadata", () => {
+    expect(streamBoundaryKey(undefined)).toBeUndefined();
+    expect(streamBoundaryKey({})).toBeUndefined();
+    expect(streamBoundaryKey({ checkpoint_ns: "" })).toBeUndefined();
+    expect(streamBoundaryKey({ langgraph_node: 42 })).toBeUndefined();
+  });
+});
+
+describe("hasFinishSignal", () => {
+  it("detects a finish reason in either metadata record", () => {
+    expect(hasFinishSignal({ content: "", response_metadata: { finish_reason: "stop" } })).toBe(true);
+    expect(hasFinishSignal({ content: "", additional_kwargs: { finish_reason: "tool_calls" } })).toBe(true);
+  });
+
+  it("ignores a missing, null, or empty finish reason", () => {
+    expect(hasFinishSignal({ content: "" })).toBe(false);
+    expect(hasFinishSignal({ content: "", response_metadata: { finish_reason: null } })).toBe(false);
+    expect(hasFinishSignal({ content: "", response_metadata: { finish_reason: "" } })).toBe(false);
   });
 });
 

--- a/src/renderer/business/service/stream-merge.ts
+++ b/src/renderer/business/service/stream-merge.ts
@@ -3,19 +3,52 @@
  * Markdown string without gluing distinct assistant messages onto one line.
  *
  * The agent streams in `messages` mode: a single assistant message arrives as
- * many chunks that share the same `id` and must be concatenated directly (token
- * streaming). When the agent graph emits a *new* assistant message its `id`
- * changes; concatenating it straight onto the previous one produces output like
- * `...check?### Summary`, where `###` is no longer at the start of a line and
- * Markdown renders it verbatim. Inserting a blank line at the boundary keeps the
- * heading on its own block.
+ * many chunks that must be concatenated directly (token streaming). When the
+ * graph emits a *new* assistant message - typically the summary the model writes
+ * after a tool call - concatenating it straight onto the previous one produces
+ * output like `...check?### Summary`, where `###` is no longer at the start of a
+ * line and Markdown renders it verbatim. A blank line at that boundary keeps the
+ * heading in its own block.
+ *
+ * The boundary is taken from the LangGraph stream metadata (the second element
+ * of every `messages` tuple) rather than from the chunk id. LangGraph tags each
+ * chunk with the checkpoint namespace of the node execution that produced it
+ * (`<node>:<taskId>`, minted once per node run), so it changes exactly once per
+ * assistant message and is provider independent. The chunk id is not: OpenAI
+ * repeats one completion id for a whole message, but a LiteLLM gateway proxying
+ * Ollama mints a fresh id on every SSE chunk (and LangGraph only rewrites the
+ * ids it generated itself), so treating any id change as a boundary inserted a
+ * blank line between every token and rendered one word per Markdown paragraph.
+ *
+ * Without metadata the rule degrades to an id change that is additionally gated
+ * on a finish signal already seen for the previous message, so per-chunk ids
+ * still concatenate. `@langchain/openai` reports `finish_reason` in the
+ * generation info, which is not merged into the chunk on the callback path
+ * LangGraph streams through, so that fallback usually resolves to plain
+ * concatenation - the safe direction, since a missing separator is a cosmetic
+ * defect while a spurious one breaks every line of the answer.
  */
 
 import type { MessageContent } from "@langchain/core/messages";
 
 export interface StreamMergeState {
   lastMessageId: string | undefined;
+  lastBoundaryKey: string | undefined;
+  // Whether the provider already reported the current message as complete. Only
+  // consulted by the id fallback, when no LangGraph metadata is available.
+  finished: boolean;
   started: boolean;
+}
+
+/**
+ * The parts of a streamed `AIMessageChunk` this module reads. Declared
+ * structurally so the helpers stay free of any LangChain runtime dependency.
+ */
+export interface AiMessageChunk {
+  id?: string;
+  content: MessageContent;
+  additional_kwargs?: Record<string, unknown>;
+  response_metadata?: Record<string, unknown>;
 }
 
 // Content-part types that carry the model's chain-of-thought rather than the
@@ -25,6 +58,8 @@ const REASONING_PART_TYPES = new Set(["reasoning", "thinking"]);
 
 export const createStreamMergeState = (): StreamMergeState => ({
   lastMessageId: undefined,
+  lastBoundaryKey: undefined,
+  finished: false,
   started: false,
 });
 
@@ -133,26 +168,106 @@ export const extractReasoningText = (
 };
 
 /**
+ * Identify the graph node execution a streamed chunk belongs to, from the
+ * LangGraph metadata carried alongside it. The checkpoint namespace is
+ * `<node>:<taskId>` with the task id derived from the superstep, so it is minted
+ * once per node run and is the same for every token of one assistant message.
+ * Falls back to node plus step, and returns undefined when the metadata carries
+ * neither (callers then use the id fallback).
+ */
+export const streamBoundaryKey = (metadata: Record<string, unknown> | undefined): string | undefined => {
+  if (!metadata) {
+    return undefined;
+  }
+
+  const checkpointNamespace = metadata.langgraph_checkpoint_ns ?? metadata.checkpoint_ns;
+  if (typeof checkpointNamespace === "string" && checkpointNamespace.length > 0) {
+    return checkpointNamespace;
+  }
+
+  const node = metadata.langgraph_node;
+  if (typeof node !== "string" || node.length === 0) {
+    return undefined;
+  }
+
+  const step = metadata.langgraph_step;
+  return typeof step === "number" ? `${node}:${step}` : node;
+};
+
+/**
+ * Whether a chunk reports the message it belongs to as complete. Providers put
+ * the OpenAI `finish_reason` either on `response_metadata` or on
+ * `additional_kwargs`; an explicit null (sent on every intermediate chunk) means
+ * "not finished" and is ignored.
+ */
+export const hasFinishSignal = (chunk: AiMessageChunk): boolean => {
+  for (const source of [chunk.response_metadata, chunk.additional_kwargs]) {
+    const reason = source?.finish_reason;
+    if (typeof reason === "string" && reason.length > 0) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const isMessageBoundary = (
+  state: StreamMergeState,
+  chunk: AiMessageChunk,
+  boundaryKey: string | undefined,
+): boolean => {
+  if (!state.started) {
+    return false;
+  }
+
+  if (boundaryKey !== undefined && state.lastBoundaryKey !== undefined) {
+    return boundaryKey !== state.lastBoundaryKey;
+  }
+
+  // No metadata to compare: an id change alone is not evidence of a new message,
+  // because some gateways mint one id per streamed chunk. Require the previous
+  // message to have been reported as finished as well.
+  return state.finished && chunk.id !== undefined && chunk.id !== state.lastMessageId;
+};
+
+/**
  * Returns the text to yield for an incoming AI message chunk, updating `state`.
  *
- * Empty chunks yield nothing. When a new assistant message begins (a defined
- * `id` that differs from the previous one) a blank-line separator is prepended
- * so the following content starts a fresh Markdown block. Chunks with no id, or
- * the same id, are concatenated directly to preserve token streaming.
+ * Empty chunks yield nothing. When a new assistant message begins a blank-line
+ * separator is prepended so the following content starts a fresh Markdown block;
+ * every other chunk is concatenated directly to preserve token streaming. See
+ * the module doc comment for how the boundary is detected.
  *
- * `content` may be a plain string or LangChain's structured content array; it is
- * flattened to text first, so a chunk that also carries `tool_call_chunks` still
- * contributes its preamble text instead of being dropped.
+ * `metadata` is the second element of the `messages` stream tuple. `content` may
+ * be a plain string or LangChain's structured content array; it is flattened to
+ * text first, so a chunk that also carries `tool_call_chunks` still contributes
+ * its preamble text instead of being dropped.
  */
-export const mergeAiChunk = (state: StreamMergeState, id: string | undefined, content: MessageContent): string => {
-  const text = flattenContentText(content);
+export const mergeAiChunk = (
+  state: StreamMergeState,
+  chunk: AiMessageChunk,
+  metadata?: Record<string, unknown>,
+): string => {
+  // Recorded before the empty-chunk exit below: OpenAI-compatible endpoints
+  // report `finish_reason` on a final chunk whose content delta is empty.
+  if (hasFinishSignal(chunk)) {
+    state.finished = true;
+  }
+
+  const text = flattenContentText(chunk.content);
   if (text.length === 0) {
     return "";
   }
 
-  const isNewMessage = state.started && id !== undefined && id !== state.lastMessageId;
-  state.lastMessageId = id;
+  const boundaryKey = streamBoundaryKey(metadata);
+  const isNewMessage = isMessageBoundary(state, chunk, boundaryKey);
+
+  state.lastMessageId = chunk.id;
+  state.lastBoundaryKey = boundaryKey;
   state.started = true;
+  if (isNewMessage) {
+    state.finished = false;
+  }
 
   return isNewMessage ? `\n\n${text}` : text;
 };


### PR DESCRIPTION
Pre-release smoke testing of v0.7.0 against local OpenAI-compatible endpoints (Ollama directly and Ollama behind a LiteLLM gateway) surfaced three bugs, fixed here with one commit each.

## 1. Merge streamed chunks on graph node boundaries instead of chunk ids

LiteLLM proxying Ollama mints a fresh chunk id on every SSE delta (confirmed with curl against the gateway). The id-change rule in `stream-merge.ts` treated every token as a new assistant message, prepending a blank line to each one, and the chat rendered one word per Markdown paragraph. The message boundary now comes from the LangGraph stream metadata (the checkpoint namespace, minted once per node execution and identical for every token of one assistant message, provider independent), so the post-tool-call summary message still gets its separator while per-chunk ids no longer break anything. Without metadata the rule degrades to an id change gated on a previously seen finish signal, and otherwise to plain concatenation: under-separating is a cosmetic defect, over-separating broke every answer.

## 2. Stop forwarding the renderer's browser context headers upstream

The local proxy forwarded all renderer headers to the upstream endpoint, including `Origin` (`http://<cluster-id>.localhost:<port>`). Ollama's origin allowlist rejects that with a bodyless 403, so a Base URL pointed straight at Ollama, exactly as the README documents, could not work. `Origin`, `Referer`, `Cookie` and the `sec-fetch-*` / `sec-ch-*` families are now stripped by an exported, tested predicate that mirrors the existing response-header filter; the managed Authorization handling and the no-auth route behavior are unchanged.

## 3. Redact API keys from logged agent inputs and state

The agent input and the LangGraph state carry `modelApiKey`, and several log lines printed those objects verbatim to the DevTools console, exposing the user's real API key in cleartext. Every value logged through the logger service, plus the raw `console.log` sites that print the graph state, now pass through a redaction helper (plain objects and arrays only, reference preserving, depth capped) that replaces credential fields with `<redacted>` and leaves everything else exactly as it was.

## Validation

- biome and tsc clean
- 340 unit tests pass, 24 of them new: gateway-style per-chunk-id streams and the other boundary cases, the request-header predicate plus a wire-level proxy test asserting what actually reaches the upstream, and the redaction helper
- Manual smoke test on Windows (Freelens 1.10.3, Ollama with llama3.2:3b in WSL2 docker, both direct and behind LiteLLM) in progress before merge

Generated with [Claude Code](https://claude.com/claude-code)
