### PR TITLE
Align the AI Explain configuration check with the chat readiness

### DIFF
--- a/src/common/service/chat-service.ts
+++ b/src/common/service/chat-service.ts
@@ -33,7 +33,7 @@ export interface ApprovalInterrupt {
 const useChatService = () => {
   const { log } = useLog("useChatService");
   const applicationStatusStore = useApplicationStatusStore();
-  const aiAnalysisService: AiAnalysisService = useAiAnalysisService(applicationStatusStore);
+  const aiAnalysisService: AiAnalysisService = useAiAnalysisService();
 
   const getReadableErrorMessage = (error: unknown) => {
     if (!(error instanceof Error)) {

--- a/src/renderer/business/provider/chat-readiness.test.ts
+++ b/src/renderer/business/provider/chat-readiness.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { AIProviders, type CustomModel } from "./ai-models";
-import { isAgentConfigured } from "./chat-readiness";
+import { buildAgentReadinessInput, isAgentConfigured } from "./chat-readiness";
 
 const openAiModels: CustomModel[] = [
   { provider: AIProviders.OPEN_AI, name: "gpt-5.5" },
@@ -33,5 +33,31 @@ describe("isAgentConfigured", () => {
   it("falls back to the first model's provider when the selection does not match", () => {
     expect(isAgentConfigured({ models: openAiModels, selectedModel: "unknown", openAIKey: "" })).toBe(false);
     expect(isAgentConfigured({ models: openAiModels, selectedModel: "unknown", openAIKey: "sk-test" })).toBe(true);
+  });
+});
+
+describe("buildAgentReadinessInput", () => {
+  const prefsWithoutStoredKey = { models: openAiModels, selectedModel: "gpt-5.5", openAIKey: "" };
+
+  it("picks up the key from the environment", () => {
+    expect(isAgentConfigured(buildAgentReadinessInput(prefsWithoutStoredKey, { OPENAI_API_KEY: "sk-env" }))).toBe(true);
+  });
+
+  // Passing `undefined` would fall back to the real `process.env`, so an empty
+  // object stands in for "no environment key set".
+  it("is not configured without an environment key and without a stored key", () => {
+    expect(isAgentConfigured(buildAgentReadinessInput(prefsWithoutStoredKey, {}))).toBe(false);
+  });
+
+  it("treats a whitespace-only environment key as unset", () => {
+    expect(isAgentConfigured(buildAgentReadinessInput(prefsWithoutStoredKey, { OPENAI_API_KEY: "   " }))).toBe(false);
+  });
+
+  it("keeps working with the stored key alone", () => {
+    expect(
+      isAgentConfigured(
+        buildAgentReadinessInput({ models: openAiModels, selectedModel: "gpt-5.5", openAIKey: "sk-test" }, {}),
+      ),
+    ).toBe(true);
   });
 });

--- a/src/renderer/business/provider/chat-readiness.ts
+++ b/src/renderer/business/provider/chat-readiness.ts
@@ -29,3 +29,21 @@ export const isAgentConfigured = ({ models, selectedModel, openAIKey, envOpenAIK
 
   return true;
 };
+
+// Single place building the readiness input from the preferences store, so every
+// feature resolves the key the same way. Invariant: chat and AI Explain must
+// agree on what "configured" means, with OPENAI_API_KEY taking precedence over
+// the stored key; the drift between the two resolutions caused issue #97, where
+// a key provided only via the environment made the chat work but AI Explain fail.
+export const buildAgentReadinessInput = (
+  prefs: { models: CustomModel[]; selectedModel: string; openAIKey: string },
+  // Tests pass a fake environment instead of touching the real `process.env`.
+  env: { OPENAI_API_KEY?: string } | undefined = typeof process !== "undefined"
+    ? (process.env as { OPENAI_API_KEY?: string })
+    : undefined,
+): AgentReadinessInput => ({
+  models: prefs.models,
+  selectedModel: prefs.selectedModel,
+  openAIKey: prefs.openAIKey,
+  envOpenAIKey: env?.OPENAI_API_KEY,
+});

--- a/src/renderer/business/service/ai-analysis-service.tsx
+++ b/src/renderer/business/service/ai-analysis-service.tsx
@@ -1,6 +1,7 @@
 import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { PreferencesStore } from "../../../common/store";
 import useLog from "../../../common/utils/logger/logger-service";
-import { AppContextType } from "../../context/application-context";
+import { buildAgentReadinessInput, isAgentConfigured } from "../provider/chat-readiness";
 import { useModelProvider } from "../provider/model-provider";
 import { ANALYSIS_PROMPT_TEMPLATE } from "../provider/prompt-template-provider";
 
@@ -36,7 +37,7 @@ export interface AiAnalysisService {
   analyze: (message: string) => AsyncGenerator<string, void, unknown>;
 }
 
-export const useAiAnalysisService = (applicationStatusStore: AppContextType): AiAnalysisService => {
+export const useAiAnalysisService = (): AiAnalysisService => {
   const { log } = useLog("useAiAnalysisService");
 
   const analyze = async function* (message: string) {
@@ -46,8 +47,11 @@ export const useAiAnalysisService = (applicationStatusStore: AppContextType): Ai
       throw new Error("No message provided for analysis.");
     }
 
-    if (!applicationStatusStore.apiKey) {
-      throw new Error("API key is required. Use the settings to register it.");
+    // Same readiness check as the chat input, so a key provided only through the
+    // OPENAI_API_KEY environment variable works here too.
+    const preferencesStore = PreferencesStore.getInstanceOrCreate<PreferencesStore>();
+    if (!isAgentConfigured(buildAgentReadinessInput(preferencesStore))) {
+      throw new Error("The agent is not configured. Use the settings to add a model and register the API key.");
     }
 
     const model = useModelProvider().getModel();

--- a/src/renderer/components/text-input/text-input-hook.tsx
+++ b/src/renderer/components/text-input/text-input-hook.tsx
@@ -1,7 +1,7 @@
 import { Renderer } from "@freelensapp/extensions";
 import * as React from "react";
 import { PreferencesStore } from "../../../common/store";
-import { isAgentConfigured } from "../../business/provider/chat-readiness";
+import { buildAgentReadinessInput, isAgentConfigured } from "../../business/provider/chat-readiness";
 import { useApplicationStatusStore } from "../../context/application-context";
 import { navigateToExtensionPreferences } from "../../navigation/navigate-to-extension-preferences";
 
@@ -35,12 +35,7 @@ export const useTextInput = ({ onSend }: TextInputHookProps) => {
   // Show the model dropdown only when the agent is ready to chat. Otherwise
   // (no models left, or no OpenAI key set) the UI offers a single button that
   // links to this extension's preferences.
-  const agentConfigured = isAgentConfigured({
-    models: preferencesStore.models,
-    selectedModel: preferencesStore.selectedModel,
-    openAIKey: preferencesStore.openAIKey,
-    envOpenAIKey: typeof process !== "undefined" ? process.env.OPENAI_API_KEY : undefined,
-  });
+  const agentConfigured = isAgentConfigured(buildAgentReadinessInput(preferencesStore));
 
   const adaptTextareaHeight = () => {
     const textarea = textareaRef.current;


### PR DESCRIPTION
The chat decides whether the agent is configured with `isAgentConfigured`, which also honours the `OPENAI_API_KEY` environment variable (a documented setup). AI Explain had its own check on the stored preferences key only, so with a key provided only through the environment the chat worked but Explain failed with "API key is required. Use the settings to register it.". This is the surviving variant of the drift reported in #97, after the provider rework shipped in v0.7.0 removed the original Google AI scenario.

Both features now build the readiness input with the same shared helper, so they cannot drift again:

- `buildAgentReadinessInput` in `chat-readiness.ts` is the single place resolving the key (environment variable first, stored key second)
- the chat input and the AI Explain gate both call `isAgentConfigured` on that input
- the Explain error message now covers the whole configuration, not just the key
- unit tests cover the environment-only key case

Closes #97

Generated with [Claude Code](https://claude.com/claude-code)
